### PR TITLE
feat: source-agnostic /yoke:ask, retire query-trace contract

### DIFF
--- a/.vibeflow/audits/ask-source-agnostic-read-part-1-audit.md
+++ b/.vibeflow/audits/ask-source-agnostic-read-part-1-audit.md
@@ -1,0 +1,151 @@
+# Audit Report: ask-source-agnostic-read-part-1
+
+**Verdict: PASS**
+
+> Auditor: /vibeflow:audit (autonomous run, 2026-04-25)
+> Spec: `.vibeflow/specs/ask-source-agnostic-read-part-1.md`
+> PRD: `.vibeflow/prds/ask-source-agnostic-read.md`
+
+## Test execution
+
+No project-wide test runner exists (no `package.json`, `pyproject.toml`,
+`Cargo.toml`, `go.mod`, etc.). The repo's tests are individual bash smoke
+scripts under `tests/smoke/`. The spec's anti-scope explicitly excludes
+test changes (those are owned by Part 3).
+
+| Verification | Result |
+| :--- | :--- |
+| `lib/working-memory/paths.sh` smoke-load in subshell | exit 0 |
+| `wm_query_trace_path` removed (`type` returns "not found") | PASS |
+| `WM_ARCHIVE_CATEGORIES` reduced to 4 entries | PASS |
+| Other `wm_*` helpers (`wm_prd_path`, `wm_contracts_path`, …) still load | PASS |
+| `tests/smoke/sprint-3.test.sh` not affected by Part 1 | PASS (no `query-trace` references) |
+| `tests/smoke/sprint-4.test.sh` not affected by Part 1 | PASS (no `query-trace` references) |
+| `tests/smoke/sprint-2.test.sh` (asserts old contract) | FAIL — owned by Part 3 |
+| `tests/smoke/sprint-5.test.sh` (asserts old YAML trace shape) | FAIL — owned by Part 3 |
+| `tests/smoke/folder-isolation.test.sh` (asserts query-traces category) | FAIL — owned by Part 3 |
+| `tests/smoke/ask-no-clone.test.sh` (built around old trace flow) | FAIL — owned by Part 3 |
+
+The four failing smoke tests all fail for the same root cause: they assert
+the *old* trace contract that this PR deliberately removes. The PRD and the
+multi-part split anticipated this — the test-suite alignment is the entire
+purpose of Part 3, which depends on Parts 1 and 2 having landed first.
+Verifying *that* this is the failure mode (and not a system regression)
+required reading the asserting code in each test and confirming each hit
+matches the symbols deleted in Part 1.
+
+## DoD Checklist
+
+- [x] **DoD-1** — `skills/ask/SKILL.md` no longer references
+      `.yoke/.current`, `wm_active_slug`, `wm_query_trace_path`,
+      `query-traces`, or any YAML trace shape. The pre-condition section
+      that aborted on missing active task is removed; Phase 5 contains
+      only response composition.
+      *Evidence:* `grep -E "\.yoke/\.current|wm_active_slug|wm_query_trace_path|query-traces|query-trace" skills/ask/SKILL.md`
+      returns empty. `grep -nE "\btrace\b" skills/ask/SKILL.md` returns
+      empty. The "Phase 5 — Compose response" section contains only
+      composition rules (no 5.1 trace write).
+- [x] **DoD-2** — `skills/ask/SKILL.md` description rewritten:
+      source-agnostic, registry-resolved, filesystem-only, 15-cap, no
+      trace.
+      *Evidence:* Frontmatter (lines 1–14) reads "Source-agnostic read
+      against the registered canonical memory. Resolves the active
+      memory via lib/canonical-memory/resolve-memory.sh … reads the
+      local filesystem directly … Caps total entity reads at 15. Pure
+      read — writes nothing on disk and does not depend on any active
+      task."
+- [x] **DoD-3** — `lib/working-memory/paths.sh` does not export
+      `wm_query_trace_path`; `WM_ARCHIVE_CATEGORIES` does not contain
+      `query-traces`.
+      *Evidence:* `grep -n "wm_query_trace_path" lib/working-memory/paths.sh`
+      returns empty. `WM_ARCHIVE_CATEGORIES=(prds tech-specs acceptance-contracts contracts)`
+      at line 44. Subshell smoke-load confirms `type
+      wm_query_trace_path` reports "not found" while other `wm_*`
+      helpers still resolve as functions. The file-header layout
+      comment was also updated so the documentation matches the code.
+- [x] **DoD-4** — Invariants preserved.
+      *Evidence:*
+      - 15-entity cap: 5 mentions in SKILL.md (Phase 2.4 limit; Phase
+        2.5 hard cap; Critical rule #4; anti-pattern; description).
+      - No clone/pull/fetch: rule #1 + Phase 0 explicit "no `git clone`,
+        no `git pull`, no `git fetch`" + description.
+      - No fabrication: rule #7 + Phase 5.5 explicit "NEVER fabricate".
+      - `resolve-memory.sh`: description + Phase 0 source line +
+        rule #6 + See-also.
+      - Bare wikilinks: Phase 5.3 + rule #5.
+- [x] **DoD-5** — `allowed-tools` excludes `Task`.
+      *Evidence:* `allowed-tools: Bash, Read, Glob, Grep`. Note: `Write`
+      was also dropped (no longer needed; the skill is pure read). This
+      is a tightening of the tool envelope, not a regression.
+
+## Pattern Compliance
+
+- [x] **`.vibeflow/patterns/memory-model.md`** — followed.
+      The skill remains the canonical-memory read mediator; reads stop
+      at the 15-entity cap (progressive disclosure preserved); Phase 0
+      uses `lib/canonical-memory/resolve-memory.sh` (no clone, no pull,
+      no fetch). The two-tier model is unchanged. Note: the doctrine
+      doc itself still describes the trace mechanism — that is the
+      explicit subject of Part 4 and is properly anti-scoped here.
+- [x] **`.vibeflow/patterns/plugin-structure.md`** — followed.
+      `skills/ask/SKILL.md` retains the standard frontmatter shape
+      (`name`, `description`, `argument-hint`, `allowed-tools`). No new
+      files introduced; no skill layout disturbed.
+
+## Convention Compliance
+
+- [x] `.vibeflow/conventions.md` "Don'ts → Do NOT allow the Generator
+      or the Validator to read canonical memory directly — every query
+      goes through the Orchestrator." — preserved. `/yoke:ask` is the
+      mediated read path; Part 1 does not relax this.
+- [x] `.vibeflow/conventions.md` "Don'ts → Do NOT load the entire
+      canonical memory into any agent's context — only the relevant
+      subgraph". — preserved (15-cap intact).
+- [x] No backwards-compatibility shim added (per PRD anti-scope and
+      conventions doctrine). `wm_query_trace_path` is deleted outright.
+
+## Anti-scope discipline
+
+| Anti-scope item | Status |
+| :--- | :--- |
+| Test changes (Part 3) | RESPECTED — `tests/` untouched |
+| Agent contract changes (Part 2) | RESPECTED — `agents/` untouched |
+| Doctrine `.vibeflow/` updates (Part 4) | RESPECTED — `.vibeflow/` untouched |
+| User-facing doc changes (Parts 5–6) | RESPECTED — `docs/`, `CLAUDE.md`, `CHANGELOG.md` untouched |
+| `lib/canonical-memory/resolve-memory.sh` | RESPECTED — untouched |
+| Memory registry shape | RESPECTED — `memories.json` schema untouched |
+| Compatibility shim for `wm_query_trace_path` | RESPECTED — none added |
+| New graphify or `/yoke:teach` escalation logic | RESPECTED — none added |
+
+## Risks (from spec)
+
+- **R1 / Internal callers still reference `wm_query_trace_path`** —
+  REMAINS, by design. Confirmed callers in `agents/{generator,validator,
+  orchestrator}.md` and four smoke tests; each is owned by Parts 2/3
+  per the multi-part split. Loud failure on those callers is the
+  intended signal until Parts 2/3 land.
+- **R2 / SKILL.md rewrite drops a load-bearing invariant** — DID NOT
+  HAPPEN. Each invariant was independently grep-verified (DoD-4).
+- **R3 / `_WM_PATHS_LOADED` re-source guard breaks** — DID NOT HAPPEN.
+  Subshell smoke-load returns exit 0 and all preserved helpers resolve
+  as functions.
+
+## Gaps
+
+None. All 5 DoD checks satisfied; all anti-scope items respected;
+budget used 2 / ≤ 4 files; no convention violations.
+
+## Notes for downstream parts
+
+- Part 2 must replace each Generator/Validator/Orchestrator reference
+  to `wm_query_trace_path` and `.yoke/query-traces/<slug>.md` with the
+  declarative `/yoke:ask` invocation rule.
+- Part 3 must update the four smoke tests so they assert the new
+  contract — every removed assertion must either map to a preserved
+  invariant (Part 1's DoD-4) or be intentionally deleted with the trace
+  contract.
+
+## Next step
+
+Ready to ship Part 1. Proceed to Part 2: `agents/{orchestrator,generator,
+validator}.md` rewrite.

--- a/.vibeflow/audits/ask-source-agnostic-read-part-2-audit.md
+++ b/.vibeflow/audits/ask-source-agnostic-read-part-2-audit.md
@@ -1,0 +1,183 @@
+# Audit Report: ask-source-agnostic-read-part-2
+
+**Verdict: PASS**
+
+> Auditor: /vibeflow:audit (autonomous run, 2026-04-25)
+> Spec: `.vibeflow/specs/ask-source-agnostic-read-part-2.md`
+> PRD: `.vibeflow/prds/ask-source-agnostic-read.md`
+> Dependency: ask-source-agnostic-read-part-1 (PASS)
+
+## Test execution
+
+No project-wide test runner exists. The smoke tests
+(`sprint-2.test.sh`, `sprint-5.test.sh`, `folder-isolation.test.sh`,
+`ask-no-clone.test.sh`) remain failing for the same reason as Part 1's
+audit: each asserts the old query-trace contract that this PR series
+deliberately retires. Those failures are owned by Part 3, which depends
+on Parts 1 and 2 having landed.
+
+| Verification | Result |
+| :--- | :--- |
+| All three agents `tools:` includes `Skill` | PASS |
+| All three agents `description` free of `query-traces` / "trace lands" | PASS |
+| Orchestrator Authority section: declarative bypass rule | PASS |
+| Orchestrator Mode A: invoke `/yoke:ask`, reason inline | PASS |
+| Orchestrator Mode B (Monitor) and Mode C (Canonize) structurally intact | PASS |
+| Generator/Validator cycle-start trace-read replaced with on-demand `/yoke:ask` | PASS |
+| Generator/Validator "Never read directly" rewritten with explicit `/yoke:ask` routing | PASS |
+| Decision 5 transition guards present in all three agents | PASS |
+
+## DoD Checklist
+
+- [x] **DoD-1** — Orchestrator Mode A consult-mode rewritten: invokes
+      `/yoke:ask` via the Skill tool and reasons over the response
+      in-conversation; no instructions to write
+      `.yoke/query-traces/<slug>.md`.
+      *Evidence:* `agents/orchestrator.md` "Mode A — Consult" bullets:
+      "Read canonical memory by invoking `/yoke:ask` via the Skill
+      tool", "Reason over the `/yoke:ask` response inline … no file is
+      written on disk as a consult-mode side effect". `grep -nE
+      "write.*query-trace|trace lands|trace entry|YAML trace"` returns
+      empty.
+- [x] **DoD-2** — Orchestrator no longer asserts the "absence of trace
+      entry is a bypass" rule. Bypass discipline is restated
+      declaratively.
+      *Evidence:* `agents/orchestrator.md` "## Authority" reads:
+      "Bypass discipline (declarative): the Generator and the
+      Validator **must** invoke `/yoke:ask` via the Skill tool for
+      every canonical-memory read. Direct filesystem reads of the
+      registered memory (cat, grep, clone, pull) are prohibited."
+      Also adds Trigger-4 escalation hint when the Orchestrator
+      observes a violation. `grep -nE "absence.*trace|trace
+      entry.*bypass|bypass.*trace"` returns empty.
+- [x] **DoD-3** — Generator and Validator no longer require reading
+      `.yoke/query-traces/<slug>.md` at the start of every cycle.
+      *Evidence:* `agents/generator.md` "Always" bullet replaced with
+      "Invoke `/yoke:ask` via the Skill tool when you need canonical
+      context — ratified policies, domain ownership, prior decisions,
+      patterns relevant to the Acceptance Contract criterion …
+      Before relying on prior knowledge for any of those, ask the
+      canonical memory." Symmetric edit in `agents/validator.md`
+      ("when sensor evidence needs to be judged against canonical-
+      memory rules — ratified policies, calibration metadata, prior
+      decisions on similar criteria"). The "Never" sections in both
+      files now state explicit `/yoke:ask` routing rather than
+      Orchestrator-mediated trace consumption.
+- [x] **DoD-4** — All three subagent YAML `description` fields are free
+      of `query-traces`/"trace lands" mentions.
+      *Evidence:* `grep -h "^description:" agents/*.md | grep -E
+      "query-trace|trace lands"` returns empty. The descriptions now
+      describe the canonical-memory access path positively (Orchestrator:
+      "invoking /yoke:ask via the Skill tool and reasoning over the
+      response in-conversation"; Generator and Validator: "Reads
+      canonical memory only by invoking /yoke:ask via the Skill tool.
+      Never writes canonical memory.").
+- [x] **DoD-5** — `tools:` field on each agent is
+      `Read, Write, Edit, Grep, Glob, Bash, Skill`. No `Write` grant
+      targets `.yoke/query-traces/`. The Allowed-tools sections in
+      each body describe write authority over working-memory artifacts
+      and host code only — never under `.yoke/query-traces/`.
+      *Evidence:* `grep "^tools:" agents/*.md`. The four query-traces
+      hits in body text are negative instructions ("`.yoke/query-traces/`
+      does not exist; do not read or write any path under it") — the
+      Decision-5 transition guard, not live grants.
+- [x] **DoD-6** — Mode B (Monitor) and Mode C (Canonize) logic untouched.
+      *Evidence:* `agents/orchestrator.md` Mode B preserved verbatim:
+      Generator/Validator divergence detection, escalate.sh wiring,
+      hard-bound + sprint-contract-contradiction routing. Mode C
+      preserved: `mode=canonize` activation, `/yoke:preserve`
+      invocation with `--from-orchestrator`, five-criterion cascade
+      delegated to `lib/canonical-memory/canonization-criteria.sh`,
+      Model C impact-class routing, propose-write.sh retirement note.
+      The only edit inside Mode C scope was removing
+      `.yoke/query-traces/<slug>.md` from the working-memory reads
+      list (a stale file reference the spec explicitly permits
+      cleaning up).
+
+## Pattern Compliance
+
+- [x] **`.vibeflow/patterns/roles.md`** — followed.
+      The Orchestrator remains the sole writer of canonical memory under
+      Model C. Generator and Validator file ownership unchanged
+      (Generator writes `.yoke/runtime/progress.md` and
+      `.yoke/contracts/<slug>.md`; Validator co-writes `.yoke/contracts/<slug>.md`).
+      No subagent shares context with the Orchestrator beyond what
+      `/yoke:implement` orchestration surfaces. The single-Skill-call
+      discipline is preserved (`tools:` adds `Skill` for canonical-memory
+      reads, no other tools added). Note: the doctrine doc itself still
+      describes the trace handoff — Part 4 owns that update.
+- [x] **`.vibeflow/patterns/memory-model.md`** — followed.
+      Read mediator pattern preserved: Generator and Validator now read
+      canonical memory through the same skill (`/yoke:ask`) that the
+      Orchestrator uses in consult mode. Progressive disclosure
+      preserved (the 15-cap is enforced inside `/yoke:ask`). Two-tier
+      memory model unchanged — only the cross-tier handoff mechanism
+      changed (from trace-file → from in-cycle Skill invocation).
+      Doctrine update is Part 4's responsibility.
+
+## Convention Compliance
+
+- [x] `.vibeflow/conventions.md` Don't *"Do NOT allow the Generator or
+      the Validator to read canonical memory directly — every query
+      goes through the Orchestrator."* — the spirit is preserved
+      (every read goes through `/yoke:ask`); the letter shifts (the
+      Orchestrator is no longer the relay). Part 4 will update the
+      doctrine wording to match.
+- [x] `.vibeflow/conventions.md` Don't *"Do NOT load the entire
+      canonical memory into any agent's context"* — preserved.
+      `/yoke:ask` enforces the 15-cap regardless of caller.
+- [x] `.vibeflow/conventions.md` *"runtime subagents must never share
+      context"* — preserved. Generator and Validator each invoke
+      `/yoke:ask` independently; they do not see each other's
+      responses.
+
+## Anti-scope discipline
+
+| Anti-scope item | Status |
+| :--- | :--- |
+| Skill or lib changes (Part 1) | RESPECTED — `skills/` and `lib/` untouched |
+| Test updates (Part 3) | RESPECTED — `tests/` untouched |
+| Doctrine `.vibeflow/` updates (Part 4) | RESPECTED — `.vibeflow/` untouched |
+| File-ownership changes for `.yoke/contracts/<slug>.md`, `.yoke/runtime/progress.md` | RESPECTED — ownership preserved verbatim |
+| Canonize-mode logic, five-criterion filter, propose-write.sh wiring | RESPECTED — Mode C body unchanged except stale reads-list line |
+| Introducing a new file-based handoff to replace the trace | RESPECTED — none introduced; Mode A explicitly uses inline reasoning |
+
+## Risks (from spec)
+
+- **R1 / Subagents reflexively try to read `.yoke/query-traces/<slug>.md`**
+  — MITIGATED. Decision-5 transition-guard lines added to all three
+  agents in body text ("`.yoke/query-traces/` does not exist; do not
+  read or write any path under it").
+- **R2 / Generator or Validator reasons without canonical grounding** —
+  MITIGATED. Both "Always" sections now say "Before relying on prior
+  knowledge for [policies / decisions / calibration], ask the
+  canonical memory."
+- **R3 / Edit accidentally touches Orchestrator's canonize or monitor
+  sections** — DID NOT HAPPEN. Mode B and Mode C bodies preserved;
+  only the Mode C reads list dropped a stale file reference.
+- **R4 / Allowed-tools loses something the agent still needs** — DID
+  NOT HAPPEN. Existing grants preserved; only the trace-write privilege
+  was removed (was implicit; now explicitly absent). The Orchestrator
+  Allowed-tools section retains `Write`/`Edit` "reserved for future
+  use" with a brief note.
+
+## Gaps
+
+None. All 6 DoD checks satisfied; budget used 3/≤4; anti-scope items
+respected; convention compliance preserved.
+
+## Notes for downstream parts
+
+- Part 3 must remove the trace assertions from the four smoke tests
+  and add a regression assertion that all three agents have `Skill` in
+  their `tools:` envelope.
+- Part 4 must update `.vibeflow/conventions.md`,
+  `.vibeflow/patterns/memory-model.md`, and `.vibeflow/patterns/roles.md`
+  so the doctrine descriptions match the runtime: Generator and
+  Validator read canonical memory via `/yoke:ask`; the bypass rule is
+  declarative; the consult-mode → trace-handoff narrative is replaced
+  with the per-question invocation pattern.
+
+## Next step
+
+Ready to ship Part 2. Proceed to Part 3: smoke-test alignment.

--- a/.vibeflow/audits/ask-source-agnostic-read-part-3-audit.md
+++ b/.vibeflow/audits/ask-source-agnostic-read-part-3-audit.md
@@ -1,0 +1,192 @@
+# Audit Report: ask-source-agnostic-read-part-3
+
+**Verdict: PASS**
+
+> Auditor: /vibeflow:audit (autonomous run, 2026-04-25)
+> Spec: `.vibeflow/specs/ask-source-agnostic-read-part-3.md`
+> PRD: `.vibeflow/prds/ask-source-agnostic-read.md`
+> Dependencies: ask-source-agnostic-read-part-1 (PASS), ask-source-agnostic-read-part-2 (PASS)
+
+## Test execution
+
+| Test | Result |
+| :--- | :--- |
+| `tests/smoke/sprint-2.test.sh` | PASS |
+| `tests/smoke/sprint-5.test.sh` | PASS |
+| `tests/smoke/folder-isolation.test.sh` | PASS |
+| `tests/smoke/ask-no-clone.test.sh` | PASS |
+| `tests/smoke/sprint-3.test.sh` (regression) | PASS |
+| `tests/smoke/sprint-4.test.sh` (regression) | PASS |
+| `tests/smoke/sprint-6.test.sh` (regression) | PASS |
+| `tests/smoke/sprint-7.test.sh` (regression) | PASS |
+| `tests/smoke/sprint-8.test.sh` (regression) | PASS |
+| `tests/smoke/memory-migration.test.sh` (regression) | PASS |
+| `tests/smoke/preserve-model-c.test.sh` (regression) | PASS |
+| `tests/smoke/status-readonly.test.sh` (regression) | PASS |
+| `tests/smoke/teach-ingest.test.sh` (regression) | PASS |
+
+**13/13 smoke tests PASS.** This is the first time the suite has been
+fully green since the trace-removal effort began; Parts 1+2 left the
+suite intentionally inconsistent until this part landed.
+
+## DoD Checklist
+
+- [x] **DoD-1** — `tests/smoke/sprint-2.test.sh`: trace-write assertion
+      removed; replacement assertions cover skill callable without
+      `.yoke/.current` (negative-pattern grep + positive
+      "source-agnostic" phrase grep), allowed-tools excludes both
+      `Task` and `Write`, references `resolve-memory.sh`, declares
+      no-clone, declares no-fabrication, caps at 15.
+      *Evidence:* `tests/smoke/sprint-2.test.sh` checks 8 (lines
+      105-138) reads as the new shape; existing checks at lines 7, 9
+      preserved unchanged.
+- [x] **DoD-2** — `tests/smoke/sprint-5.test.sh`: assertions about the
+      YAML trace shape (`mode: ask`, `entities_read`, `capped`,
+      `invoker`) and the `query-traces` reference removed; only
+      `resolve-memory.sh` is asserted. No duplicate of sprint-2's
+      source-agnostic check (deletion preferred per spec).
+      *Evidence:* `tests/smoke/sprint-5.test.sh` check 5 (lines 86-95)
+      and check 13 (lines 239-244) reflect the new shape.
+- [x] **DoD-3** — `tests/smoke/folder-isolation.test.sh`: per-category
+      folder layout asserts only `prds`, `tech-specs`,
+      `acceptance-contracts`, `contracts`. The migration check for the
+      singular `query-trace.md` is replaced with a sweep that
+      enforces no live query-trace references in `skills/`, `lib/`, or
+      `hooks/` (exclusion regex skips lines marked retired). Any
+      `wm_query_trace_path` invocation is deleted; the simulated flow
+      no longer writes a trace; the forbidden-flat list no longer
+      includes `.yoke/query-trace.md`.
+      *Evidence:* `tests/smoke/folder-isolation.test.sh` lines 43-72
+      (flat-path scan + sweep), 90-126 (simulated flow), 132-157
+      (case statement + forbidden list).
+- [x] **DoD-4** — `tests/smoke/ask-no-clone.test.sh`: untouched. On
+      inspection the test had no trace coupling — it exercises the
+      Part 1 resolution lib end-to-end and asserts (a) reflog stable
+      across two resolutions, (b) `resolve-memory.sh` has no
+      `clone/pull/fetch`, (c) SKILL.md declares the no-clone
+      invariant, (d) `query.sh` is gone. All four assertions still
+      hold under the new skill shape.
+      *Evidence:* `bash tests/smoke/ask-no-clone.test.sh` reports
+      `All Part 3 no-clone scenarios PASS`.
+- [x] **DoD-5** — All four smoke tests pass. Confirmed by direct
+      execution above.
+- [x] **DoD-6** — No surviving *live* reference to `query-trace.md`,
+      `query-traces/`, or `wm_query_trace_path` in any test. Surviving
+      occurrences are all (i) docstrings explaining what was retired
+      or (ii) negative-assertion patterns asserting the contract has
+      not returned. The strict reading of "no test references" is
+      relaxed to "no surviving reference as a live mechanism" per the
+      spec body's intent ("the migration check for the singular
+      `query-trace.md` is removed (the singular file did not survive
+      past v0.6.0; the plural directory will not exist)").
+      *Evidence:* `grep -RnE 'query-trace|wm_query_trace_path'
+      tests/smoke/` returns 11 hits, every one of which is a comment,
+      docstring, or err-branch of a negative-assertion guard.
+- [x] **DoD-7** — Vacuous-green assertions absent. Each replaced
+      assertion tests a real property:
+      - "allowed-tools excludes Write" — would fail if Write returns.
+      - "source-agnostic phrase present" — would fail if the SKILL.md
+        regresses to require an active task.
+      - "no live query-trace references in skills/lib/hooks" — would
+        fail if any caller re-introduces the path.
+      - sprint-5 trace-shape assertions deleted outright (no
+        replacement that would always green).
+
+## Pattern Compliance
+
+- [x] **`.vibeflow/patterns/sensors.md`** — followed.
+      Each new test assertion has clear pass/err messages and tests a
+      named property. The "structured output" convention applies to
+      runtime sensors but the test convention here mirrors it
+      (`pass "<rule>"` / `err "<violation>"`).
+- [x] **`.vibeflow/patterns/plugin-structure.md`** — followed.
+      `tests/smoke/` layout preserved; no new directory introduced; no
+      new test files created (DoD anti-scope).
+
+## Convention Compliance
+
+- [x] `.vibeflow/conventions.md` Implementation Plan Conventions —
+      "Smoke test per sprint": preserved; `bash 4+` target preserved;
+      external `timeout 600` discipline preserved (`ask-no-clone`
+      already wraps itself; sprint-2/5/folder-isolation are
+      pre-Sprint-6 and don't run ralph loops).
+
+## Anti-scope discipline
+
+| Anti-scope item | Status |
+| :--- | :--- |
+| Adding new test files | RESPECTED — no new files in `tests/smoke/` |
+| Wiring `tests/` into CI (Sprint 8) | RESPECTED — no CI changes |
+| Smoke-test harness or `timeout 600` discipline | RESPECTED — preserved |
+| `tests/smoke/sprint-3.test.sh`, `sprint-4.test.sh`, `teach-ingest.test.sh` | RESPECTED — untouched; regressions PASS |
+
+## Risks (from spec)
+
+- **R1 / Vacuous-green assertion** — DID NOT HAPPEN. Each replaced
+  assertion is verified as testing a real property.
+- **R2 / Removed assertion takes a real safety property with it** —
+  DID NOT HAPPEN. Each removed assertion was about the trace contract
+  itself; preserved invariants (15-cap, no-clone, no-fabrication,
+  resolve-memory.sh, allowed-tools-excludes-Task) still asserted by
+  sprint-2 plus a new "Write excluded" check.
+- **R3 / Test fails on macOS bash 3** — N/A (project targets bash 4+;
+  the suite was already passing under bash 4 prior to this PR).
+- **R4 / `timeout 600` exceeded** — DID NOT HAPPEN. Suite runs in
+  seconds. The new flow does fewer disk writes than the old.
+
+## Notable item: budget over-run
+
+The spec's scope listed 4 test files; this implementation modified 3
+test files (ask-no-clone needed no edit) plus 2 additional **skill**
+files:
+
+- `skills/implement/SKILL.md` — removed the
+  `wm_query_trace_path "$slug"` initialization step from the cycle-0
+  setup. The function had been deleted in Part 1; this line would
+  have failed at runtime as soon as Part 1 shipped.
+- `skills/drift-sense/SKILL.md` — three trace references rewritten:
+  (a) staleness-source falls back to `last_validated` only; (b)
+  `--target traces` mode now scans contracts only; (c) traces-mode
+  pre-condition no longer mentions the retired `.yoke/query-traces/<slug>.md`.
+
+These two files were Part 1 stragglers — Part 1's R1 mitigation
+required a grep across `skills/` to catch every caller of the deleted
+helper, but the Part 1 audit missed these two. They were caught by
+folder-isolation.test.sh's new "no live query-trace references" sweep.
+Patching them was necessary to make DoD-5 (tests pass) achievable;
+without the patches the suite would have stayed red.
+
+Files modified: 5 / spec scope 4. Treating as a Part 1 corrigendum
+embedded in Part 3 rather than re-opening Part 1's audit. The two
+skill files have a minimal-scope edit each (one removed line in
+implement; three rewritten lines + 1 deprecation note in drift-sense)
+and the broader behavioral implication (drift-sense `--target traces`
+mode loses query-trace as an input source) is acknowledged in inline
+comments.
+
+This over-run is **PASS-compatible** under the audit skill's rules —
+the rule that triggers automatic FAIL is "tests fail", not "budget
+exceeded by 1". The architect (spec author) is hereby informed; if
+this should have been a Part 1 amendment with a separate audit, that
+is a process call rather than a code call.
+
+## Gaps
+
+None. All 7 DoD checks satisfied; all 13 smoke tests pass; anti-scope
+respected; pattern compliance preserved.
+
+## Notes for downstream parts
+
+- Part 4 (doctrine update) must update `.vibeflow/conventions.md`,
+  `.vibeflow/patterns/memory-model.md`, and
+  `.vibeflow/patterns/roles.md` to reflect the runtime + skill +
+  test contracts now established by Parts 1-3.
+- Part 5 (CLAUDE.md + docs) must update the working-memory layout
+  and any `query-trace.md` mentions in user-facing docs.
+- Part 6 (changelog + trailing docs) must record the contract change
+  end-to-end, including the Part 1 corrigendum to `skills/implement`
+  and `skills/drift-sense`.
+
+## Next step
+
+Ready to ship Part 3. Proceed to Part 4: `.vibeflow/` doctrine update.

--- a/.vibeflow/audits/ask-source-agnostic-read-part-4-audit.md
+++ b/.vibeflow/audits/ask-source-agnostic-read-part-4-audit.md
@@ -1,0 +1,193 @@
+# Audit Report: ask-source-agnostic-read-part-4
+
+**Verdict: PASS**
+
+> Auditor: /vibeflow:audit (autonomous run, 2026-04-25)
+> Spec: `.vibeflow/specs/ask-source-agnostic-read-part-4.md`
+> PRD: `.vibeflow/prds/ask-source-agnostic-read.md`
+> Dependency: ask-source-agnostic-read-part-1 (PASS)
+
+## Test execution
+
+13/13 smoke tests PASS — no regression introduced by the doctrine
+edits. Doctrine changes are documentation only; they do not change
+runtime behavior, but the test suite is run as a defensive
+sanity-check that no doc edit accidentally hit live code.
+
+| Test | Result |
+| :--- | :--- |
+| `tests/smoke/sprint-2.test.sh` | PASS |
+| `tests/smoke/sprint-3.test.sh` | PASS |
+| `tests/smoke/sprint-4.test.sh` | PASS |
+| `tests/smoke/sprint-5.test.sh` | PASS |
+| `tests/smoke/sprint-6.test.sh` | PASS |
+| `tests/smoke/sprint-7.test.sh` | PASS |
+| `tests/smoke/sprint-8.test.sh` | PASS |
+| `tests/smoke/ask-no-clone.test.sh` | PASS |
+| `tests/smoke/folder-isolation.test.sh` | PASS |
+| `tests/smoke/memory-migration.test.sh` | PASS |
+| `tests/smoke/preserve-model-c.test.sh` | PASS |
+| `tests/smoke/status-readonly.test.sh` | PASS |
+| `tests/smoke/teach-ingest.test.sh` | PASS |
+
+## DoD Checklist
+
+- [x] **DoD-1** — `.vibeflow/conventions.md` `Working memory —
+      canonical files` section no longer lists `query-trace.md`. The
+      relevant Don't is restated declaratively: "Do NOT allow any
+      agent to read canonical memory directly. All reads route
+      through `/yoke:ask` invoked via the Skill tool — direct
+      filesystem reads … are prohibited."
+      *Evidence:* `grep -nE "query-trace" .vibeflow/conventions.md`
+      returns empty.
+- [x] **DoD-2** — `.vibeflow/patterns/memory-model.md` table no
+      longer contains the `query-trace.md` row. The Canonical-memory
+      access timing → Consult paragraph rewritten: "Any runtime
+      subagent — Generator, Validator, or Orchestrator — invokes
+      `/yoke:ask` via the Skill tool on demand and reasons over the
+      response in-conversation." Example tree no longer includes
+      `query-trace.md`. Implementation Mapping list rewritten —
+      "Canonical-memory reads do not materialize a working-memory
+      artifact". Bypass anti-pattern rewritten: "agents reading
+      canonical memory by `cat`/`grep`/cloning the substrate —
+      bypasses progressive disclosure and the `/yoke:ask` mediation
+      contract".
+      *Evidence:* `grep -nE "query-trace" .vibeflow/patterns/memory-model.md`
+      returns empty.
+- [x] **DoD-3** — `.vibeflow/patterns/roles.md` Generator and
+      Validator sections rewritten: "Reads canonical memory: only via
+      `/yoke:ask` invoked through the Skill tool; never directly.
+      Direct filesystem reads of the registered memory (cat, grep,
+      clone, pull) are prohibited." Orchestrator consult-mode
+      description: "Invokes `/yoke:ask` via the Skill tool and reasons
+      over the response in-conversation. The skill enforces
+      progressive disclosure (≤ 15 entity reads, 1-level wikilink
+      hop) — never the full memory." Bypass discipline restated as
+      declarative rule (no "absence of trace entry" phrasing).
+      *Evidence:* `grep -nE "query-trace" .vibeflow/patterns/roles.md`
+      returns empty.
+- [x] **DoD-4** — Cross-document consistency. All three load-bearing
+      docs (`conventions.md`, `memory-model.md`, `roles.md`) describe
+      the canonical-memory read path identically: "invoke `/yoke:ask`
+      via the Skill tool" with declarative bypass rule. The
+      progressive-disclosure cap (15 entity reads, 1-level hop) is
+      stated consistently. The two-tier memory model (working memory
+      vs canonical memory) and the single-write-path invariant
+      (`/yoke:preserve` via Skill tool, Orchestrator only) are
+      preserved consistently across all docs. Verified by reading
+      each doc end-to-end.
+- [x] **DoD-5** — Sweep gate. No file under `.vibeflow/` references
+      `query-trace.md` or `query-traces/<slug>.md` as a live
+      mechanism. Surviving occurrences (verified via
+      `grep -RnE "query-trace|query-traces|wm_query_trace_path"
+      .vibeflow/`) are all in `.vibeflow/decisions.md` (lines 21, 56)
+      — historical decision records explicitly framed as past state.
+      The spec's anti-scope makes decisions.md historical entries
+      out-of-scope.
+
+## Pattern Compliance
+
+This part is self-referential — the patterns being edited *are* the
+project's pattern docs. Compliance check is "do the rewritten docs
+remain internally consistent with the project's actual runtime?":
+
+- [x] **memory-model.md** — agrees with the runtime now established
+      by Parts 1-3. `/yoke:ask` is a pure read; Generator and
+      Validator invoke it directly via Skill tool; Orchestrator
+      consult mode invokes it and reasons inline; the trace handoff
+      is gone.
+- [x] **roles.md** — agrees with `agents/orchestrator.md`,
+      `agents/generator.md`, `agents/validator.md` as updated by
+      Part 2. Read/write authorities preserved verbatim except for
+      the trace path replacement.
+- [x] **conventions.md** Don'ts — preserves "no agent except
+      Orchestrator writes canonical memory" and "no full canonical
+      memory in any context" while updating the read-path Don't to
+      match the new contract.
+- [x] **plugin-structure.md** — not edited; no inconsistency with
+      the updated docs.
+
+## Convention Compliance
+
+- [x] Markdown style — preserved (table syntax, list bullets, code
+      block fences, emphasis).
+- [x] No documentation fabrication — every replacement statement
+      reflects an actual code/agent state established by Parts 1-3.
+- [x] Linguistic precision — "must" / "never" / "any agent" used
+      consistently with the doctrine doc style.
+
+## Anti-scope discipline
+
+| Anti-scope item | Status |
+| :--- | :--- |
+| `CLAUDE.md` (project root) — Part 5 | RESPECTED — not edited |
+| `docs/architecture.md`, `docs/lineage.md`, `docs/troubleshooting.md` — Part 5 | RESPECTED |
+| `docs/quickstart.md`, `examples/*`, `CHANGELOG.md` — Part 6 | RESPECTED |
+| `.vibeflow/decisions.md` — historical | RESPECTED — untouched |
+| `.vibeflow/index.md` — fold-in if hit | FOLDED IN (line 49 had a hit; spec explicitly permits this) |
+| Code/test files — Parts 1-3 | RESPECTED |
+
+## Risks (from spec)
+
+- **R1 / Doctrine drift vs runtime** — DID NOT HAPPEN. Doctrine and
+  runtime are now consistent (Parts 1-2 updated runtime; Part 4
+  updated doctrine). Both flow through `/yoke:ask` via the Skill tool
+  on demand.
+- **R2 / Stale reference missed** — DID NOT HAPPEN. DoD-5 sweep gate
+  passed. The grep that originally caught the strays in
+  `phase-flow.md` and `ralph-loop.md` was the very mechanism that
+  prompted the budget over-run.
+- **R3 / Pattern doc loses load-bearing invariant unrelated to the
+  trace** — DID NOT HAPPEN. The 15-cap, no-clone, single-write-path,
+  two-tier-memory invariants are all explicitly preserved in the
+  rewrites; only trace-related prose was replaced.
+- **R4 / Cross-document inconsistency** — DID NOT HAPPEN. Final
+  read-through across all 6 modified docs confirms the canonical-memory
+  read path is described identically.
+
+## Notable item: budget over-run
+
+The spec scoped 3 explicit files + `.vibeflow/index.md` as fold-in.
+Implementation modified 6:
+
+1. `.vibeflow/conventions.md` (in scope)
+2. `.vibeflow/patterns/memory-model.md` (in scope)
+3. `.vibeflow/patterns/roles.md` (in scope)
+4. `.vibeflow/index.md` (spec-allowed fold-in)
+5. `.vibeflow/patterns/phase-flow.md` (DoD-5 sweep fold-in)
+6. `.vibeflow/patterns/ralph-loop.md` (DoD-5 sweep fold-in)
+
+Files 5 and 6 were not anticipated by the spec author. They contain
+live mechanism descriptions — phase-flow's Phase 4 output column and
+ralph-loop's Orchestrator consult+monitor description — that the
+spec's DoD-5 sweep gate ("no file under `.vibeflow/` references
+query-trace as a live mechanism") demands fixing. Without those
+edits, DoD-5 fails. Edit was minimal-scope: one cell in phase-flow's
+table, three sections in ralph-loop. Both edits preserve every
+non-trace invariant verbatim.
+
+Pattern same as Part 3's stragglers: sweep-gate fold-ins with
+declared rationale. Treating as in-scope corrections; PASS-compatible
+under the audit skill's rules (the only automatic-fail trigger is
+"tests fail").
+
+## Gaps
+
+None. All 5 DoD checks satisfied; 13/13 smoke tests pass; anti-scope
+items respected; convention compliance preserved; cross-document
+consistency verified.
+
+## Notes for downstream parts
+
+- Part 5 must update `CLAUDE.md` (project root) and `docs/*.md` so
+  user- and agent-facing docs match the doctrine now established by
+  Parts 1-4.
+- Part 6 must update `docs/quickstart.md`, the example CLAUDE.md,
+  and `CHANGELOG.md` with a clearly-marked **Breaking** entry that
+  records the contract change end-to-end (including the Part 1
+  corrigendum to `skills/implement` + `skills/drift-sense` and the
+  Part 4 sweep fold-ins to `phase-flow.md` + `ralph-loop.md`).
+
+## Next step
+
+Ready to ship Part 4. Proceed to Part 5: repo `CLAUDE.md` + main docs.

--- a/.vibeflow/audits/ask-source-agnostic-read-part-5-audit.md
+++ b/.vibeflow/audits/ask-source-agnostic-read-part-5-audit.md
@@ -1,0 +1,152 @@
+# Audit Report: ask-source-agnostic-read-part-5
+
+**Verdict: PASS**
+
+> Auditor: /vibeflow:audit (autonomous run, 2026-04-25)
+> Spec: `.vibeflow/specs/ask-source-agnostic-read-part-5.md`
+> PRD: `.vibeflow/prds/ask-source-agnostic-read.md`
+> Dependencies: ask-source-agnostic-read-part-1 (PASS), ask-source-agnostic-read-part-4 (PASS)
+
+## Test execution
+
+13/13 smoke tests PASS — Part 5 is doc-only and introduces no runtime
+behavior; the suite is run as a defensive sanity-check.
+
+| Test | Result |
+| :--- | :--- |
+| sprint-2.test.sh | PASS |
+| sprint-3.test.sh | PASS |
+| sprint-4.test.sh | PASS |
+| sprint-5.test.sh | PASS |
+| sprint-6.test.sh | PASS |
+| sprint-7.test.sh | PASS |
+| sprint-8.test.sh | PASS |
+| ask-no-clone.test.sh | PASS |
+| folder-isolation.test.sh | PASS |
+| memory-migration.test.sh | PASS |
+| preserve-model-c.test.sh | PASS |
+| status-readonly.test.sh | PASS |
+| teach-ingest.test.sh | PASS |
+
+## DoD Checklist
+
+- [x] **DoD-1** — Repo-root `CLAUDE.md` working-memory description
+      no longer lists `query-trace.md`. The Working memory tier row
+      reads: `prd.md, tech-spec.md, acceptance-contract.md,
+      progress.md, contracts.md`.
+      *Evidence:* `grep -nE "query-trace" CLAUDE.md` returns empty.
+- [x] **DoD-2** — `docs/architecture.md` ASCII diagram of `.yoke/`
+      no longer contains `query-trace.md`. The third column
+      now reads `/yoke:ask (Skill)` to indicate the runtime read
+      path. The Consult-mode bullet rewritten: "invoke `/yoke:ask`
+      via the Skill tool when canonical-memory context is needed;
+      reason over the response in-conversation. The skill is
+      source-agnostic and writes nothing on disk." The "Three
+      runtime subagents" file list (line 150 area) drops
+      `query-trace.md` from the working-memory tuple.
+      *Evidence:* `grep -nE "query-trace" docs/architecture.md`
+      returns empty.
+- [x] **DoD-3** — `docs/lineage.md` no longer carries the live
+      "audit-trail writing to `.yoke/query-trace.md`" line. The
+      `lib/canonical-memory/query.sh` subsection is now headed
+      `(retired)` with a paragraph explicitly framing both the
+      primitive AND its trace contract as retired. Surviving
+      `query-trace` mentions are inside the "Historical adaptations
+      (no longer in effect)" sub-block.
+      *Evidence:* `grep -nE "query-trace" docs/lineage.md` returns
+      one hit at line 60, inside the explicit historical narrative
+      ("The audit-trail / query-trace contract … was retired in
+      ask-source-agnostic-read Part 1"). Spec text permits
+      historical references "explicitly framed as past."
+- [x] **DoD-4** — `docs/troubleshooting.md` does not include any
+      step that checks `.yoke/query-traces/` or `.yoke/query-trace.md`.
+      The "skill X is missing canonical-memory access" guidance
+      rewritten: "All canonical-memory access goes through `/yoke:ask`
+      invoked via the Skill tool. The skill is source-agnostic …
+      Verify `/yoke:ask` resolves the active memory by running
+      `bash lib/canonical-memory/resolve-memory.sh --memory <name>`."
+      "Where do I find the canonical-memory repo?" rewritten away
+      from the retired `~/.cache/yoke/canonical/<slug>/` cache to the
+      registered-path-in-`memories.json` model. "How do I reset Yoke
+      for a clean test?" no longer instructs `rm -rf` against the
+      retired cache path.
+      *Evidence:* `grep -nE "query-trace" docs/troubleshooting.md`
+      returns empty.
+- [x] **DoD-5** — Sweep gate. Surviving live-mechanism references
+      to `query-trace.md` or `query-traces/<slug>.md` across the four
+      files: zero. Sole surviving occurrence at `docs/lineage.md:60`
+      is inside an explicit `### lib/canonical-memory/query.sh
+      (retired)` subsection with `**Historical adaptations (no
+      longer in effect)**` framing — a permitted historical narrative
+      per spec text.
+
+## Pattern Compliance
+
+- [x] **`.vibeflow/patterns/memory-model.md`** — followed.
+      `CLAUDE.md` and `docs/architecture.md` working-memory layouts
+      agree with the doctrine doc as updated by Part 4. Both now
+      describe the same five-file working-memory tuple (prd,
+      tech-spec, acceptance-contract, progress, contracts) plus
+      `.snapshots/`.
+- [x] **`.vibeflow/patterns/plugin-structure.md`** — followed.
+      Architecture diagram and repo-layout descriptions remain
+      consistent with the patterns doc; no structural changes.
+
+## Convention Compliance
+
+- [x] Markdown style — preserved across all four files (table
+      syntax, code-block fences, header levels, list bullets).
+- [x] No fabrication — every replacement statement reflects the
+      runtime + lib state established by Parts 1-4.
+- [x] Linguistic precision — "retired", "no longer in effect",
+      "source-agnostic" used consistently.
+
+## Anti-scope discipline
+
+| Anti-scope item | Status |
+| :--- | :--- |
+| `.vibeflow/` doctrine — Part 4 | RESPECTED — not edited |
+| `docs/quickstart.md`, `examples/greenfield-payment-service/CLAUDE.md`, `CHANGELOG.md` — Part 6 | RESPECTED |
+| `README.md` — verify and skip if clean | RESPECTED — verified clean by grep, not edited |
+| `docs/installation.md`, `docs/canonical-memory-setup.md` — verify and fold in only on hit | RESPECTED — verified clean by grep, not edited |
+| Documentation about other plugin features (bootstrap, teach, preserve, drift-sense, status, memory) | RESPECTED — only the trace-related sections in the four scoped files were touched |
+
+## Risks (from spec)
+
+- **R1 / Architecture diagram has multiple occurrences of the trace;
+  one is missed** — DID NOT HAPPEN. All three occurrences in
+  `docs/architecture.md` (lines 23, 88, 150) updated; post-edit
+  grep confirms zero remaining.
+- **R2 / Lineage narrative becomes confusing** — DID NOT HAPPEN.
+  The historical subsection is now explicitly headed `(retired)` and
+  the body opens with a paragraph framing both the primitive and the
+  trace contract as past. The remaining mention at line 60 is inside
+  that framed block.
+- **R3 / A doc references the working-memory layout assuming 6
+  files** — DID NOT HAPPEN. Both `CLAUDE.md` and
+  `docs/architecture.md` now agree on the 5-file working-memory
+  tuple. Numeric counts in surrounding prose were preserved (no
+  "the six files" leftovers found).
+- **R4 / Future drift between CLAUDE.md and `memory-model.md`** —
+  N/A for this audit. Both files now agree; reviewer should keep
+  them in lockstep on future edits.
+
+## Gaps
+
+None. All 5 DoD checks satisfied; budget exactly met (4/4); 13/13
+smoke tests pass; anti-scope respected; pattern compliance preserved.
+
+## Notes for downstream parts
+
+- Part 6 closes the doc sweep with `docs/quickstart.md`,
+  `examples/greenfield-payment-service/CLAUDE.md`, and the breaking-
+  change `CHANGELOG.md` entry. The CHANGELOG entry should record the
+  full PR series end-to-end: Parts 1-2 (skill + agents), Part 3
+  (tests + Part 1 corrigendum to `skills/implement` and
+  `skills/drift-sense`), Part 4 (doctrine + sweep fold-ins to
+  `phase-flow.md` and `ralph-loop.md`), Part 5 (CLAUDE.md + main
+  docs), and Part 6 itself.
+
+## Next step
+
+Ready to ship Part 5. Proceed to Part 6: trailing docs + CHANGELOG.

--- a/.vibeflow/audits/ask-source-agnostic-read-part-6-audit.md
+++ b/.vibeflow/audits/ask-source-agnostic-read-part-6-audit.md
@@ -1,0 +1,186 @@
+# Audit Report: ask-source-agnostic-read-part-6
+
+**Verdict: PASS**
+
+> Auditor: /vibeflow:audit (autonomous run, 2026-04-25)
+> Spec: `.vibeflow/specs/ask-source-agnostic-read-part-6.md`
+> PRD: `.vibeflow/prds/ask-source-agnostic-read.md`
+> Dependencies: ask-source-agnostic-read-part-1 (PASS), ask-source-agnostic-read-part-4 (PASS)
+
+## Test execution
+
+13/13 smoke tests PASS — full suite green at the end of the PR series.
+
+| Test | Result |
+| :--- | :--- |
+| sprint-2.test.sh | PASS |
+| sprint-3.test.sh | PASS |
+| sprint-4.test.sh | PASS |
+| sprint-5.test.sh | PASS |
+| sprint-6.test.sh | PASS |
+| sprint-7.test.sh | PASS |
+| sprint-8.test.sh | PASS |
+| ask-no-clone.test.sh | PASS |
+| folder-isolation.test.sh | PASS |
+| memory-migration.test.sh | PASS |
+| preserve-model-c.test.sh | PASS |
+| status-readonly.test.sh | PASS |
+| teach-ingest.test.sh | PASS |
+
+## DoD Checklist
+
+- [x] **DoD-1** — `docs/quickstart.md` no longer describes
+      `/yoke:ask` as "mediated"; replaced with "adaptive
+      canonical-memory query".
+      *Evidence:* `grep -n "mediated" docs/quickstart.md` returns
+      empty.
+- [x] **DoD-2** — `examples/greenfield-payment-service/CLAUDE.md`
+      mirrors quickstart wording exactly: "adaptive canonical-memory
+      query".
+      *Evidence:* identical phrasing across both files.
+- [x] **DoD-3** — `CHANGELOG.md` contains the new entry, marked
+      **Breaking**, covering: removal of query-trace contract,
+      removal of `wm_query_trace_path` and `query-traces` archive
+      category, change to bypass discipline (declarative), runtime-
+      agent contract change (Generator/Validator/Orchestrator now
+      invoke `/yoke:ask` via Skill), and migration note (delete
+      orphaned `.yoke/query-traces/` directory).
+      *Evidence:* `head -90 CHANGELOG.md` shows the new entry with
+      all five required content elements present.
+- [x] **DoD-4** — CHANGELOG entry follows existing style: `## [...]
+      — title — **Breaking**` header (matches the `## [version]` —
+      title format, with `[Unreleased]` per spec wording "create one
+      if absent"); `### Removed` and `### Changed` and `### Migration`
+      sections matching prior-entry section ordering; markdown
+      bullets and code-block fences match the existing style.
+- [x] **DoD-5** — Sweep gate. No surviving live-mechanism reference
+      in any of the three scoped files.
+      *Evidence:* `grep -nE "query-trace|query-traces|wm_query_trace_path"`
+      against `docs/quickstart.md`, `examples/greenfield-payment-service/CLAUDE.md`,
+      and `CHANGELOG.md`. Quickstart and example CLAUDE.md grep
+      empty. CHANGELOG hits are inside the new entry's "Removed"
+      section that explicitly describes the retirement — these are
+      historical narrative, not live references (consistent with the
+      spec's permitted historical framing).
+
+## Pattern Compliance
+
+- [x] **`.vibeflow/patterns/plugin-structure.md`** — followed.
+      `examples/` layout preserved; CHANGELOG.md style preserved.
+- [x] **`.vibeflow/conventions.md`** Implementation Plan Conventions
+      "Every sprint ships an installable plugin" — the plugin is
+      still installable. Per-version stamping preserved (entry uses
+      `[Unreleased]` until release).
+
+## Convention Compliance
+
+- [x] CHANGELOG style — Keep-a-Changelog convention preserved
+      (Removed / Changed / Migration sections; bullet style; code
+      fences for shell commands).
+- [x] Linguistic precision — "Breaking" prominently marked;
+      "retired" used consistently for the gone-but-historically-
+      framed contract.
+- [x] No fabrication — every CHANGELOG bullet describes a real edit
+      from Parts 1-5 (or this part's own corrigenda).
+
+## Anti-scope discipline (strict spec scope)
+
+| Anti-scope item | Status |
+| :--- | :--- |
+| Other docs (Part 5) | RESPECTED — not re-edited by Part 6 |
+| Doctrine `.vibeflow/` (Part 4) | RESPECTED |
+| Migration tooling for existing projects | RESPECTED — CHANGELOG instructs the user to `rm -rf .yoke/query-traces/`; no migration code shipped |
+| Other examples | RESPECTED — only the greenfield-payment-service example references `/yoke:ask` |
+| `README.md` | RESPECTED — verified clean by grep, not edited |
+
+## Risks (from spec)
+
+- **R1 / CHANGELOG entry undersells the breakage** — DID NOT HAPPEN.
+  Entry is prominently labeled `(**Breaking**)` in the title, has a
+  `> Breaking.` callout immediately after the summary paragraph, and
+  closes with a `### Migration` section.
+- **R2 / Quickstart and example CLAUDE.md drift** — DID NOT HAPPEN.
+  Identical phrasing landed in both; future edits should keep them
+  in lockstep.
+- **R3 / A surviving query-trace reference is missed in another
+  example or doc** — Caught by the post-Part-6 sweep. README,
+  installation, canonical-memory-setup verified clean. Three
+  additional callers in `skills/` (bootstrap, implement, preserve)
+  were patched as a final cross-cutting corrigendum (see "Notable
+  item" below).
+
+## Notable item: cross-cutting corrigendum (out of strict scope)
+
+After completing the spec-scope edits, a final repo-wide sweep
+caught three more files with live `wm_query_trace_path` and
+`.yoke/query-traces/<slug>.md` references that were missed by
+earlier audits:
+
+1. `skills/bootstrap/SKILL.md` — listed `query-traces/` as a live
+   archive category in the bootstrap rationale.
+2. `skills/implement/SKILL.md` — five additional references to
+   `wm_query_trace_path` in the cycle-loop input contracts for
+   Generator, Validator, and Orchestrator (Part 3 patched only
+   line 51's cycle-0 init).
+3. `skills/preserve/SKILL.md` — referenced `query-traces/<slug>.md`
+   in the free-form input parser's `.yoke/<task-slug>/` directory
+   read.
+
+All three were live runtime references — `skills/implement/SKILL.md`
+in particular would have failed at runtime by calling the deleted
+`wm_query_trace_path` function. Patched here as a final corrigendum
+to make the user-stated condition "ALL THE WORK is DONE" true. The
+budget over-run mirrors Part 3 (where the same sweep gate caught
+implement/drift-sense stragglers) and Part 4 (where the sweep gate
+caught phase-flow/ralph-loop stragglers); the pattern indicates the
+spec author should write tighter sweep gates into all multi-part
+docrtine-removal PRDs in the future.
+
+Files modified by Part 6 in total: 6 (3 in spec scope + 3
+corrigendum).
+
+## Notable item: version bump reverted
+
+I initially bumped `plugin.json` from 1.1.0 → 1.2.0 to keep the
+CHANGELOG entry's version in sync. This caused
+`tests/smoke/sprint-8.test.sh` to FAIL — the test has a hardcoded
+expectation that `plugin.json.version == "1.1.0"`. Bumping
+`plugin.json` would have cascaded edits into `marketplace.json`,
+`README.md`, and the sprint-8 assertions, growing scope further.
+
+Resolution: reverted `plugin.json` to 1.1.0 and changed the CHANGELOG
+header to `## [Unreleased]` per the spec's explicit guidance ("Add
+under the next unreleased header, or create one if absent"). The
+plugin will get its 1.2.0 version stamp when the maintainer cuts the
+release commit.
+
+## Gaps
+
+None. All 5 DoD checks satisfied; 13/13 smoke tests pass; anti-scope
+items respected for the strict spec scope; pattern + convention
+compliance preserved.
+
+## End of PR series
+
+This is the last part. The full ask-source-agnostic-read PRD is
+implemented:
+
+| Part | Files | Verdict |
+| :--- | :--- | :--- |
+| 1 | skills/ask + lib/working-memory/paths.sh | PASS |
+| 2 | agents/{generator,validator,orchestrator}.md | PASS |
+| 3 | tests/smoke/{sprint-2,sprint-5,folder-isolation,ask-no-clone}.test.sh + skills/{implement,drift-sense} corrigenda | PASS |
+| 4 | .vibeflow/{conventions,index,patterns/{memory-model,roles,phase-flow,ralph-loop}}.md | PASS |
+| 5 | CLAUDE.md, docs/{architecture,lineage,troubleshooting}.md | PASS |
+| 6 | docs/quickstart.md, examples/.../CLAUDE.md, CHANGELOG.md + skills/{bootstrap,implement,preserve} corrigenda | PASS |
+
+Final state: `/yoke:ask` is a pure source-agnostic read; the
+`.yoke/query-traces/` archive and `wm_query_trace_path` helper are
+gone; bypass discipline is declarative; doctrine + tests + docs are
+all consistent. 13/13 smoke tests pass.
+
+## Next step
+
+Ready to ship the full PR series. The maintainer can choose to land
+all 6 parts as a single PR or as a series. Recommended: single PR for
+this scope (cross-cutting bugfix at the doctrine level).

--- a/.vibeflow/conventions.md
+++ b/.vibeflow/conventions.md
@@ -77,7 +77,11 @@ Every task that enters runtime materializes this minimum tree of ephemeral files
 - `acceptance-contract.md` — `/yoke:acceptance-contract` skill writes (Validator persona inline); everyone reads (Phase 3 artifact, binding)
 - `progress.md` — Generator (runtime subagent) writes; Validator + Orchestrator read
 - `contracts.md` — Generator + Validator co-write on consensus; both + Orchestrator read (sprint contracts)
-- `query-trace.md` — `/yoke:ask` skill + Orchestrator (consult mode) write; all read (mediated canonical-memory queries)
+
+Canonical-memory reads do **not** materialize a working-memory artifact —
+`/yoke:ask` is a pure read invoked on demand via the Skill tool by any
+caller (Generator, Validator, Orchestrator, spec-phase skills, ad-hoc
+human queries).
 
 ### Canonical memory — per-item format
 - Body in markdown
@@ -99,7 +103,7 @@ Principle: "every rule gets periodically re-tested against the current model."
 
 ## Don'ts
 
-- Do NOT allow the Generator or the Validator to read canonical memory directly — every query goes through the Orchestrator.
+- Do NOT allow any agent to read canonical memory directly. All reads route through `/yoke:ask` invoked via the Skill tool — direct filesystem reads of the registered memory (cat, grep, clone, pull) are prohibited.
 - Do NOT allow any agent except the Orchestrator to write to canonical memory (and only with Model C applied).
 - Do NOT load the entire canonical memory into any agent's context — only the relevant subgraph, via the Orchestrator.
 - Do NOT accept generic sensor output ("tests failed", "build broken") — that is a sensor bug.

--- a/.vibeflow/index.md
+++ b/.vibeflow/index.md
@@ -45,11 +45,12 @@ subagents adapt.*
   parallel each cycle.
 - **Orchestrator** (`agents/orchestrator.md`) — runtime subagent and
   sole writer of canonical memory under Model C. Three modes:
-  consult (read canonical memory live during cycles, append to
-  `.yoke/query-trace.md`), monitor (detect divergence, escalate via
-  `lib/ralph-loop/escalate.sh`), canonize (at loop termination,
-  apply five-criteria filter, propose writes via
-  `lib/canonical-memory/propose-write.sh`).
+  consult (invoke `/yoke:ask` via the Skill tool to read canonical
+  memory live and reason over the response in-conversation), monitor
+  (detect divergence, escalate via `lib/ralph-loop/escalate.sh`),
+  canonize (at loop termination, invoke `/yoke:preserve` via the
+  Skill tool to apply the five-criterion cascade and open Model
+  C-classified PRs).
 
 Spec-phase work (Phases 1–3) is performed by skills with embedded
 persona prompts:

--- a/.vibeflow/patterns/memory-model.md
+++ b/.vibeflow/patterns/memory-model.md
@@ -37,8 +37,12 @@ access.
 | `acceptance-contract.md` | `/yoke:acceptance-contract` skill (Validator persona) | all | Phase 3 binding artifact |
 | `progress.md` | Generator (runtime subagent) | Validator + Orchestrator | implementation state across cycles |
 | `contracts.md` | Generator + Validator (jointly, on consensus) | both + Orchestrator | accumulated sprint contracts |
-| `query-trace.md` | `/yoke:ask` skill + Orchestrator (consult mode) | all | mediated canonical-memory queries |
 | free notes | any agent | any agent | rough context, no schema |
+
+Canonical-memory reads are **not** materialized as working-memory
+artifacts. `/yoke:ask` is a pure read invoked on demand via the Skill
+tool; it produces only the conversational response and writes nothing
+on disk.
 
 Lifetime: task / sprint / PR scope. Location: `.yoke/` in the host
 project repo, created by `/yoke:bootstrap`.
@@ -91,10 +95,11 @@ doctrine.** Model C applies by impact class of the write, not by
 content type.
 
 ### Canonical-memory access timing
-- **Consult (live, during runtime).** The Orchestrator subagent
-  reads canonical memory every cycle and surfaces relevant subgraph
-  entries to `.yoke/query-trace.md`. The Generator and Validator
-  consume the trace as freshest-snapshot input.
+- **Consult (live, during runtime).** Any runtime subagent — Generator,
+  Validator, or Orchestrator — invokes `/yoke:ask` via the Skill tool
+  on demand and reasons over the response in-conversation. The skill
+  is source-agnostic and writes nothing on disk; each invocation is
+  independent.
 - **Canonize (write, at loop termination only).** The
   Orchestrator's canonize mode is the only canonical-memory write
   path. Mid-loop writes are forbidden — they would bypass Model C
@@ -159,7 +164,6 @@ Working-memory layout for a task:
 ├── acceptance-contract.md
 ├── progress.md
 ├── contracts.md
-├── query-trace.md
 ├── config.yaml
 └── .snapshots/
     └── cycle-N.yaml
@@ -174,7 +178,7 @@ Working-memory layout for a task:
 - Canonical-memory items without `traceability` — undeletable junk over time.
 - Working memory in a different repo than the project — recovery and audit become harder, no benefit.
 - Mid-loop canonical-memory writes — bypasses Model C governance windows.
-- Agents reading canonical memory by `cat`/`grep`/cloning the substrate — bypasses progressive disclosure and bypass detection.
+- Agents reading canonical memory by `cat`/`grep`/cloning the substrate — bypasses progressive disclosure and the `/yoke:ask` mediation contract.
 
 ## Implementation Mapping
 
@@ -188,9 +192,9 @@ created by `/yoke:bootstrap`:
 - `.yoke/prd.md`, `.yoke/tech-spec.md`,
   `.yoke/acceptance-contract.md`, `.yoke/progress.md`,
   `.yoke/contracts.md`
-- `.yoke/query-trace.md` — log of every mediated canonical-memory
-  query (written by `/yoke:ask` and the Orchestrator subagent's
-  consult mode)
+- Canonical-memory reads do not materialize a working-memory
+  artifact — `/yoke:ask` is a pure read invoked on demand via the
+  Skill tool by any subagent or skill that needs canonical context.
 - `.yoke/config.yaml` — per-project Yoke config (hard-bound
   overrides, canonical-repo URL)
 - `.yoke/.snapshots/cycle-N.yaml` — per-cycle

--- a/.vibeflow/patterns/phase-flow.md
+++ b/.vibeflow/patterns/phase-flow.md
@@ -36,7 +36,7 @@ output) and a typed output artifact.
 | 1 — Discovery | `/yoke:discover` skill (Generator persona inline) | raw idea | `prd.md` | Trigger 1 (PRD approval) |
 | 2 — Tech Spec | `/yoke:tech-spec` skill (Generator persona inline) | approved PRD | `tech-spec.md` | Trigger 2 (Tech Spec approval) |
 | 3 — Acceptance Contract | `/yoke:acceptance-contract` skill (Validator persona inline) | PRD + Tech Spec | `acceptance-contract.md` | Trigger 3 (Contract ratification) |
-| 4 — Runtime | `/yoke:implement` skill (spawns Generator + Validator + Orchestrator subagents in parallel each cycle) | approved Contract | merge-ready code + `progress.md` + `contracts.md` + `query-trace.md` | Trigger 4 (only on divergence or bound) |
+| 4 — Runtime | `/yoke:implement` skill (spawns Generator + Validator + Orchestrator subagents in parallel each cycle) | approved Contract | merge-ready code + `progress.md` + `contracts.md` | Trigger 4 (only on divergence or bound) |
 | 5 — Canonization (auto) | Orchestrator subagent in canonize mode (final Task call from `/yoke:implement`) | full working memory + termination reason | proposed writes to canonical memory (PRs) | Trigger 5 (Model C ratification) |
 | 5 — Canonization (manual escape hatch) | `/yoke:canonize` skill (spawns Orchestrator subagent in canonize mode against existing `.yoke/`) | existing working memory | proposed writes | Trigger 5 |
 

--- a/.vibeflow/patterns/ralph-loop.md
+++ b/.vibeflow/patterns/ralph-loop.md
@@ -39,14 +39,14 @@ disjoint inputs from the freshest snapshot of working memory:
   `hooks/verify-acceptance.sh` (or reads its prior snapshot); emits
   structured JSON verdicts.
 - **Orchestrator (`agents/orchestrator.md`)** in consult+monitor
-  mode — reads canonical memory via `lib/canonical-memory/query.sh`
-  and appends to `.yoke/query-trace.md`; detects divergence and
-  escalates via `lib/ralph-loop/escalate.sh`.
+  mode — invokes `/yoke:ask` via the Skill tool to read canonical
+  memory and reasons over the response in-conversation; detects
+  divergence and escalates via `lib/ralph-loop/escalate.sh`.
 
 Per-agent file-write contracts (declared in `agents/*.md`) prevent
-within-batch collisions: Generator owns `progress.md`, Orchestrator
-owns `query-trace.md`, and `contracts.md` is appended only on
-consensus events post-batch.
+within-batch collisions: Generator owns `progress.md`; Validator and
+Orchestrator do not write working-memory artifacts in consult/monitor
+mode; `contracts.md` is appended only on consensus events post-batch.
 
 ### Deterministic nodes (no agent decision)
 - Sensor execution: `hooks/verify-acceptance.sh` runs after each
@@ -104,8 +104,7 @@ human attention.
 On any termination path, `/yoke:implement` issues one final
 Orchestrator-only Task call with `mode=canonize`. The Orchestrator:
 
-- Reads `.yoke/progress.md`, `.yoke/contracts.md`,
-  `.yoke/query-trace.md`, and all
+- Reads `.yoke/progress.md`, `.yoke/contracts.md`, and all
   `.yoke/.snapshots/cycle-*.yaml`.
 - Applies the five-criterion cascade via
   `lib/canonical-memory/canonization-criteria.sh`.
@@ -169,7 +168,7 @@ loop:
   parallel_spawn:
     Generator(.yoke/, last_snapshot)        # writes code + progress.md
     Validator(.yoke/, last_snapshot)        # emits structured verdicts
-    Orchestrator(mode="consult+monitor")    # query-trace.md + escalate on divergence
+    Orchestrator(mode="consult+monitor")    # /yoke:ask + escalate on divergence
   # --- deterministic nodes ---
   sensor_output = run_sensors()                                     # verify-acceptance.sh
   if contradicts(latest_contract, acceptance_contract):

--- a/.vibeflow/patterns/roles.md
+++ b/.vibeflow/patterns/roles.md
@@ -40,10 +40,10 @@ that satisfies every Contract criterion.
 - Writes: `.yoke/progress.md` every cycle; `.yoke/contracts.md`
   jointly with the Validator on consensus events.
 - Reads: upstream artifacts read-only; sensor output from
-  `verify-acceptance.sh`; `.yoke/query-trace.md` for subgraph entries
-  the Orchestrator surfaced.
-- Reads canonical memory: never directly. Consumes
-  Orchestrator-surfaced subgraph via `.yoke/query-trace.md`.
+  `verify-acceptance.sh`.
+- Reads canonical memory: only via `/yoke:ask` invoked through the
+  Skill tool; never directly. Direct filesystem reads of the
+  registered memory (cat, grep, clone, pull) are prohibited.
 - Writes canonical memory: never.
 
 ### Validator (runtime subagent)
@@ -55,31 +55,33 @@ using declared sensors and structured verdicts.
   consensus events. Emits structured JSON verdicts that the next cycle
   reads.
 - Reads: sensor output from `verify-acceptance.sh`; upstream artifacts
-  read-only; `.yoke/query-trace.md`.
-- Reads canonical memory: never directly. Consumes
-  Orchestrator-surfaced subgraph via `.yoke/query-trace.md`.
+  read-only.
+- Reads canonical memory: only via `/yoke:ask` invoked through the
+  Skill tool; never directly.
 - Writes canonical memory: never.
 
 ### Orchestrator (runtime subagent — sole canonical-memory writer)
 Three runtime modes:
 
-1. **Consult.** Per cycle, alongside Generator and Validator. Reads
-   canonical memory via `lib/canonical-memory/query.sh` and surfaces
-   relevant subgraph entries to `.yoke/query-trace.md` (progressive
-   disclosure — never the full memory).
+1. **Consult.** Per cycle, alongside Generator and Validator. Invokes
+   `/yoke:ask` via the Skill tool and reasons over the response
+   in-conversation. The skill enforces progressive disclosure
+   (≤ 15 entity reads, 1-level wikilink hop) — never the full memory.
 2. **Monitor.** Per cycle. Detects Generator↔Validator divergence and
    sprint-contract / Acceptance-Contract contradictions; on detection
    invokes `lib/ralph-loop/escalate.sh` to emit the Trigger-4 packet.
-3. **Canonize.** Once at loop termination. Applies the five-criterion
-   cascade via `lib/canonical-memory/canonization-criteria.sh`,
-   classifies impact per Model C, and proposes writes via
-   `lib/canonical-memory/propose-write.sh`. The only canonical-memory
-   write path during the loop.
+3. **Canonize.** Once at loop termination. Invokes `/yoke:preserve`
+   via the Skill tool, which applies the five-criterion cascade,
+   classifies impact per Model C, and opens PRs against the canonical-
+   memory substrate. The only canonical-memory write path during the
+   loop.
 
 The Orchestrator is the **sole writer of canonical memory** under
 Model C; no other agent or skill may propose writes; no other agent
-may write directly. Bypass detection: any read that does not leave a
-trace entry in `.yoke/query-trace.md` is a bypass.
+may write directly. Bypass discipline (declarative): every
+canonical-memory read by Generator, Validator, or Orchestrator
+**must** go through `/yoke:ask` invoked via the Skill tool; direct
+filesystem reads of the registered memory are prohibited.
 
 ### Spec-phase personas (inline in skills, no subagents)
 - **Generator persona** lives inline in `skills/discover/SKILL.md` and

--- a/.vibeflow/prds/ask-source-agnostic-read.md
+++ b/.vibeflow/prds/ask-source-agnostic-read.md
@@ -1,0 +1,245 @@
+# PRD: `/yoke:ask` — source-agnostic canonical-memory read
+
+> Generated via /vibeflow:discover on 2026-04-25
+
+## Problem
+
+`/yoke:ask` is documented and described as the canonical-memory adaptive
+reader for any caller (the Orchestrator at runtime, the Generator and
+Validator subagents seeking context, spec-phase skills enriching their
+outputs, and ad-hoc human queries per `docs/quickstart.md`). In
+practice, the skill aborts unless `.yoke/.current` exists and points at
+a valid slug — i.e. it only works *inside* an active task, after
+`/yoke:discover` has been run.
+
+The coupling is not architectural; it is a side-effect of the
+bypass-detection trace. Phase 5.1 of `skills/ask/SKILL.md` writes a
+YAML entry per query to `.yoke/query-traces/<slug>.md`, and the slug
+comes from `wm_active_slug()` in `lib/working-memory/paths.sh`. No
+active task → no trace path → abort. Memory resolution itself
+(`lib/canonical-memory/resolve-memory.sh`) is already source-agnostic;
+the trace is the only blocker.
+
+This breaks every legitimate caller that runs *before* a task is
+established (the spec-phase skills `tests/smoke/sprint-2.test.sh:95`
+asserts as routing through `/yoke:ask`) and any ad-hoc invocation,
+and produces an internally inconsistent contract: tests assert routing
+that the skill cannot satisfy.
+
+The trace concept is also doing more work than it should. It was
+originally introduced as the bypass-detection signal per
+`.vibeflow/conventions.md` ("absence of a trace entry is the bypass
+signal"), but it has accreted a second role: the channel by which the
+Orchestrator surfaces canonical-memory subgraphs to the Generator and
+Validator (`agents/generator.md:49`, `agents/validator.md:63`). Both
+roles are now fragile — bypass detection has weak teeth, and using a
+markdown audit log as an inter-agent data channel inverts the
+read-only intent of the skill.
+
+The decision: **remove the query-trace concept entirely**. `/yoke:ask`
+becomes a pure read against canonical memory, callable from any
+source, with no working-memory dependency.
+
+## Target Audience
+
+Direct callers of `/yoke:ask`:
+
+1. **Generator subagent** during runtime cycles, when the
+   implementation work needs canonical-memory context.
+2. **Validator subagent** during runtime cycles, when sensor evidence
+   needs to be checked against canonical-memory rules.
+3. **Orchestrator subagent** in consult mode at runtime and in
+   canonize mode at termination.
+4. **Spec-phase skills** (`/yoke:discover`, `/yoke:tech-spec`,
+   `/yoke:acceptance-contract`) when enriching their outputs with
+   prior decisions, ownership, or known constraints.
+5. **Human users** running `/yoke:ask "<question>"` directly (per
+   `docs/quickstart.md:55`).
+
+Indirect audience: anyone maintaining `agents/` and `skills/` that
+currently read or write `.yoke/query-traces/<slug>.md`.
+
+## Proposed Solution
+
+Refactor `/yoke:ask` so that it is a source-agnostic, read-only
+canonical-memory reader, structurally aligned with `bedrock:ask` but
+preserving Yoke's plugin paths, memory-registry resolution, and the
+15-entity progressive-disclosure cap.
+
+WHAT changes:
+
+- Remove the active-task pre-condition. `/yoke:ask` no longer reads
+  `.yoke/.current` and no longer requires `wm_active_slug()`.
+- Remove the YAML trace write at Phase 5.1.
+- Remove the query-traces directory from working-memory layout
+  (`lib/working-memory/paths.sh`, `WM_ARCHIVE_CATEGORIES`,
+  `wm_query_trace_path()`).
+- Remove the trace-read step at the start of every Generator and
+  Validator cycle. When those subagents need canonical-memory context,
+  they invoke `/yoke:ask` directly via the Skill tool and consume the
+  response in-conversation.
+- Update `.vibeflow/conventions.md` to retire the "absence of a trace
+  entry is the bypass signal" doctrine. Bypass discipline becomes a
+  declarative rule on the skill itself ("agents must invoke /yoke:ask
+  for canonical-memory reads; direct filesystem reads of the memory
+  are prohibited"), enforced by review and by the skill's
+  `allowed-tools` envelope rather than by an audit-log scan.
+- Update `agents/orchestrator.md` so that consult mode no longer
+  emits trace entries; the Orchestrator's responsibility narrows to
+  invoking `/yoke:ask` and acting on the response (escalation,
+  divergence detection, canonization candidates).
+- Update tests, docs, and the changelog to reflect the new contract.
+
+WHAT does NOT change:
+
+- The 15-entity progressive-disclosure cap.
+- The memory-resolution chain (`--memory` flag → CWD detection →
+  default).
+- The no-clone, no-pull, no-fetch invariant: `/yoke:ask` reads
+  `$YOKE_MEMORY_PATH` directly from the local filesystem.
+- The no-fabrication rule and the "read-only against the memory"
+  invariant.
+- The plugin-path conventions for entity definitions and templates.
+
+## Success Criteria
+
+A reader can confirm the fix is correct by observing all of the
+following, without running an active task:
+
+1. `/yoke:ask "<question>"` invoked from a directory with **no**
+   `.yoke/.current` returns a valid answer (or the empty-state
+   response) without aborting.
+2. `/yoke:ask "<question>"` invoked from inside a host project that
+   *does* have `.yoke/.current` returns the same valid answer; the
+   active-task pointer is irrelevant to behavior.
+3. No file is written under `.yoke/query-traces/` by `/yoke:ask`
+   (the directory does not exist after a fresh bootstrap).
+4. The Generator and Validator subagents, at the start of a runtime
+   cycle, do not attempt to read a query-traces file. When they need
+   canonical-memory context, they invoke `/yoke:ask` via the Skill
+   tool and the response is the only channel.
+5. `lib/working-memory/paths.sh` exports no `wm_query_trace_path`
+   helper; `WM_ARCHIVE_CATEGORIES` does not include `query-traces`.
+6. `tests/smoke/sprint-2.test.sh`, `tests/smoke/sprint-5.test.sh`,
+   `tests/smoke/folder-isolation.test.sh`, and
+   `tests/smoke/ask-no-clone.test.sh` are updated to assert the new
+   contract (no trace, no active-task pre-condition) and pass under
+   `bash tests/smoke/<file>.test.sh`.
+7. `.vibeflow/conventions.md`, `CLAUDE.md`, `docs/architecture.md`,
+   and `docs/lineage.md` no longer reference `query-trace.md` or
+   `query-traces/<slug>.md` as live mechanisms.
+
+## Scope v0
+
+In scope, in this order:
+
+1. **`skills/ask/SKILL.md`** — remove pre-condition on `.yoke/.current`,
+   remove Phase 5.1 trace write, drop "trace" from critical rules and
+   anti-patterns, simplify the description.
+2. **`lib/working-memory/paths.sh`** — drop `wm_query_trace_path`,
+   remove `query-traces` from `WM_ARCHIVE_CATEGORIES`.
+3. **`agents/orchestrator.md`** — rewrite consult-mode section to
+   call `/yoke:ask` and consume its response in-conversation; remove
+   all "write to `.yoke/query-traces/<slug>.md`" instructions and the
+   "absence of trace entry is a bypass" rule; update YAML
+   `description`.
+4. **`agents/generator.md`** and **`agents/validator.md`** — remove
+   "read `.yoke/query-traces/<slug>.md` at the start of every cycle";
+   replace with "invoke `/yoke:ask` via the Skill tool when canonical-
+   memory context is needed".
+5. **Tests** — update `tests/smoke/sprint-2.test.sh`,
+   `tests/smoke/sprint-5.test.sh`,
+   `tests/smoke/folder-isolation.test.sh`,
+   `tests/smoke/ask-no-clone.test.sh` to match the new contract.
+6. **Docs** — `.vibeflow/conventions.md` (retire the bypass-via-
+   absence-of-trace doctrine and replace with a declarative bypass
+   rule), `CLAUDE.md` (working-memory table), `docs/architecture.md`,
+   `docs/lineage.md`, `docs/quickstart.md`, `docs/troubleshooting.md`,
+   `examples/greenfield-payment-service/CLAUDE.md`.
+7. **`CHANGELOG.md`** — add an entry describing the breaking change.
+
+## Anti-scope
+
+Explicitly **out** of this PRD; each is a candidate for a separate
+PRD if and when it becomes a real need:
+
+- The deferred graphify subgraph traversal (still parked).
+- The `/yoke:teach` escalation path from `needs_remote_content`.
+- A replacement bypass-detection mechanism (e.g. logging,
+  pre-commit hooks, runtime instrumentation). Bypass discipline
+  becomes purely declarative in v0; instrumentation can return
+  later if review reveals it is needed.
+- Changes to `lib/canonical-memory/resolve-memory.sh` or the
+  registry shape.
+- Changes to the 15-entity cap.
+- Any new caller-aware behavior (rate limits per invoker,
+  per-invoker filtering, etc.).
+- Migration tooling for repos that already have `.yoke/query-traces/`
+  on disk; the directory is simply ignored.
+- Backwards-compatibility shims for the removed
+  `wm_query_trace_path` helper. Any caller still referencing it is a
+  bug to fix in this same PRD's scope, not a callsite to preserve.
+
+## Technical Context
+
+Existing patterns and constraints to follow:
+
+- **Plugin-path resolution** in skills uses the "Base directory for
+  this skill" injected at invocation; entity definitions and templates
+  live at `<plugin_dir>/entities/` and `<plugin_dir>/templates/`. This
+  PRD does not change that.
+- **Memory resolution** is delegated to
+  `lib/canonical-memory/resolve-memory.sh`, which already supports
+  `--memory <name>`, CWD detection, and a `default` registry entry.
+  No changes needed.
+- **Working-memory layout** is documented in
+  `lib/working-memory/paths.sh` and tested in
+  `tests/smoke/folder-isolation.test.sh`. The query-traces category
+  must be removed from both, and the v0.6.0 per-category folders
+  doctrine remains otherwise intact.
+- **Conventions doctrine** lives in `.vibeflow/conventions.md`, which
+  currently lists `query-trace.md` as a working-memory artifact (line
+  80) and frames bypass detection around its absence. Both must be
+  rewritten.
+- **Reference implementation**: the `bedrock:ask` skill at
+  `~/.claude/plugins/marketplaces/claude-bedrock/skills/ask/SKILL.md`
+  is the structural reference — no working-memory dependency, no
+  trace, vault-first read with self-assessment. Yoke deviates only
+  where Yoke-specific architecture demands (memory registry instead
+  of vault registry; deferred graphify; deferred `/yoke:teach`
+  escalation).
+- **Pre-existing tests that must keep passing** after the fix:
+  `tests/smoke/sprint-1.test.sh`, `tests/smoke/sprint-3.test.sh`,
+  `tests/smoke/sprint-4.test.sh` (these do not assert trace
+  behavior, so the change should be invisible to them).
+- **Sprint discipline** (`CLAUDE.md` "Sprint discipline" section):
+  this PRD spans Sprint 2 and Sprint 5 surfaces, so the resulting
+  spec should be implemented as a *cross-cutting fix*, not a new
+  sprint. Treat it as a bugfix at the doctrine level. The CHANGELOG
+  entry must call out the breaking change for any project that has
+  already bootstrapped against an older Yoke.
+
+## Open Questions
+
+- **Bypass discipline replacement.** Once the trace is gone, the only
+  enforcement that agents go through `/yoke:ask` is declarative (the
+  rule in the agent prompts and skill `allowed-tools`). If during
+  implementation it becomes clear this is too weak — e.g. the skill
+  gets routinely bypassed — open a follow-up PRD for an alternative
+  signal. Not load-bearing for v0.
+- **Orchestrator consult mode shape.** With the trace gone, consult
+  mode is "Orchestrator invokes `/yoke:ask` and reasons over the
+  response within its own turn." Verify during spec-writing that this
+  preserves the Orchestrator's runtime responsibilities (divergence
+  detection, canonization candidates) without requiring a persisted
+  artifact. If a persisted artifact turns out to be necessary for a
+  *different* reason (e.g. checkpointing across resumed runs), that is
+  a separate concern from query-tracing and should be designed on its
+  own merits.
+- **Generator/Validator context delivery timing.** Today the trace
+  acts as a once-per-cycle handoff (Orchestrator surfaces, agents
+  read at cycle start). Calling `/yoke:ask` directly is a
+  per-question handoff. Confirm during tech-spec that the per-question
+  pattern is acceptable for the ralph loop's iteration cadence and
+  context budget; if it is not, a different solution is needed (but
+  *not* a return to the trace).

--- a/.vibeflow/specs/ask-source-agnostic-read-part-1.md
+++ b/.vibeflow/specs/ask-source-agnostic-read-part-1.md
@@ -1,0 +1,102 @@
+# Spec: `/yoke:ask` source-agnostic — Part 1 / Skill + working-memory lib
+
+> Generated via /vibeflow:gen-spec on 2026-04-25
+> PRD: `.vibeflow/prds/ask-source-agnostic-read.md`
+
+## Objective
+
+Make `/yoke:ask` invocable from any caller by deleting the active-task
+pre-condition and the query-trace write at Phase 5.1 of `skills/ask/SKILL.md`,
+and removing the working-memory helper that backed it.
+
+## Context
+
+`skills/ask/SKILL.md` aborts unless `.yoke/.current` exists, because Phase 5.1
+writes a YAML trace entry whose path comes from `wm_active_slug()` →
+`wm_query_trace_path()` in `lib/working-memory/paths.sh`. Memory resolution
+itself (`lib/canonical-memory/resolve-memory.sh`) is already source-agnostic
+and works without a task. The trace is the only blocker. This part removes
+the trace contract from the skill and the lib; the doctrine, agent prompts,
+tests, and docs follow in Parts 2–6.
+
+## Definition of Done
+
+1. `skills/ask/SKILL.md` no longer references `.yoke/.current`,
+   `wm_active_slug`, `wm_query_trace_path`, `.yoke/query-traces/`, or any
+   YAML trace shape; the pre-condition section that aborted on missing
+   active task is removed; Phase 5 contains only response composition.
+2. `skills/ask/SKILL.md` description (frontmatter) is rewritten to match
+   the new contract: source-agnostic, registry-resolved, filesystem-only
+   read, 15-entity cap, no trace.
+3. `lib/working-memory/paths.sh` does not export `wm_query_trace_path`;
+   `WM_ARCHIVE_CATEGORIES` does not contain `query-traces`.
+4. `skills/ask/SKILL.md` preserves: 15-entity progressive-disclosure cap,
+   no-clone / no-pull / no-fetch invariants, no-fabrication rule, memory
+   resolution via `lib/canonical-memory/resolve-memory.sh`, and the
+   bare-wikilink citation rule.
+5. `skills/ask/SKILL.md` `allowed-tools` does not include `Task`
+   (spec-phase / read skills must not spawn subagents per `patterns/roles.md`).
+
+## Scope
+
+- Edit `skills/ask/SKILL.md` — remove pre-condition and Phase 5.1 trace
+  write; rewrite description; preserve invariants in DoD #4.
+- Edit `lib/working-memory/paths.sh` — drop `wm_query_trace_path`; remove
+  `query-traces` from `WM_ARCHIVE_CATEGORIES`; preserve every other helper
+  and constant.
+
+## Anti-scope
+
+- Test changes (Part 3).
+- Agent contract changes (Part 2).
+- Doctrine doc changes (Part 4).
+- User-facing doc changes (Parts 5–6).
+- Changes to `lib/canonical-memory/resolve-memory.sh` or the memory
+  registry shape.
+- A backwards-compatibility shim for `wm_query_trace_path`. Any caller
+  that breaks after this part is fixed in Parts 2–3, not preserved.
+- Any new graphify or `/yoke:teach` escalation logic.
+
+## Technical Decisions
+
+1. **Helper removal vs deprecation.** Delete `wm_query_trace_path` outright.
+   Trade-off: any internal caller still referencing it fails loudly at
+   runtime. Justification: the project's anti-pattern policy forbids
+   compatibility shims; loud failure is the correct signal.
+2. **`WM_ARCHIVE_CATEGORIES` shrink.** Reduce to
+   `(prds tech-specs acceptance-contracts contracts)`. Trade-off:
+   `wm_slug_in_use` no longer detects collisions in the (removed)
+   `query-traces` directory. Justification: that directory will not exist
+   and must not be re-created by `wm_*` callers.
+3. **SKILL.md description rewrite.** Replace "Read-only adaptive query …
+   Writes a YAML trace entry to .yoke/query-traces/<slug>.md for bypass
+   detection" with a description aligned with the PRD: source-agnostic,
+   `lib/canonical-memory/resolve-memory.sh` resolution, filesystem-only,
+   15-entity cap. Trade-off: the description gets shorter and loses the
+   bypass-detection claim. Justification: that claim is no longer true.
+4. **No new file output.** The skill writes nothing on disk after this
+   part — pure read. Any future audit signal is a separate spec.
+
+## Applicable Patterns
+
+- `.vibeflow/patterns/memory-model.md` — read-mediator role; 15-entity
+  progressive-disclosure cap; consult-live access timing.
+- `.vibeflow/patterns/plugin-structure.md` — `skills/` layout; SKILL.md
+  frontmatter shape.
+
+## Risks
+
+- **R1 / Internal callers still reference `wm_query_trace_path`.**
+  Mitigation: grep `wm_query_trace_path|query-traces|query-trace` across
+  `skills/`, `agents/`, `lib/`, `hooks/` before merging Parts 2–3; every
+  hit is fixed in its corresponding part.
+- **R2 / SKILL.md rewrite drops a load-bearing invariant.** Mitigation:
+  DoD #4 enumerates the invariants explicitly; reviewer must confirm each
+  survives in the rewritten skill text.
+- **R3 / `lib/working-memory/paths.sh` re-source guard breaks.** The file
+  uses `_WM_PATHS_LOADED` to be idempotent; removing one helper must not
+  perturb that guard. Mitigation: smoke-load the file in a subshell post-edit.
+
+## Dependencies
+
+- None.

--- a/.vibeflow/specs/ask-source-agnostic-read-part-2.md
+++ b/.vibeflow/specs/ask-source-agnostic-read-part-2.md
@@ -1,0 +1,117 @@
+# Spec: `/yoke:ask` source-agnostic — Part 2 / Runtime agent contracts
+
+> Generated via /vibeflow:gen-spec on 2026-04-25
+> PRD: `.vibeflow/prds/ask-source-agnostic-read.md`
+
+## Objective
+
+Switch Generator, Validator, and Orchestrator from "consume canonical-memory
+subgraph via `.yoke/query-traces/<slug>.md`" to "invoke `/yoke:ask` via the
+Skill tool when canonical-memory context is needed", and replace the
+"absence of trace entry is a bypass" rule with a declarative bypass discipline.
+
+## Context
+
+Today the trace acts as a once-per-cycle Orchestrator → Generator/Validator
+handoff: Orchestrator consult mode reads canonical memory and surfaces a
+subgraph to the trace; Generator and Validator read the trace at the start
+of every cycle. With the trace gone (Part 1), each subagent calls
+`/yoke:ask` directly and consumes the response in-conversation. The
+Orchestrator's consult-mode role narrows from "surface and persist" to
+"invoke and reason inline." Bypass detection becomes a declarative rule on
+each subagent prompt rather than a scan over the trace file.
+
+## Definition of Done
+
+1. `agents/orchestrator.md` consult-mode section instructs the subagent to
+   invoke `/yoke:ask` via the Skill tool and reason over the response
+   in-conversation; no instructions to write `.yoke/query-traces/<slug>.md`
+   or any equivalent file.
+2. `agents/orchestrator.md` no longer asserts "any read that does not leave
+   a trace entry is a bypass." Bypass discipline is restated declaratively:
+   "Generator and Validator MUST invoke `/yoke:ask` for canonical-memory
+   reads; direct filesystem reads of the registered memory are prohibited."
+3. `agents/generator.md` and `agents/validator.md` no longer require reading
+   `.yoke/query-traces/<slug>.md` at the start of every cycle. Each subagent
+   prompt instructs invoking `/yoke:ask` via the Skill tool when canonical
+   context is needed.
+4. The three subagent YAML `description` fields no longer mention
+   `.yoke/query-traces/<slug>.md` or "trace lands in …".
+5. `agents/orchestrator.md`, `agents/generator.md`, and `agents/validator.md`
+   `allowed-tools` lists include `Skill`; no `Write` access targets
+   `.yoke/query-traces/`. Other tool grants (Read, Edit, Bash on the file
+   ownerships each agent already has) are preserved.
+6. The Orchestrator's monitor and canonize sections are not modified by
+   this part — only consult, the bypass rule, the description, and
+   allowed-tools.
+
+## Scope
+
+- Edit `agents/orchestrator.md`.
+- Edit `agents/generator.md`.
+- Edit `agents/validator.md`.
+
+## Anti-scope
+
+- Skill or lib changes (Part 1).
+- Test updates (Part 3).
+- Doctrine `.vibeflow/` updates (Part 4).
+- File-ownership changes for `.yoke/contracts/<slug>.md`,
+  `.yoke/runtime/progress.md`, etc.
+- Any change to the Orchestrator's canonize-mode logic, the five-criterion
+  filter, or the `propose-write.sh` wiring.
+- Introducing a new file-based handoff to replace the trace.
+
+## Technical Decisions
+
+1. **Bypass discipline becomes declarative.** Stated as a rule in each
+   subagent prompt; no automated detection in v0. Trade-off: weaker
+   automated signal than the trace scan provided. Justification: PRD
+   anti-scope explicitly defers replacement instrumentation; the rule is
+   enforced at review and by `allowed-tools` envelope.
+2. **Per-question vs per-cycle context delivery.** Generator and Validator
+   query on demand via `/yoke:ask` instead of reading a cycle-start
+   handoff. Trade-off: extra Skill-tool invocations during a cycle.
+   Justification: avoids accumulating unused canonical context; matches
+   PRD intent ("receives a query from any source").
+3. **Orchestrator consult mode shape.** Invoke `/yoke:ask` and reason
+   inline; no persisted artifact. Trade-off: nothing for other subagents
+   to read offline. Justification: PRD open question 2 — checkpointing
+   across resumed runs is a separate concern; do not re-introduce the
+   trace as that mechanism.
+4. **No new shared file.** Specifically, do not introduce a replacement
+   like `.yoke/runtime/consult.md` or similar. The PRD forbids
+   re-introducing the same problem under a different name.
+5. **Explicit "do not read query-traces" line during transition.** Each
+   subagent prompt includes one line stating that `.yoke/query-traces/`
+   does not exist and must not be read or written. This guards against
+   reflexive behavior during the transition window. The line may be
+   removed in a future cleanup once the cohort is stable.
+
+## Applicable Patterns
+
+- `.vibeflow/patterns/roles.md` — write/read authority per runtime
+  subagent; single-Skill-call discipline; no shared context between
+  Generator and Validator.
+- `.vibeflow/patterns/memory-model.md` — read-mediator role; consult-live
+  access timing.
+
+## Risks
+
+- **R1 / Subagents reflexively try to read `.yoke/query-traces/<slug>.md`.**
+  Mitigation: explicit negative instruction in each prompt (Decision 5).
+- **R2 / Generator or Validator reasons without canonical grounding when
+  it should have queried.** Mitigation: prompt-level instruction —
+  "before relying on prior knowledge for X (where X = ratified policy,
+  domain ownership, prior decision), invoke `/yoke:ask`."
+- **R3 / Edit accidentally touches the Orchestrator's canonize or monitor
+  sections.** Mitigation: scope each edit to the consult section, the
+  bypass rule, the description, and allowed-tools; reviewer diffs the
+  file by section.
+- **R4 / Allowed-tools loses something the agent still needs.**
+  Mitigation: enumerate the existing grants; only the trace-write
+  privilege is removed; everything else is preserved.
+
+## Dependencies
+
+- `.vibeflow/specs/ask-source-agnostic-read-part-1.md`

--- a/.vibeflow/specs/ask-source-agnostic-read-part-3.md
+++ b/.vibeflow/specs/ask-source-agnostic-read-part-3.md
@@ -1,0 +1,124 @@
+# Spec: `/yoke:ask` source-agnostic — Part 3 / Test suite alignment
+
+> Generated via /vibeflow:gen-spec on 2026-04-25
+> PRD: `.vibeflow/prds/ask-source-agnostic-read.md`
+
+## Objective
+
+Update the four smoke tests that assert query-trace behavior so they
+reflect the no-trace, source-agnostic contract introduced in Parts 1–2.
+
+## Context
+
+Four smoke tests currently encode the trace contract:
+
+- `tests/smoke/sprint-2.test.sh` — asserts `/yoke:ask` writes to
+  `.yoke/query-traces/<slug>.md`, references `wm_query_trace_path`,
+  declares no-clone, declares no-fabrication, caps at 15.
+- `tests/smoke/sprint-5.test.sh` — asserts the YAML trace shape (mode,
+  entities_read, capped, invoker fields).
+- `tests/smoke/folder-isolation.test.sh` — asserts the per-category
+  folder layout including `query-traces/`, plus a migration check for
+  the singular `query-trace.md`.
+- `tests/smoke/ask-no-clone.test.sh` — asserts the no-clone invariant
+  under the (now-removed) trace-emitting flow.
+
+After Parts 1–2, assertions about (a)–(c) become false; (d)'s no-clone
+property must be preserved with revised assertion code. This part
+realigns each test in place.
+
+## Definition of Done
+
+1. `tests/smoke/sprint-2.test.sh` — assertions about trace writing,
+   `wm_query_trace_path`, and `.yoke/query-traces/<slug>.md` are removed.
+   Replacement assertions cover: skill is callable without `.yoke/.current`;
+   skill references `lib/canonical-memory/resolve-memory.sh`; allowed-tools
+   excludes `Task`; declares no-clone; declares no-fabrication; caps at 15.
+2. `tests/smoke/sprint-5.test.sh` — assertions about the YAML trace shape
+   (`mode: ask`, `entities_read`, `capped`, `invoker`) are removed. Any
+   assertion that overlaps with sprint-2 is deleted (no duplicate); any
+   remaining assertion is consistent with Part 1.
+3. `tests/smoke/folder-isolation.test.sh` — the per-category folder
+   layout assertion lists only `prds`, `tech-specs`,
+   `acceptance-contracts`, `contracts`. The migration check for the
+   singular `query-trace.md` is removed (the singular file did not
+   survive past v0.6.0; the plural directory will not exist). Any
+   `wm_query_trace_path` invocation is deleted.
+4. `tests/smoke/ask-no-clone.test.sh` — the no-clone invariant assertion
+   is preserved; any setup or assertion that depended on the old trace
+   flow is updated so the test still exercises the no-clone property
+   under the new skill shape.
+5. All four smoke tests pass under
+   `timeout 600 bash tests/smoke/<file>.test.sh` against a clean test
+   repo created by the harness each test already uses.
+6. **No surviving reference** in any test file under `tests/` to
+   `query-trace.md`, `query-traces/`, or `wm_query_trace_path`.
+7. **Vacuous-green assertions are forbidden** — every replaced assertion
+   tests a real new property or is deleted; no `grep -q '<string that
+   does not exist>'` no-ops.
+
+## Scope
+
+- Edit `tests/smoke/sprint-2.test.sh`.
+- Edit `tests/smoke/sprint-5.test.sh`.
+- Edit `tests/smoke/folder-isolation.test.sh`.
+- Edit `tests/smoke/ask-no-clone.test.sh`.
+
+## Anti-scope
+
+- Adding new test files. Coverage for the source-agnostic-call path is
+  added inside `sprint-2.test.sh` (where `/yoke:ask` shape is asserted),
+  not in a new file.
+- Wiring `tests/` into CI (Sprint 8).
+- Changes to the smoke-test harness, the `timeout 600` discipline, or
+  the test-repo bootstrap helpers.
+- Changes to `tests/smoke/sprint-1.test.sh`, `sprint-3.test.sh`,
+  `sprint-4.test.sh`, or `teach-ingest.test.sh`. Pre-edit verification:
+  none of these reference query-trace; if grep finds a hit, fold it
+  into this part's scope.
+
+## Technical Decisions
+
+1. **Update in place vs replace.** Edit each test file in place rather
+   than rewriting from scratch. Trade-off: heavier review than a clean
+   rewrite. Justification: preserves the rest of each test's coverage
+   and isolates the diff to trace-related assertions.
+2. **Failure window.** Tests are guaranteed to be inconsistent with the
+   skill between merging Part 1 and merging Part 3. Implementation
+   sequence must land Parts 1, 2, 3 close together; ideally as a single
+   PR series with a held merge until Part 3 is reviewed.
+3. **No bypass-detection assertion.** Bypass discipline is declarative
+   in v0 (Part 2). There is nothing automated to assert. A future spec
+   that adds a sensor will own its own assertion.
+4. **Migration assertion removal.** `folder-isolation.test.sh` currently
+   asserts that the singular `.yoke/query-trace.md` migration is
+   complete. Both the singular and plural forms cease to be live; the
+   migration check goes with them.
+
+## Applicable Patterns
+
+- `.vibeflow/patterns/sensors.md` — structured output convention; "every
+  sprint adds `tests/smoke/sprint-N.test.sh`" discipline.
+- `.vibeflow/patterns/plugin-structure.md` — tests/ layout.
+
+## Risks
+
+- **R1 / Vacuous-green assertion.** A removed assertion is replaced with
+  a `grep` for a string that doesn't exist anyway. Mitigation: DoD #7
+  forbids it; reviewer scans every replaced assertion.
+- **R2 / Removed assertion takes a real safety property with it.**
+  Mitigation: enumerate every removed assertion in the PR description;
+  reviewer maps each removal to either Part 1's DoD #4 invariants
+  (preserved) or the trace contract (intentionally removed).
+- **R3 / Test fails on macOS bash 3.** Mitigation: `.vibeflow/conventions.md`
+  pins bash 4+; ensure tests use bash 4 features only where the existing
+  tests already do.
+- **R4 / `timeout 600` bound is exceeded by the new flow.** Mitigation:
+  the new flow does fewer disk writes than the old; runtime should
+  shrink, not grow. If it grows unexpectedly, profile before relaxing
+  the bound.
+
+## Dependencies
+
+- `.vibeflow/specs/ask-source-agnostic-read-part-1.md`
+- `.vibeflow/specs/ask-source-agnostic-read-part-2.md`

--- a/.vibeflow/specs/ask-source-agnostic-read-part-4.md
+++ b/.vibeflow/specs/ask-source-agnostic-read-part-4.md
@@ -1,0 +1,142 @@
+# Spec: `/yoke:ask` source-agnostic — Part 4 / Doctrine update
+
+> Generated via /vibeflow:gen-spec on 2026-04-25
+> PRD: `.vibeflow/prds/ask-source-agnostic-read.md`
+
+## Objective
+
+Update the three doctrine documents — `.vibeflow/conventions.md`,
+`.vibeflow/patterns/memory-model.md`, and `.vibeflow/patterns/roles.md` —
+so the project's authoritative descriptions of working memory and
+canonical-memory mediation reflect the no-trace, source-agnostic
+`/yoke:ask` contract.
+
+## Context
+
+Each of the three doctrine documents encodes the trace contract:
+
+- `conventions.md` lists `query-trace.md` as a working-memory canonical
+  file (line ~80) and frames bypass detection around its absence.
+- `patterns/memory-model.md` table of working-memory files contains a
+  `query-trace.md` row; the "Canonical-memory access timing" section
+  describes the Orchestrator surfacing entries to the trace; the
+  example tree and the Implementation Mapping list both include
+  `query-trace.md`; an anti-pattern references "bypass detection."
+- `patterns/roles.md` Generator and Validator sections describe their
+  canonical-memory read path as consuming `.yoke/query-trace.md`; the
+  Orchestrator consult-mode description names the trace as the surface;
+  one sentence states "any read that does not leave a trace entry is a
+  bypass."
+
+Doctrine is the project's source of truth and must be coherent with the
+runtime behavior. This part rewrites the doctrine in line with the PRD's
+declarative bypass discipline.
+
+## Definition of Done
+
+1. `.vibeflow/conventions.md` `Working memory — canonical files` section
+   no longer lists `query-trace.md`. The relevant entry under "Don'ts"
+   is restated declaratively: "no agent reads canonical memory directly;
+   reads route through `/yoke:ask`."
+2. `.vibeflow/patterns/memory-model.md` table of working-memory files
+   no longer contains the `query-trace.md` row. The "Canonical-memory
+   access timing → Consult" paragraph no longer mentions writing to the
+   trace; it describes the Orchestrator invoking `/yoke:ask` and
+   reasoning over the response. The example working-memory layout no
+   longer includes `query-trace.md`. The Implementation Mapping list
+   no longer includes `query-trace.md`. The anti-pattern about bypass
+   detection is rewritten to point at the declarative `/yoke:ask`
+   mediation rule.
+3. `.vibeflow/patterns/roles.md` Generator and Validator sections do
+   not reference `.yoke/query-trace.md`; their canonical-memory read
+   path is "invoke `/yoke:ask` via the Skill tool". The Orchestrator
+   consult-mode description does not mention surfacing entries to the
+   trace. The "Bypass detection" sentence is rewritten or removed
+   consistent with DoD #1's declarative rule.
+4. **Cross-document consistency** — no statement in one doctrine doc
+   contradicts another (e.g., one declaring "no trace" while another
+   still describes consult-mode subgraph surfacing).
+5. **Sweep gate** — no file under `.vibeflow/` references `query-trace.md`
+   or `query-traces/<slug>.md` as a live mechanism. Historical
+   references (e.g., decisions log entries that record past state) are
+   acceptable only if explicitly framed as historical.
+
+## Scope
+
+- Edit `.vibeflow/conventions.md` (working-memory file list ~line 80;
+  Don'ts ~line 102; bypass-related anti-pattern statements).
+- Edit `.vibeflow/patterns/memory-model.md` (table at line ~40;
+  consult-timing paragraphs ~lines 92–101; example tree ~line 162;
+  Implementation Mapping ~lines 191–193; anti-pattern at ~line 177).
+- Edit `.vibeflow/patterns/roles.md` (Generator section ~lines 43–46;
+  Validator section ~lines 58–60; Orchestrator consult-mode + bypass
+  ~lines 66–82; spec-phase note that already routes through `/yoke:ask`
+  is preserved).
+
+## Anti-scope
+
+- `CLAUDE.md` (project root) — Part 5.
+- `docs/architecture.md`, `docs/lineage.md`, `docs/troubleshooting.md` —
+  Part 5.
+- `docs/quickstart.md`, `examples/greenfield-payment-service/CLAUDE.md`,
+  `CHANGELOG.md` — Part 6.
+- `.vibeflow/decisions.md` — historical record; entries that record past
+  decisions are not rewritten.
+- `.vibeflow/index.md` — verify it has no live trace reference; touch
+  only if a hit is found (then fold into this part).
+- Code/test files — Parts 1–3.
+
+## Technical Decisions
+
+1. **Doctrine wording for bypass discipline.** Replace every variant of
+   "absence of trace entry is the signal" with the declarative form: "no
+   agent reads canonical memory directly; reads route through `/yoke:ask`."
+   Trade-off: loses the automation hook the trace once provided.
+   Justification: doctrine should describe what is true, not what was
+   true. The PRD explicitly defers a replacement signal.
+2. **Anti-pattern rewrite in `memory-model.md`.** Replace "agents reading
+   canonical memory by cat/grep/cloning the substrate — bypasses
+   progressive disclosure and bypass detection" with "… bypasses
+   progressive disclosure and the `/yoke:ask` mediation contract."
+   Trade-off: subtle wording change. Justification: precision — the
+   anti-pattern is still real; only the enforcement mechanism changed.
+3. **Historical references.** `decisions.md`, the changelog, and any
+   "Scoped Analyses" entry in `index.md` may continue to reference the
+   trace as historical. Doctrine prose (the rules themselves) must not.
+4. **Generator/Validator wording.** "Reads canonical memory: never
+   directly" becomes "Reads canonical memory: only via `/yoke:ask`."
+   Trade-off: the prohibition is unchanged; the affirmative path
+   becomes explicit. Justification: a positive instruction is more
+   actionable than a negation.
+
+## Applicable Patterns
+
+- `.vibeflow/patterns/memory-model.md` — self-referential; this part
+  edits it.
+- `.vibeflow/patterns/roles.md` — self-referential; this part edits it.
+- `.vibeflow/patterns/plugin-structure.md` — unchanged; referenced for
+  consistency check (working-memory layout described in plugin-structure
+  must agree with the updated `memory-model.md`).
+
+## Risks
+
+- **R1 / Doctrine drift vs runtime.** Part 4 lands before Part 2 →
+  doctrine says "invoke `/yoke:ask`" while `agents/orchestrator.md`
+  still writes to the trace. Mitigation: dependency declared (Part 4 →
+  Part 1); reviewers should land Parts 1, 2, 4 close together. Worst
+  case is a transient inconsistency window.
+- **R2 / Stale reference missed.** Mitigation: DoD #5 is a sweep gate;
+  grep `query-trace|query-traces|bypass.*trace|trace.*entry` across
+  `.vibeflow/` post-edit and reconcile every hit.
+- **R3 / A pattern doc loses a load-bearing invariant unrelated to the
+  trace** (e.g., the 15-cap, no-clone, single-write-path invariants).
+  Mitigation: edits are scoped to trace-related prose; non-trace
+  invariants are explicitly out of scope and must read identically
+  before and after.
+- **R4 / Cross-document inconsistency.** Easy to miss when editing
+  three docs in parallel. Mitigation: DoD #4 + final read-through of
+  all three docs in sequence as the last step.
+
+## Dependencies
+
+- `.vibeflow/specs/ask-source-agnostic-read-part-1.md`

--- a/.vibeflow/specs/ask-source-agnostic-read-part-5.md
+++ b/.vibeflow/specs/ask-source-agnostic-read-part-5.md
@@ -1,0 +1,125 @@
+# Spec: `/yoke:ask` source-agnostic — Part 5 / Repo CLAUDE.md + main docs
+
+> Generated via /vibeflow:gen-spec on 2026-04-25
+> PRD: `.vibeflow/prds/ask-source-agnostic-read.md`
+
+## Objective
+
+Update the repo-root `CLAUDE.md` and the three load-bearing user-facing
+docs (`docs/architecture.md`, `docs/lineage.md`, `docs/troubleshooting.md`)
+so user- and agent-facing descriptions of `/yoke:ask` and working memory
+match the no-trace contract.
+
+## Context
+
+These four documents encode the trace as a live mechanism:
+
+- `CLAUDE.md` (project root) restates the working-memory file list,
+  including `query-trace.md`, in the architecture section's table.
+- `docs/architecture.md` includes an ASCII diagram of `.yoke/` that
+  contains `query-trace.md`, plus a description of consult mode that
+  reads "surface relevant subgraph entries to `.yoke/query-trace.md`."
+- `docs/lineage.md` includes "audit-trail writing to `.yoke/query-trace.md`
+  (Yoke-specific contribution)" framed as current behavior.
+- `docs/troubleshooting.md` instructs users to inspect the trace as part
+  of debugging canonical-memory access.
+
+Doctrine has been updated in Part 4. These user-facing docs follow.
+
+## Definition of Done
+
+1. Repo-root `CLAUDE.md` working-memory description does not list
+   `query-trace.md`. The working-memory tier explanation is consistent
+   with `.vibeflow/patterns/memory-model.md` as updated by Part 4.
+2. `docs/architecture.md` ASCII diagram of `.yoke/` does not contain
+   `query-trace.md`. The consult-mode bullet ("Consult (per cycle) — read
+   canonical memory live; surface relevant subgraph entries to
+   .yoke/query-trace.md") is rewritten to: "Consult (per cycle) — invoke
+   `/yoke:ask` via the Skill tool when canonical-memory context is
+   needed."
+3. `docs/lineage.md` removes the line "audit-trail writing to
+   `.yoke/query-trace.md`" and any other live trace reference. Historical
+   narrative about the previous design is acceptable only if explicitly
+   framed as past.
+4. `docs/troubleshooting.md` does not include a step that checks
+   `.yoke/query-traces/` or `.yoke/query-trace.md`. Debugging guidance
+   for canonical-memory access is updated to reflect the new flow
+   (verify `/yoke:ask` runs without `.yoke/.current`; check
+   `lib/canonical-memory/resolve-memory.sh` resolution).
+5. **Sweep gate** — no live-mechanism reference to `query-trace.md` or
+   `query-traces/<slug>.md` survives in any of the four files; counts
+   of working-memory files quoted in prose match the new layout.
+
+## Scope
+
+- Edit `CLAUDE.md` (project root).
+- Edit `docs/architecture.md`.
+- Edit `docs/lineage.md`.
+- Edit `docs/troubleshooting.md`.
+
+## Anti-scope
+
+- `.vibeflow/` doctrine — Part 4.
+- `docs/quickstart.md`, `examples/greenfield-payment-service/CLAUDE.md`,
+  `CHANGELOG.md` — Part 6.
+- `README.md` — verify no live trace reference; if absent, do not touch.
+  If present, fold into this part.
+- `docs/installation.md`, `docs/canonical-memory-setup.md` — verify;
+  fold in only on a hit.
+- Documentation about other plugin features (bootstrap, teach, preserve,
+  drift-sense, status, memory) is not touched.
+
+## Technical Decisions
+
+1. **CLAUDE.md duplication of the working-memory list.** Single source of
+   truth lives in `.vibeflow/patterns/memory-model.md` (Part 4).
+   `CLAUDE.md` duplicates a summary of it as quick reference for agents.
+   Trade-off: two places to update; risk of drift. Justification:
+   `CLAUDE.md` is loaded into every agent context; the duplication is
+   load-bearing for correctness.
+2. **`docs/lineage.md` historical framing.** Past architectural narrative
+   (e.g., "the v0.5 design used a trace") is acceptable so long as the
+   surrounding text frames the trace as past, not present. Trade-off:
+   slight risk of confusion. Justification: lineage is the place for
+   historical narrative; surgical edits are better than wholesale
+   rewrites.
+3. **`docs/architecture.md` diagram fidelity.** The ASCII diagram is
+   updated to remove `query-trace.md`; surrounding labels and counts
+   (e.g., "the four working-memory files") are updated accordingly.
+   Trade-off: more lines touched than a single edit. Justification: a
+   diagram with stale counts is worse than no diagram.
+4. **`docs/troubleshooting.md` debugging step rewrite.** Replace
+   trace-inspection guidance with: verify `/yoke:ask` runs without
+   `.yoke/.current`; verify `lib/canonical-memory/resolve-memory.sh`
+   returns a path; verify the registered memory exists on disk. This
+   gives the user the actual debugging surface that survives.
+
+## Applicable Patterns
+
+- `.vibeflow/patterns/memory-model.md` — single source of truth on
+  working-memory files. CLAUDE.md and `docs/architecture.md` summaries
+  must agree with it.
+- `.vibeflow/patterns/plugin-structure.md` — repo layout; relevant for
+  the architecture diagram.
+
+## Risks
+
+- **R1 / Architecture diagram has multiple occurrences of the trace; one
+  is missed.** Mitigation: post-edit grep `query-trace|query-traces`
+  across the four files.
+- **R2 / Lineage narrative becomes confusing — one trace mention
+  removed, another remains historical.** Mitigation: read full sections,
+  not just lines; ensure each remaining mention is explicitly framed as
+  past.
+- **R3 / A doc references the working-memory layout in a way that
+  implicitly assumes 6 files (with trace).** Mitigation: search for
+  numeric counts ("five", "six", "the … files of"); update each.
+- **R4 / Drift between CLAUDE.md and `.vibeflow/patterns/memory-model.md`
+  in the future.** Mitigation: Part 4 is dependency; both docs land in
+  the same PR series. Long-term: if drift recurs, the future spec is to
+  consolidate by having CLAUDE.md include-by-reference.
+
+## Dependencies
+
+- `.vibeflow/specs/ask-source-agnostic-read-part-1.md`
+- `.vibeflow/specs/ask-source-agnostic-read-part-4.md`

--- a/.vibeflow/specs/ask-source-agnostic-read-part-6.md
+++ b/.vibeflow/specs/ask-source-agnostic-read-part-6.md
@@ -1,0 +1,112 @@
+# Spec: `/yoke:ask` source-agnostic — Part 6 / Trailing docs + changelog
+
+> Generated via /vibeflow:gen-spec on 2026-04-25
+> PRD: `.vibeflow/prds/ask-source-agnostic-read.md`
+
+## Objective
+
+Sweep the remaining user-facing surfaces (`docs/quickstart.md`,
+`examples/greenfield-payment-service/CLAUDE.md`) and add a CHANGELOG
+entry that records the breaking change for any project already
+bootstrapped against an older Yoke.
+
+## Context
+
+Two trailing surfaces still describe `/yoke:ask` as "mediated
+canonical-memory query" — accurate while the trace mediated, misleading
+once `/yoke:ask` is a direct, source-agnostic read. The CHANGELOG is the
+contract surface for downstream users: any project that previously ran
+`/yoke:bootstrap` against an older Yoke version now has a stale
+`.yoke/query-traces/` directory and stale agent prompts. The migration
+note tells them what to do.
+
+## Definition of Done
+
+1. `docs/quickstart.md` no longer describes `/yoke:ask` as "mediated".
+   The phrase is replaced with "adaptive canonical-memory query" (or
+   equivalent wording consistent with `skills/ask/SKILL.md`'s revised
+   description from Part 1).
+2. `examples/greenfield-payment-service/CLAUDE.md` mirrors the
+   quickstart wording — same phrasing for the `/yoke:ask` description
+   line. No new content is added; only the description is corrected.
+3. `CHANGELOG.md` contains a new entry — clearly marked **Breaking** —
+   describing:
+   - Removal of the query-trace contract.
+   - Removal of `wm_query_trace_path` and the `query-traces` archive
+     category from `lib/working-memory/paths.sh`.
+   - Change to bypass discipline (declarative rule on each subagent
+     prompt).
+   - Runtime-agent contract change: Generator, Validator, and
+     Orchestrator now read canonical memory by invoking `/yoke:ask` via
+     the Skill tool.
+   - Migration note: any pre-existing `.yoke/query-traces/` directory
+     in a host project is now orphaned and may be deleted.
+4. The CHANGELOG entry follows the existing CHANGELOG.md style
+   conventions: section ordering, version line, link style, date format.
+5. **Sweep gate** — no surviving reference in any of the three files
+   to `query-trace.md` or `query-traces/<slug>.md` as a live mechanism.
+
+## Scope
+
+- Edit `docs/quickstart.md`.
+- Edit `examples/greenfield-payment-service/CLAUDE.md`.
+- Edit `CHANGELOG.md`.
+
+## Anti-scope
+
+- `.vibeflow/` doctrine — Part 4.
+- `CLAUDE.md` (project root), `docs/architecture.md`, `docs/lineage.md`,
+  `docs/troubleshooting.md` — Part 5.
+- Migration tooling for existing projects — explicitly excluded by the
+  PRD anti-scope. The CHANGELOG note instructs the user; we do not ship
+  code that mutates host repos.
+- Other examples (`examples/` may grow over time; only the
+  greenfield-payment-service example references `/yoke:ask` today).
+- README.md — verify no live trace reference; if absent, do not touch.
+  If present, fold into this part.
+
+## Technical Decisions
+
+1. **Description wording.** "Adaptive canonical-memory query" matches
+   `bedrock:ask`'s framing and the new `skills/ask/SKILL.md`
+   description. Trade-off: small lexical drift from earlier docs.
+   Justification: accuracy and consistency across surfaces.
+2. **Migration note instead of migration code.** The CHANGELOG simply
+   tells the user that any `.yoke/query-traces/` directory is orphaned
+   and can be deleted. Trade-off: a tiny user-side step. Justification:
+   PRD anti-scope explicitly defers migration tooling; the user can
+   `rm -rf .yoke/query-traces/` (or simply ignore it) without harm.
+3. **CHANGELOG section placement.** Add under the next unreleased
+   header, or create one if absent, matching the repo's existing style.
+   Mark the entry **Breaking**. Cross-link to Parts 1–5 via a single
+   "removes the query-trace contract end-to-end" sentence rather than
+   listing every file edited (the diff already enumerates them).
+4. **Identical phrasing in quickstart and example CLAUDE.md.** Reduces
+   future drift. Trade-off: minor. Justification: both files describe
+   the same thing; differences invite questions.
+
+## Applicable Patterns
+
+- `.vibeflow/patterns/plugin-structure.md` — `examples/` layout and
+  scope.
+- `.vibeflow/conventions.md` "Implementation Plan Conventions" → "Every
+  sprint ships an installable plugin": each shipped change must update
+  the changelog.
+
+## Risks
+
+- **R1 / CHANGELOG entry undersells the breakage.** Mitigation: explicit
+  **Breaking** label + migration note; do not bury under "internal
+  refactor".
+- **R2 / Quickstart and example CLAUDE.md drift in wording over future
+  edits.** Mitigation: identical phrasing landed in both files in this
+  part; future edits to one should update the other.
+- **R3 / A surviving `query-trace` reference is missed in another
+  example or doc not enumerated here.** Mitigation: post-edit grep
+  `query-trace|query-traces` across the entire repo before merging
+  the part-6 PR; any hit is fixed in scope.
+
+## Dependencies
+
+- `.vibeflow/specs/ask-source-agnostic-read-part-1.md`
+- `.vibeflow/specs/ask-source-agnostic-read-part-4.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,86 @@ All notable changes to this project are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased] — Source-agnostic /yoke:ask (**Breaking**)
+
+`/yoke:ask` is now a pure source-agnostic read against the registered
+canonical memory. The previous v1.1 contract required `.yoke/.current`
+to point at an active task and emitted a YAML query-trace entry on
+every invocation; both are retired. Any caller — Generator, Validator,
+Orchestrator, spec-phase skills, or ad-hoc human queries — invokes
+`/yoke:ask` directly via the Skill tool when canonical context is
+needed; the skill produces only the conversational response and writes
+nothing on disk.
+
+> **Breaking.** Already-bootstrapped projects must delete the orphaned
+> `.yoke/query-traces/` directory if it exists; otherwise no migration
+> required.
+
+### Removed
+
+- **Query-trace contract end-to-end.** The
+  `.yoke/query-traces/<slug>.md` archive is gone, along with its
+  bypass-detection role.
+  - `lib/working-memory/paths.sh`: `wm_query_trace_path` deleted;
+    `query-traces` removed from `WM_ARCHIVE_CATEGORIES`.
+  - `skills/ask/SKILL.md`: Phase 5.1 trace write removed; the
+    `.yoke/.current` pre-condition removed; `Write` removed from
+    `allowed-tools` (skill is pure read).
+  - `agents/{generator,validator}.md`: cycle-start trace-read removed;
+    "Reads canonical memory: only via `/yoke:ask`" replaces
+    "Consumes Orchestrator-surfaced subgraph via query-trace".
+  - `agents/orchestrator.md`: consult mode invokes `/yoke:ask` and
+    reasons inline; "absence of trace entry is a bypass" rewritten as
+    a declarative bypass-discipline rule with Trigger-4 escalation
+    hint.
+  - `skills/implement/SKILL.md`: cycle-0 query-trace initialization
+    step removed (corrigendum to Part 1).
+  - `skills/drift-sense/SKILL.md`: staleness-source falls back to
+    `last_validated`; `--target traces` mode now scans
+    `.yoke/contracts/*.md` only (corrigendum to Part 1).
+
+### Changed
+
+- **`/yoke:ask` description** rewritten to "Source-agnostic read
+  against the registered canonical memory" — no active-task
+  pre-condition, no on-disk side effects, 15-entity progressive-
+  disclosure cap preserved.
+- **`agents/{generator,validator,orchestrator}.md`** `tools:` envelope
+  adds `Skill` (the only canonical-memory access path); `description`
+  fields rewritten to match the new contract.
+- **Bypass discipline** is declarative: every canonical-memory read
+  by Generator, Validator, or Orchestrator MUST go through
+  `/yoke:ask` invoked via the Skill tool; direct filesystem reads
+  (cat, grep, clone, pull) are prohibited. The Orchestrator may
+  raise a sprint-contract divergence (Trigger-4 candidate) if it
+  observes a bypass.
+- **Doctrine docs** (`.vibeflow/conventions.md`,
+  `.vibeflow/patterns/{memory-model,roles,phase-flow,ralph-loop}.md`,
+  `.vibeflow/index.md`) updated so the Generator/Validator/Orchestrator
+  read path and the working-memory file list reflect the no-trace
+  contract.
+- **Repo + user docs** (`CLAUDE.md`, `docs/architecture.md`,
+  `docs/lineage.md`, `docs/troubleshooting.md`,
+  `docs/quickstart.md`,
+  `examples/greenfield-payment-service/CLAUDE.md`) updated so
+  user-facing descriptions match the new contract; the architecture
+  diagram now shows `/yoke:ask (Skill)` instead of `query-trace.md`.
+- **Smoke tests** (`tests/smoke/sprint-2.test.sh`,
+  `sprint-5.test.sh`, `folder-isolation.test.sh`) realigned: trace
+  assertions removed; new assertions cover the source-agnostic
+  contract (no abort without `.yoke/.current`, allowed-tools
+  excludes `Write`, sweep gate against query-trace re-introduction).
+
+### Migration
+
+- For host projects already bootstrapped against v1.1: delete the
+  orphaned `.yoke/query-traces/` directory if it exists.
+  ```bash
+  rm -rf .yoke/query-traces/
+  ```
+- No further migration is required. Skills, agents, and templates
+  ship with the new contract on `/plugin upgrade`.
+
 ## [1.1.0] — 2026-04-25 — Runtime-only agents
 
 Architectural refactor of the agent topology. v1.0 had five subagent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ A framework for software development with AI agents. It couples two adversarial 
 
 | Tier | Location | Who writes | Lifetime |
 | :---- | :---- | :---- | :---- |
-| Working memory | host project's `.yoke/` (`prd.md`, `tech-spec.md`, `acceptance-contract.md`, `progress.md`, `contracts.md`, `query-trace.md`) | Generator/Validator/derived agents freely | task/sprint |
+| Working memory | host project's `.yoke/` (`prd.md`, `tech-spec.md`, `acceptance-contract.md`, `progress.md`, `contracts.md`) | Generator/Validator/derived agents freely | task/sprint |
 | Canonical memory | external substrate via MCP (reference: Claude Bedrock; replaceable) | only Orchestrator, under Model C | permanent, versioned |
 
 The separation exists because the blast radius is asymmetric: corrupted working memory affects one task; corrupted canonical memory affects the organization.

--- a/agents/generator.md
+++ b/agents/generator.md
@@ -1,7 +1,7 @@
 ---
 name: generator
-description: Runtime subagent — iterates over the approved Tech Spec inside the binding Acceptance Contract envelope, writes implementation code, and persists progress at the end of every cycle. Co-writes contracts.md on consensus with the Validator. Never writes canonical memory.
-tools: Read, Write, Edit, Grep, Glob, Bash
+description: Runtime subagent — iterates over the approved Tech Spec inside the binding Acceptance Contract envelope, writes implementation code, and persists progress at the end of every cycle. Co-writes contracts.md on consensus with the Validator. Reads canonical memory only by invoking /yoke:ask via the Skill tool. Never writes canonical memory.
+tools: Read, Write, Edit, Grep, Glob, Bash, Skill
 ---
 
 # Generator
@@ -46,9 +46,12 @@ and acts on the specific violations it reports.
   criterion you are interpreting.
 - **Cite the Acceptance Contract criterion** you are addressing in
   every cycle's `progress.md` entry (`citing_criterion:` field).
-- **Read `.yoke/query-traces/<slug>.md`** at the start of every cycle for
-  any relevant canonical-memory subgraph entries the Orchestrator
-  surfaced on the previous cycle.
+- **Invoke `/yoke:ask` via the Skill tool** when you need canonical
+  context — ratified policies, domain ownership, prior decisions,
+  patterns relevant to the Acceptance Contract criterion you are
+  addressing. Before relying on prior knowledge for any of those, ask
+  the canonical memory. The skill is source-agnostic and can be called
+  any time during a cycle.
 
 ### Never
 
@@ -58,9 +61,11 @@ and acts on the specific violations it reports.
   2 / 3 respectively.
 - **Never write canonical memory.** That authority belongs to the
   Orchestrator under Model C.
-- **Never read canonical memory directly.** Canonical-memory
-  consultation during cycles is the Orchestrator's responsibility;
-  you consume the surfaced subgraph via `.yoke/query-traces/<slug>.md`.
+- **Never read canonical memory directly.** Direct filesystem reads
+  of the registered memory (cat, grep, clone, pull) are prohibited.
+  Reads route exclusively through `/yoke:ask` invoked via the Skill
+  tool. `.yoke/query-traces/` does not exist; do not read or write any
+  path under it.
 - **Never share context with the Validator.** Adversarial separation
   is by design. Communicate only via working-memory files
   (`.yoke/runtime/progress.md` written by you; `.yoke/contracts/<slug>.md` co-written
@@ -78,31 +83,34 @@ and acts on the specific violations it reports.
 
 `task` — read `.yoke/prds/<slug>.md`, `.yoke/tech-specs/<slug>.md`,
 `.yoke/acceptance-contracts/<slug>.md`, `.yoke/runtime/progress.md`,
-`.yoke/contracts/<slug>.md`, `.yoke/query-traces/<slug>.md`, and
-`verify-acceptance.sh` output. Write `.yoke/runtime/progress.md` and
-`.yoke/contracts/<slug>.md`. Read and write code files in the host project
-workspace.
+`.yoke/contracts/<slug>.md`, and `verify-acceptance.sh` output. Write
+`.yoke/runtime/progress.md` and `.yoke/contracts/<slug>.md`. Read and
+write code files in the host project workspace. Read canonical memory
+only by invoking `/yoke:ask` via the Skill tool.
 
 ## Allowed tools
 
 - `Read`, `Write`, `Edit` — `.yoke/runtime/progress.md` and `.yoke/contracts/<slug>.md`
   (write); host project code files (write); upstream `.yoke/*.md`
-  artifacts and `.yoke/query-traces/<slug>.md` (read-only).
+  artifacts (read-only).
 - `Grep`, `Glob` — across the host project workspace.
 - `Bash` — to invoke `hooks/verify-acceptance.sh` after applying
   changes (so you can read the structured verdict on the next cycle).
+- `Skill` — to invoke `/yoke:ask` for canonical-memory reads. This is
+  the only canonical-memory access path.
 
 ## Restrictions
 
 - Cannot modify `.yoke/prds/<slug>.md`, `.yoke/tech-specs/<slug>.md`,
-  `.yoke/acceptance-contracts/<slug>.md`, or `.yoke/query-traces/<slug>.md`.
-  Read-only.
-- Cannot read or write canonical memory directly. Phase 4 is fully
-  scoped to working memory inside the Acceptance Contract envelope;
-  canonical-memory consultation during cycles is the Orchestrator's
-  responsibility.
+  or `.yoke/acceptance-contracts/<slug>.md`. Read-only.
+- Cannot read or write canonical memory directly — reads are routed
+  through `/yoke:ask` invoked via the Skill tool; writes are forbidden
+  outright. Phase 4 working memory inside the Acceptance Contract
+  envelope plus on-demand `/yoke:ask` calls is the entire surface
+  available to you.
 - Cannot invoke `/yoke:canonize`, `/yoke:discover`, `/yoke:tech-spec`,
-  `/yoke:acceptance-contract`, or `/yoke:drift-sense`.
+  `/yoke:acceptance-contract`, `/yoke:drift-sense`, or `/yoke:preserve`.
+  The only `/yoke:*` skill the Generator may invoke is `/yoke:ask`.
 
 ## Pattern references
 

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -1,7 +1,7 @@
 ---
 name: orchestrator
-description: Runtime subagent — sole writer of canonical memory under Model C. Three runtime modes — consult (read canonical memory during cycles by invoking /yoke:ask via the Skill tool; trace lands in .yoke/query-traces/<slug>.md); monitor (detect Generator/Validator divergence, escalate via lib/ralph-loop/escalate.sh); canonize (at loop termination, apply five-criteria filter and propose writes via lib/canonical-memory/propose-write.sh). Spawned in parallel with Generator and Validator each cycle by /yoke:implement.
-tools: Read, Write, Edit, Grep, Glob, Bash
+description: Runtime subagent — sole writer of canonical memory under Model C. Three runtime modes — consult (read canonical memory during cycles by invoking /yoke:ask via the Skill tool and reasoning over the response in-conversation); monitor (detect Generator/Validator divergence, escalate via lib/ralph-loop/escalate.sh); canonize (at loop termination, invoke /yoke:preserve via the Skill tool to apply the five-criterion cascade and open Model C-classified PRs). Spawned in parallel with Generator and Validator each cycle by /yoke:implement.
+tools: Read, Write, Edit, Grep, Glob, Bash, Skill
 ---
 
 # Orchestrator
@@ -15,14 +15,17 @@ propose writes; no other agent may write directly.
 ## Three runtime modes
 
 You declare your active mode explicitly in the first line of every
-invocation. Mode declarations write to `.yoke/query-traces/<slug>.md` so
-traces show provenance for every operation:
+response so the cycle log shows provenance for every operation:
 
 ```
-[orchestrator:consult] cycle=<N> query="<term>" subgraph_depth=1
+[orchestrator:consult] cycle=<N> query="<term>"
 [orchestrator:monitor] cycle=<N>
 [orchestrator:canonize] candidates=<count>
 ```
+
+The mode declaration is conversational only — it is **not** persisted to
+disk. `.yoke/query-traces/` does not exist; do not read or write any file
+under that path.
 
 If you find yourself acting without a mode declaration, that is a
 self-bug — abort and re-prompt with the mode token explicit.
@@ -38,12 +41,16 @@ and the Validator.
   filesystem directly — no clone, no pull). Use it for patterns,
   decisions, and templates relevant to the next failing Acceptance
   Contract criterion.
-- The skill writes its own YAML trace entry to
-  `.yoke/query-traces/<slug>.md`; you do not write the trace yourself
-  for consult-mode reads. Append your own `[orchestrator:consult]` mode
-  declaration to the trace for cycle context.
+- Reason over the `/yoke:ask` response inline — the skill is a pure
+  read and produces only the conversational answer; no file is written
+  on disk as a consult-mode side effect.
 - Apply progressive disclosure — `/yoke:ask` caps at 15 entity reads
   with one wikilink hop. Do not dump the full canonical memory.
+- If the Generator or Validator needs canonical context that you have
+  already retrieved this cycle, surface it inline in your monitor
+  output (read by `/yoke:implement` orchestration). They may also
+  invoke `/yoke:ask` directly via the Skill tool — both paths are
+  valid.
 
 ### Mode B — Monitor (per cycle, during runtime)
 
@@ -69,7 +76,7 @@ Activated once by `/yoke:implement` when the loop terminator fires
 input parameter `mode=canonize`.
 
 - Read working-memory files: `.yoke/runtime/progress.md`,
-  `.yoke/contracts/<slug>.md`, `.yoke/query-traces/<slug>.md`.
+  `.yoke/contracts/<slug>.md`.
 - Invoke `/yoke:preserve` via the Skill tool, passing the active
   task's `.yoke/<task-slug>/` directory path along with
   `--from-orchestrator` so the skill knows it is running under the
@@ -117,8 +124,8 @@ The Orchestrator no longer calls a write primitive directly; see
 
 ### Always
 
-- **Declare your mode** in the first line of every invocation,
-  written to `.yoke/query-traces/<slug>.md`.
+- **Declare your mode** in the first line of every response
+  (conversational only; not persisted to disk).
 - **Apply Model C** before every write. Never bypass impact
   classification, even for your own observations.
 - **Use progressive disclosure** in Consult mode — load only the
@@ -143,8 +150,10 @@ The Orchestrator no longer calls a write primitive directly; see
   it; do not propose canonization candidates that have not been
   filtered.
 - **Never share context** with the Generator or Validator beyond
-  what working-memory files expose. Each cycle they read your
-  `.yoke/query-traces/<slug>.md` updates; they do not see your reasoning.
+  what working-memory files expose and what `/yoke:implement`
+  orchestration surfaces between subagents. Each cycle they invoke
+  `/yoke:ask` themselves when they need canonical context; they do not
+  see your reasoning.
 - **Never modify `.yoke/prds/<slug>.md`, `.yoke/tech-specs/<slug>.md`,
   `.yoke/acceptance-contracts/<slug>.md`, `.yoke/runtime/progress.md`, or
   `.yoke/contracts/<slug>.md`.**
@@ -158,10 +167,11 @@ Canonize):
 
 - Read: `.yoke/prds/<slug>.md`, `.yoke/tech-specs/<slug>.md`,
   `.yoke/acceptance-contracts/<slug>.md`, `.yoke/runtime/progress.md`,
-  `.yoke/contracts/<slug>.md`, `.yoke/query-traces/<slug>.md`,
-  `verify-acceptance.sh` output.
-- Write: `.yoke/query-traces/<slug>.md` (mode declarations + consult queries
-  + escalation events).
+  `.yoke/contracts/<slug>.md`, `verify-acceptance.sh` output.
+- Write: none in working memory. The Orchestrator emits its
+  mode-declared output conversationally; persistence (other than
+  canonical-memory writes via `/yoke:preserve`) is owned by the
+  Generator and Validator.
 - Canonical memory: read by invoking `/yoke:ask` via the Skill tool
   (Consult mode); write by invoking `/yoke:preserve` via the Skill
   tool (Canonize mode only). Both skills resolve the active memory
@@ -172,10 +182,9 @@ Canonize):
 
 ## Allowed tools
 
-- `Read`, `Write`, `Edit` — `.yoke/query-traces/<slug>.md` (write); other
-  `.yoke/*.md` and host code (read-only).
-- `Grep`, `Glob` — across the host project workspace and the
-  cached canonical-memory repo.
+- `Read` — `.yoke/*.md` working-memory artifacts and host code
+  (read-only).
+- `Grep`, `Glob` — across the host project workspace.
 - `Bash` — to invoke `lib/ralph-loop/escalate.sh`. Canonical-memory
   reads and writes go through Skill-tool invocations of `/yoke:ask`
   and `/yoke:preserve` respectively;
@@ -185,6 +194,13 @@ Canonize):
   (Canonize mode). Direct shell-out to `query.sh` and
   `propose-write.sh` is retired (Parts 3 and 4 of the bedrock
   canonical-memory port).
+- `Write`, `Edit` — reserved for future use; the Orchestrator does
+  not currently write to working memory. Listed in `tools:` so future
+  monitor-mode artifacts (if added by a separate spec) do not require
+  a tool envelope change.
+
+`.yoke/query-traces/` does **not** exist; never read or write any path
+under it.
 
 ## Restrictions
 
@@ -200,9 +216,15 @@ Canonize):
 
 You are the **sole writer of canonical memory** under Model C. No
 other agent or skill may propose writes; no other agent may write
-directly. Bypass detection: any read of canonical memory that does
-not write a trace entry to `.yoke/query-traces/<slug>.md` is a bypass — flag
-it.
+directly.
+
+Bypass discipline (declarative): the Generator and the Validator
+**must** invoke `/yoke:ask` via the Skill tool for every canonical-memory
+read. Direct filesystem reads of the registered memory (cat, grep,
+clone, pull) are prohibited. If you observe a Generator or Validator
+output that cites canonical-memory content without an `/yoke:ask`
+invocation in the same cycle, raise it as a sprint-contract divergence
+(Trigger 4 candidate via `lib/ralph-loop/escalate.sh`).
 
 ## Lineage
 

--- a/agents/validator.md
+++ b/agents/validator.md
@@ -1,7 +1,7 @@
 ---
 name: validator
-description: Runtime subagent — judges every Generator cycle against the binding Acceptance Contract. Runs hooks/verify-acceptance.sh, emits structured JSON verdicts (criterion / status / location / fix_instruction / sensor / evidence), co-writes .yoke/contracts/<slug>.md on consensus. Never writes canonical memory.
-tools: Read, Write, Edit, Grep, Glob, Bash
+description: Runtime subagent — judges every Generator cycle against the binding Acceptance Contract. Runs hooks/verify-acceptance.sh, emits structured JSON verdicts (criterion / status / location / fix_instruction / sensor / evidence), co-writes .yoke/contracts/<slug>.md on consensus. Reads canonical memory only by invoking /yoke:ask via the Skill tool. Never writes canonical memory.
+tools: Read, Write, Edit, Grep, Glob, Bash, Skill
 ---
 
 # Validator
@@ -60,9 +60,12 @@ specific sensor outcome.
   contract being negotiated would relax a Contract criterion, mark
   it as `status: divergence` and flag for Orchestrator escalation
   (Trigger 4 via `lib/ralph-loop/escalate.sh`).
-- **Read `.yoke/query-traces/<slug>.md`** at the start of every cycle for
-  any relevant canonical-memory subgraph entries the Orchestrator
-  surfaced on the previous cycle.
+- **Invoke `/yoke:ask` via the Skill tool** when sensor evidence needs
+  to be judged against canonical-memory rules — ratified policies,
+  calibration metadata, prior decisions on similar criteria. Before
+  relying on prior knowledge for any of those, ask the canonical
+  memory. The skill is source-agnostic and can be called any time
+  during a cycle.
 
 ### Never
 
@@ -71,9 +74,11 @@ specific sensor outcome.
 - **Never modify code in the host project.** That is the Generator's
   role. You judge, not patch.
 - **Never write canonical memory.**
-- **Never read canonical memory directly.** Canonical-memory
-  consultation during cycles is the Orchestrator's responsibility;
-  you consume the surfaced subgraph via `.yoke/query-traces/<slug>.md`.
+- **Never read canonical memory directly.** Direct filesystem reads
+  of the registered memory (cat, grep, clone, pull) are prohibited.
+  Reads route exclusively through `/yoke:ask` invoked via the Skill
+  tool. `.yoke/query-traces/` does not exist; do not read or write any
+  path under it.
 - **Never share context with the Generator.** Adversarial separation
   is by design. Communicate only via `verify-acceptance.sh` output,
   `.yoke/contracts/<slug>.md`, and structured verdicts persisted to
@@ -87,25 +92,30 @@ specific sensor outcome.
 
 `task` — read `.yoke/prds/<slug>.md`, `.yoke/tech-specs/<slug>.md`,
 `.yoke/acceptance-contracts/<slug>.md`, `.yoke/runtime/progress.md`,
-`.yoke/contracts/<slug>.md`, `.yoke/query-traces/<slug>.md`. Read host-project code
-(read-only). Write `.yoke/contracts/<slug>.md` (jointly with the Generator).
+`.yoke/contracts/<slug>.md`. Read host-project code (read-only). Write
+`.yoke/contracts/<slug>.md` (jointly with the Generator). Read canonical
+memory only by invoking `/yoke:ask` via the Skill tool.
 
 ## Allowed tools
 
-- `Read` — upstream artifacts, host project code,
-  `.yoke/query-traces/<slug>.md`, and `verify-acceptance.sh` output.
+- `Read` — upstream artifacts, host project code, and
+  `verify-acceptance.sh` output.
 - `Write`, `Edit` — `.yoke/contracts/<slug>.md` only (jointly with the
   Generator).
 - `Grep`, `Glob` — across the host project workspace.
 - `Bash` — to invoke `hooks/verify-acceptance.sh` and
   `lib/ralph-loop/escalate.sh`.
+- `Skill` — to invoke `/yoke:ask` for canonical-memory reads. This is
+  the only canonical-memory access path.
 
 ## Restrictions
 
 - Cannot modify upstream artifacts or host-project code.
-- Cannot read or write canonical memory directly. Canonical-memory
-  consultation during cycles is the Orchestrator's responsibility.
-- Cannot invoke any other `/yoke:*` skill.
+- Cannot read or write canonical memory directly — reads are routed
+  through `/yoke:ask` invoked via the Skill tool; writes are forbidden
+  outright.
+- Cannot invoke any other `/yoke:*` skill. The only `/yoke:*` skill
+  the Validator may invoke is `/yoke:ask`.
 
 ## Pattern references
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@
 - **Generator** (`agents/generator.md`) — runtime subagent. Iterates over the Tech Spec, writes code targeting the next failing Acceptance Contract criterion, persists `.yoke/progress.md` every cycle.
 - **Validator** (`agents/validator.md`) — runtime subagent. Runs `hooks/verify-acceptance.sh`, emits structured JSON verdicts per criterion, co-writes `.yoke/contracts.md` on consensus events.
 - **Orchestrator** (`agents/orchestrator.md`) — runtime subagent and **sole writer of canonical memory** under Model C. Three modes:
-  - **Consult** (per cycle) — read canonical memory live; surface relevant subgraph entries to `.yoke/query-trace.md`.
+  - **Consult** (per cycle) — invoke `/yoke:ask` via the Skill tool when canonical-memory context is needed; reason over the response in-conversation. The skill is source-agnostic and writes nothing on disk.
   - **Monitor** (per cycle) — detect Generator↔Validator divergence; escalate via `lib/ralph-loop/escalate.sh` (Trigger 4).
   - **Canonize** (at loop termination) — apply five-criteria filter; classify Model C impact; propose writes via `lib/canonical-memory/propose-write.sh`.
 
@@ -85,7 +85,7 @@ Plus support skills: `/yoke:bootstrap`, `/yoke:ask`
               │   └────┬─────┘  └────┬─────┘  └────────┬─────────┘  │
               │        │             │                 │            │
               │        ▼             ▼                 ▼            │
-              │   progress.md   contracts.md     query-trace.md     │
+              │   progress.md   contracts.md   /yoke:ask (Skill)    │
               │                                                      │
               │   ── deterministic ──> verify-acceptance.sh          │
               │   ── deterministic ──> check-contradiction           │
@@ -147,7 +147,7 @@ yoke/                              # this plugin repo
 
 <host project>/.yoke/              # working memory, per project
 └── (prd.md, tech-spec.md, acceptance-contract.md, progress.md,
-     contracts.md, query-trace.md, .snapshots/cycle-N.yaml)
+     contracts.md, .snapshots/cycle-N.yaml)
 
 <canonical-memory repo>/           # external substrate, organization-wide
 └── (markdown + frontmatter, queryable via MCP, write-only by Orchestrator)

--- a/docs/lineage.md
+++ b/docs/lineage.md
@@ -52,18 +52,24 @@ Fork dates:
   - Wired the Generator subagent.
   - Trigger-2 prompt with `approve` / `revise <feedback>` / `back to PRD`.
 
-### `lib/canonical-memory/query.sh`
+### `lib/canonical-memory/query.sh` (retired)
+
+This primitive was retired in Part 3 of the bedrock canonical-memory
+port; `/yoke:ask` now resolves the active memory via
+`lib/canonical-memory/resolve-memory.sh` and reads the local
+filesystem directly (no clone, no pull). The audit-trail / query-trace
+contract that originally lived here was retired in
+ask-source-agnostic-read Part 1 — `/yoke:ask` is now a pure read and
+emits no trace. Historical adaptations recorded for lineage:
 
 - **Source:** Bedrock's read primitives (upstream version 1.2.1).
-- **Adaptations:**
-  - Added `--trace <path> --invoker <name>` flags for deterministic
-    audit-trail writing to `.yoke/query-trace.md` (Yoke-specific
-    requirement; called by `skills/ask/SKILL.md` at spec phase and
-    by the Orchestrator subagent's consult mode at runtime).
-  - Added `--subgraph-depth N` flag for progressive disclosure (Sprint
-    6); delegates to `lib/canonical-memory/graph.sh` for traversal.
+- **Historical adaptations** (no longer in effect):
+  - `--trace <path> --invoker <name>` flags for deterministic
+    audit-trail writing (retired with the trace contract itself).
+  - `--subgraph-depth N` flag for progressive disclosure — superseded
+    by `/yoke:ask`'s built-in 15-entity cap and 1-level wikilink hop.
   - Bounded output (cap at 20 flat matches / 10 subgraph entries).
-  - Empty-state UX (`"no entries yet"` / `"no matches"` / `"not configured"`).
+  - Empty-state UX.
 
 ### `lib/canonical-memory/graph.sh`
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -52,7 +52,7 @@ Once shipped, the remaining commands are:
 Plus support commands:
 
 ```
-/yoke:ask "<term>"           # mediated canonical-memory query
+/yoke:ask "<term>"           # adaptive canonical-memory query
 /yoke:status                 # current task state
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -140,25 +140,34 @@ of `/yoke:status` and the relevant `.yoke/*.md` files.
 
 ### "skill X is missing canonical-memory access"
 
-- All canonical-memory access goes through `/yoke:ask` (mediated by the
-  Orchestrator skill). If a Generator/Validator subagent tries to read
-  canonical memory directly, the v1.0 detection is conservative
-  (trace-absence based; see Sprint 5 audit). Future versions add
-  stricter enforcement.
+- All canonical-memory access goes through `/yoke:ask` invoked via the
+  Skill tool. The skill is source-agnostic — any caller (Generator,
+  Validator, Orchestrator, spec-phase skill, or ad-hoc human query)
+  can invoke it without an active task. If you suspect a subagent is
+  bypassing it, the v0 detection is declarative — the rule is stated
+  in each subagent's prompt; review during code-review.
+- Verify `/yoke:ask` resolves the active memory by running
+  `bash lib/canonical-memory/resolve-memory.sh --memory <name>` (or
+  with no flag for CWD/default resolution). The output is
+  `<name>\t<path>` on success.
 
 ### Where do I find the canonical-memory repo?
 
-- Path: `~/.cache/yoke/canonical/<slug>/` (cloned by `/yoke:ask` on
-  first run). The URL is in `.yoke/config.yaml` →
-  `canonical_memory.url`.
+- Path: registered in `<plugin_dir>/memories.json` (one entry per
+  registered memory). Use `/yoke:memory list` to see all registered
+  memories; the entry's `path` field is the absolute filesystem path.
+  No clone cache exists — the resolution lib reads the registered path
+  directly.
 
 ### How do I reset Yoke for a clean test?
 
 ```bash
 rm -rf .yoke/                                    # working memory
-rm -rf ~/.cache/yoke/canonical/<your-slug>/      # cached canonical-memory clone
 /yoke:bootstrap                                  # re-init
 ```
+
+The canonical-memory repo at the registered path is **not** managed
+by Yoke — manage it with regular git.
 
 ### `/yoke:status` shows nothing
 

--- a/examples/greenfield-payment-service/CLAUDE.md
+++ b/examples/greenfield-payment-service/CLAUDE.md
@@ -37,5 +37,5 @@ in the flow:
 - `/yoke:implement` — Phase 4 (adversarial loop with hard bounds)
 - `/yoke:canonize` — Phase 5 (Model C — low/medium auto, high/regulatory sync)
 - `/yoke:drift-sense` — Phase 6 (continuous; runs daily via Actions)
-- `/yoke:ask "<term>"` — mediated canonical-memory query
+- `/yoke:ask "<term>"` — adaptive canonical-memory query
 - `/yoke:status` — current task state

--- a/lib/working-memory/paths.sh
+++ b/lib/working-memory/paths.sh
@@ -13,7 +13,6 @@
 #   ├── tech-specs/<slug>.md                 # versioned archive
 #   ├── acceptance-contracts/<slug>.md       # versioned archive
 #   ├── contracts/<slug>.md                  # versioned archive
-#   ├── query-traces/<slug>.md               # versioned archive
 #   └── runtime/                             # gitignored
 #       ├── progress.md
 #       ├── .cycle-counter
@@ -42,7 +41,7 @@ readonly WM_ROOT=".yoke"
 readonly WM_CURRENT_FILE="${WM_ROOT}/.current"
 readonly WM_RUNTIME_DIR="${WM_ROOT}/runtime"
 readonly WM_SLUG_REGEX='^[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9][a-z0-9-]{0,49}$'
-readonly WM_ARCHIVE_CATEGORIES=(prds tech-specs acceptance-contracts contracts query-traces)
+readonly WM_ARCHIVE_CATEGORIES=(prds tech-specs acceptance-contracts contracts)
 
 # --- slug validation --------------------------------------------------------
 
@@ -96,7 +95,6 @@ wm_prd_path()                  { _wm_archive_path "prds" "${1:-}"; }
 wm_tech_spec_path()            { _wm_archive_path "tech-specs" "${1:-}"; }
 wm_acceptance_contract_path()  { _wm_archive_path "acceptance-contracts" "${1:-}"; }
 wm_contracts_path()            { _wm_archive_path "contracts" "${1:-}"; }
-wm_query_trace_path()          { _wm_archive_path "query-traces" "${1:-}"; }
 
 # --- collision detection ----------------------------------------------------
 

--- a/skills/ask/SKILL.md
+++ b/skills/ask/SKILL.md
@@ -1,36 +1,31 @@
 ---
 name: ask
 description: >
-  Read-only adaptive query against the active canonical memory. Resolves
-  the registered memory via lib/canonical-memory/resolve-memory.sh
-  (--memory flag → CWD detection → default), then reads the local
-  filesystem directly — never `git clone`, never `git pull`. Adaptive
-  vault-first search: classify the question, glob/grep entity files,
-  follow wikilinks one level, sort by recency, compose response.
-  Caps total entity reads at 15. Writes a YAML trace entry to
-  .yoke/query-traces/<slug>.md for bypass detection.
+  Source-agnostic read against the registered canonical memory. Resolves
+  the active memory via lib/canonical-memory/resolve-memory.sh (--memory
+  flag → CWD detection → default), then reads the local filesystem
+  directly — never `git clone`, never `git pull`, never `git fetch`.
+  Classifies the question, globs/greps entity files, follows wikilinks
+  one level, sorts by recency, composes the response. Caps total entity
+  reads at 15. Pure read — writes nothing on disk and does not depend on
+  any active task.
 argument-hint: "[--memory <name>] <question>"
-allowed-tools: Bash, Read, Glob, Grep, Write
+allowed-tools: Bash, Read, Glob, Grep
 ---
 
 # /yoke:ask — Canonical-memory adaptive reader
 
-> **v1.2 refresh (Part 3 of the bedrock canonical-memory port).** Previous
-> versions shelled out to `lib/canonical-memory/query.sh`, which cloned
-> the substrate on every read into `~/.cache/yoke/canonical/<slug>/`. That
-> path is retired. The active memory is now resolved against
-> `<plugin_dir>/memories.json` and read directly from the filesystem.
-> Subgraph traversal returns when a graphify pipeline is added (deferred
-> sprint).
-
 You are a **read-only adaptive context orchestrator**. You do not write,
-edit, or delete files inside the canonical memory. The only write you
-perform is the bypass-detection trace at
-`.yoke/query-traces/<slug>.md`.
+edit, or delete files anywhere — not inside the canonical memory, not in
+the host project's `.yoke/`, not on the plugin. The skill is a pure read.
+
+`/yoke:ask` is callable from any source: the runtime Generator, Validator
+and Orchestrator subagents; the spec-phase skills (`/yoke:discover`,
+`/yoke:tech-spec`, `/yoke:acceptance-contract`); and ad-hoc human queries.
+There is no active-task pre-condition.
 
 If a query reveals outdated or missing information, suggest
-`/yoke:teach <url>` (Part 5) or `/yoke:preserve` (Part 4) — never
-attempt the write yourself.
+`/yoke:teach <url>` or `/yoke:preserve` — never attempt the write yourself.
 
 ## Plugin paths
 
@@ -44,12 +39,12 @@ this skill" provided at invocation to resolve.
 
 ## Pre-conditions
 
-- `.yoke/.current` exists and points at a valid slug (per
-  `lib/working-memory/paths.sh`). If absent, abort:
-  *"no active task; run `/yoke:discover` first."*
 - A canonical memory is registered in `<plugin_dir>/memories.json`. If
   not, abort with:
   *"No memory registered. Run /yoke:memory add <path> or re-run /yoke:bootstrap."*
+
+There is no other pre-condition. The skill is independent of host-project
+working-memory state and is callable from any directory.
 
 ## Phase 0 — Resolve the active memory
 
@@ -202,8 +197,8 @@ After Phase 2, evaluate:
   to Phase 4.
 - **`needs_remote_content`** — relevant entities reference external
   URLs (Confluence, GDoc, GitHub) not yet ingested. Suggest
-  `/yoke:teach <url>` in the response (Phase 5.2). **Do not** invoke
-  `/yoke:teach` automatically in this part — Part 5 wires that.
+  `/yoke:teach <url>` in the response (Phase 5). **Do not** invoke
+  `/yoke:teach` automatically — the v0 skill does not escalate.
 - **`needs_graphify`** — emit a `> [!warning]` callout (graphify is not
   available in v0; graphify pipeline lands in a future sprint).
   Continue with vault-only content.
@@ -225,38 +220,7 @@ When the response involves multiple dated entities, sort descending
 (most recent first). For "what happened lately" / "latest decisions",
 limit to the last 30 days.
 
-## Phase 5 — Compose response + write trace
-
-### 5.1 Trace write
-
-**Always** write a YAML trace entry to `.yoke/query-traces/<slug>.md`,
-where `<slug>` comes from `wm_query_trace_path` in
-`lib/working-memory/paths.sh`:
-
-```bash
-source lib/working-memory/paths.sh
-trace_path="$(wm_query_trace_path)"
-mkdir -p "$(dirname "$trace_path")"
-[ -f "$trace_path" ] || printf '# Query trace\n' > "$trace_path"
-```
-
-Append the entry:
-
-```yaml
-- timestamp: "<iso8601>"
-  mode: ask
-  query: "<the user's question, double-quotes escaped>"
-  memory: "<YOKE_MEMORY_NAME>"
-  entities_read: <count>
-  capped: <true|false>          # true if Phase 2 hit the 15-entity cap
-  invoker: "ask"
-```
-
-The trace is the bypass-detection signal per `.vibeflow/conventions.md`
-("absence of a trace entry is the bypass signal"). Never skip this
-step — even when no entities were read (`entities_read: 0`).
-
-### 5.2 Compose
+## Phase 5 — Compose response
 
 1. **Language:** the memory's configured language (from
    `.yoke-memory/config.json`); technical terms in English are accepted
@@ -290,27 +254,27 @@ step — even when no entities were read (`entities_read: 0`).
 | # | Rule |
 |---|---|
 | 1 | NEVER `git clone`, `git pull`, or `git fetch` against the registered memory. Reads are filesystem-only. |
-| 2 | NEVER write inside the registered memory — `/ask` is read-only. |
-| 3 | NEVER load full canonical memory into context — cap at 15 entities total. |
-| 4 | ALWAYS write the YAML trace entry — bypass detection depends on it. |
+| 2 | NEVER write inside the registered memory — `/ask` is read-only against canonical memory. |
+| 3 | NEVER write anywhere on disk — `/ask` is a pure read; the skill produces only the conversational response. |
+| 4 | NEVER load full canonical memory into context — cap at 15 entities total. |
 | 5 | ALWAYS use bare wikilinks (`[[name]]`, never `[[dir/name]]`). |
-| 6 | ALWAYS resolve `MEMORY_PATH` via Part 1's `resolve-memory.sh` — never assume CWD is the memory. |
+| 6 | ALWAYS resolve `MEMORY_PATH` via `lib/canonical-memory/resolve-memory.sh` — never assume CWD is the memory. |
 | 7 | NEVER fabricate information not found in the memory. |
 | 8 | Fleeting notes ALWAYS carry the `(source: fleeting note — unconsolidated)` disclaimer. |
 | 9 | Self-assessment outcomes route through Phase 5 messaging only — `/teach` and graphify are NOT invoked from this skill in v0. |
+| 10 | NEVER require an active task. The skill is source-agnostic and works regardless of host-project working-memory state. |
 
 ## Anti-patterns
 
-- Cloning or pulling the substrate on read — retired in v1.2.
-- Reading the canonical memory directly without the trace write —
-  bypass.
+- Cloning or pulling the substrate on read.
 - Following more than 1 wikilink hop — context explosion.
 - Returning more than 15 entity reads — context budget violation.
 - Inventing facts to fill gaps — fabrication.
+- Aborting because no active task is set — `/yoke:ask` is source-agnostic.
+- Writing any file as a side-effect of the read — the skill is pure.
 
 ## See also
 
-- `.vibeflow/patterns/memory-model.md` — the read mediator role.
-- `.vibeflow/conventions.md` — bypass-detection rule.
-- `lib/canonical-memory/resolve-memory.sh` — Part 1 resolution.
-- `lib/working-memory/paths.sh` — `wm_query_trace_path`.
+- `.vibeflow/patterns/memory-model.md` — the read-mediator role.
+- `.vibeflow/patterns/roles.md` — the canonical-memory read contract.
+- `lib/canonical-memory/resolve-memory.sh` — memory resolution.

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -117,7 +117,7 @@ Create:
   .current
   runtime/
   ```
-  Rationale: archive categories (`prds/`, `tech-specs/`, `acceptance-contracts/`, `contracts/`, `query-traces/`) are versioned by the host project. Only the per-worktree active-task pointer (`.current`) and the runtime working directory (`runtime/`) are ephemeral. See `lib/working-memory/paths.sh`.
+  Rationale: archive categories (`prds/`, `tech-specs/`, `acceptance-contracts/`, `contracts/`) are versioned by the host project. Only the per-worktree active-task pointer (`.current`) and the runtime working directory (`runtime/`) are ephemeral. See `lib/working-memory/paths.sh`.
 
 Do **not** pre-create archive category folders or any flat working-memory files (`prd.md`, `tech-spec.md`, etc.) — those are created lazily by `/yoke:discover` and downstream skills. After bootstrap completes, `.yoke/` contains exactly `config.yaml` and `.gitignore`.
 

--- a/skills/drift-sense/SKILL.md
+++ b/skills/drift-sense/SKILL.md
@@ -42,9 +42,9 @@ Reads the canonical-memory repo via the cached path
 
 - **Staleness:** items not consulted for > N days (default 30; configurable
   via `.yoke/config.yaml` `overrides.drift_sense.staleness_max_days`).
-  Source for "consulted" is the union of every per-task query-trace under
-  `.yoke/query-traces/*.md` (versioned archive); otherwise
-  `last_validated` from frontmatter.
+  Source for "consulted" is the entry's `last_validated` frontmatter
+  field. (The per-task query-trace source was retired in
+  ask-source-agnostic-read Part 1 — `/yoke:ask` no longer emits a trace.)
 - **Model drift:** items with `model_calibrated_against` ≠ the configured
   current model (env `YOKE_MODEL_ID` or default `claude-opus-4-7`).
 - **Contradictions:** items with `contradicts_with` referring to entries
@@ -52,11 +52,13 @@ Reads the canonical-memory repo via the cached path
 
 ### `--target traces`
 
-Globs `.yoke/contracts/*.md` and `.yoke/query-traces/*.md` from completed
-tasks (those merged to main of the host project — every task with files
-in those versioned archive folders) and detects recurring patterns that
-never reached canonization. Invokes
-`lib/canonical-memory/trace-analyzer.sh`:
+Globs `.yoke/contracts/*.md` from completed tasks (those merged to main
+of the host project — every task with files in this versioned archive
+folder) and detects recurring patterns that never reached canonization.
+Invokes `lib/canonical-memory/trace-analyzer.sh`. (The
+`.yoke/query-traces/*.md` source was retired in
+ask-source-agnostic-read Part 1; the mode now relies on contracts
+alone.)
 
 - Counts occurrences of each contract `topic:` across tasks.
 - Flags topics that recur ≥ N times (default 3) but have no
@@ -124,7 +126,8 @@ sensing should be a high-signal channel, not a noisy one.
 - `.yoke/config.yaml` exists (recommended; standalone mode possible).
 - For canonical-memory mode: `canonical_memory.url` is configured.
 - For traces mode: at least one completed task has emitted
-  `.yoke/contracts/<slug>.md` or `.yoke/query-traces/<slug>.md`.
+  `.yoke/contracts/<slug>.md`. (`.yoke/query-traces/<slug>.md` retired
+  in ask-source-agnostic-read Part 1.)
 - For codebase mode: host `CLAUDE.md` declares a detector under
   `## Dead code`, `## Linting`, or `## Build`.
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -46,12 +46,12 @@ termination.
     message (exit codes 3 or 4).
 - Run `hooks/pre-implementation.sh`.
 - Ensure `.yoke/runtime/` and `.yoke/contracts/` exist (`mkdir -p`).
-  Initialize `wm_progress_path` (`.yoke/runtime/progress.md`),
-  `wm_contracts_path "$slug"` (`.yoke/contracts/<slug>.md`), and
-  `wm_query_trace_path "$slug"` (`.yoke/query-traces/<slug>.md`) from
-  `templates/progress.md`, `templates/contracts.md`, and an empty
-  `# Query trace` header respectively if they don't exist (cycle 0
-  entries).
+  Initialize `wm_progress_path` (`.yoke/runtime/progress.md`) and
+  `wm_contracts_path "$slug"` (`.yoke/contracts/<slug>.md`) from
+  `templates/progress.md` and `templates/contracts.md` respectively if
+  they don't exist (cycle 0 entries). The `query-trace` initialization
+  was retired in ask-source-agnostic-read Part 1 — `/yoke:ask` is now a
+  pure read and emits no trace.
 
 ### 2. Cycle loop
 
@@ -70,10 +70,11 @@ For each cycle (numbered starting at 1):
      - Current runtime progress at `wm_progress_path` (last cycle's
        state).
      - Current sprint contracts at `wm_contracts_path "$slug"`.
-     - Current query trace at `wm_query_trace_path "$slug"`
-       (Orchestrator's prior consult output for this loop).
      - Last `verify-acceptance.sh` snapshot from
        `$(wm_snapshots_dir)/cycle-<N-1>.yaml` (if any).
+     - Canonical-memory context: invoke `/yoke:ask` via the Skill
+       tool on demand (no on-disk handoff; the skill is a pure
+       source-agnostic read).
 
      Writes code targeting the next failing Acceptance Contract
      criterion; persists `wm_progress_path` at end of turn.
@@ -84,7 +85,8 @@ For each cycle (numbered starting at 1):
        `$(wm_snapshots_dir)/cycle-<N-1>.yaml`.
      - Current sprint contracts at `wm_contracts_path` and runtime
        progress at `wm_progress_path` (read-only).
-     - Current query trace at `wm_query_trace_path`.
+     - Canonical-memory context: invoke `/yoke:ask` via the Skill
+       tool on demand.
 
      Emits structured JSON verdicts per criterion against the
      freshest snapshot's sensor output; appends sprint contracts to
@@ -93,13 +95,11 @@ For each cycle (numbered starting at 1):
 
    - **Orchestrator (`agents/orchestrator.md`)** — input:
      - `mode=consult+monitor`, `cycle=<N>`, `slug=<active slug>`.
-     - Current `wm_progress_path`, `wm_contracts_path`,
-       `wm_query_trace_path`.
+     - Current `wm_progress_path`, `wm_contracts_path`.
      - Last `verify-acceptance.sh` snapshot.
 
-     Consults canonical memory via
-     `lib/canonical-memory/query.sh` for patterns relevant to the
-     next failing criterion; appends to `wm_query_trace_path`.
+     Consults canonical memory by invoking `/yoke:ask` via the Skill
+     tool when context is needed; reasons over the response inline.
      Monitors for Generator↔Validator divergence; on divergence
      invokes `lib/ralph-loop/escalate.sh` to emit the Trigger-4
      packet (written to `wm_trigger4_packet_path`).
@@ -107,8 +107,8 @@ For each cycle (numbered starting at 1):
    Issue the three Task calls in a **single assistant turn** so
    they execute concurrently. Per-agent file-write contracts (in
    `agents/*.md`) prevent within-batch collisions: Generator owns
-   the progress file, Orchestrator owns the query trace, and the
-   contracts file is appended only on consensus events post-batch.
+   the progress file; the contracts file is appended only on
+   consensus events post-batch.
 
 2. **Sensor execution (deterministic).** Run
    `hooks/verify-acceptance.sh` (default arg resolves to
@@ -149,9 +149,9 @@ loop converged (MERGE-READY) or paused (Trigger-4 / hard-bound /
 infeasibility). Issue a **single Orchestrator-only Task call** with
 input `mode=canonize`:
 
-- Input includes `wm_progress_path`, `wm_contracts_path`,
-  `wm_query_trace_path`, all `$(wm_snapshots_dir)/cycle-*.yaml`,
-  and the loop's termination reason
+- Input includes `wm_progress_path`, `wm_contracts_path`, all
+  `$(wm_snapshots_dir)/cycle-*.yaml`, and the loop's termination
+  reason
   (`merge-ready` | `divergence` | `contract-conflict` |
   `hard-bound` | `infeasibility`).
 - Orchestrator (in canonize mode) invokes `/yoke:preserve` via the

--- a/skills/preserve/SKILL.md
+++ b/skills/preserve/SKILL.md
@@ -123,8 +123,9 @@ When the caller supplies natural text or a path to a `.yoke/` directory
 (the Orchestrator's loop-termination handoff), do this:
 
 1. **If the input is a path to a `.yoke/<task-slug>/` directory:** read
-   `progress.md`, `contracts.md`, and `query-traces/<slug>.md`.
-   Combine into the analysis blob.
+   `progress.md` and `contracts.md`. Combine into the analysis blob.
+   (The `query-traces/<slug>.md` source was retired in
+   ask-source-agnostic-read Part 1.)
 2. **Otherwise:** treat as raw text.
 3. Identify mentioned entities by name, alias, or reference (people:
    "First Last"; actors: service names / repos; teams: squad names;

--- a/tests/smoke/folder-isolation.test.sh
+++ b/tests/smoke/folder-isolation.test.sh
@@ -6,12 +6,15 @@
 #   (a) every file written under `.yoke/` lands in an allowed location
 #       (config.yaml, .gitignore, .current, prds/<slug>.md,
 #        tech-specs/<slug>.md, acceptance-contracts/<slug>.md,
-#        contracts/<slug>.md, query-traces/<slug>.md, runtime/<file>);
+#        contracts/<slug>.md, runtime/<file>);
 #   (b) no flat file `.yoke/<file>.md` for any of
-#       prd|tech-spec|acceptance-contract|contracts|progress|query-trace
-#       is ever created by the simulated flow;
+#       prd|tech-spec|acceptance-contract|contracts|progress is ever
+#       created by the simulated flow;
 #   (c) no skill or hook constructs `.yoke/<file>.md` paths via string
 #       concatenation — every path goes through `lib/working-memory/paths.sh`.
+#
+# Note: the `query-traces/` category was retired in
+# ask-source-agnostic-read Part 1 — the trace concept no longer exists.
 #
 # The skills themselves are prose-driven; this test simulates the flow by
 # invoking the path helper directly and checking that no other location
@@ -40,7 +43,7 @@ echo "[c] Hardcoded flat-path scan"
 # *defines* layout strings — it must be excluded from the flat-path ban.
 # Exclude documentation occurrences where the string is explicitly
 # forbidden or used as a "no flat file like X" comparison.
-flat_hits=$(grep -RIn -E '\.yoke/(prd|tech-spec|acceptance-contract|contracts|progress|query-trace)\.md' \
+flat_hits=$(grep -RIn -E '\.yoke/(prd|tech-spec|acceptance-contract|contracts|progress)\.md' \
               skills/ lib/ hooks/ \
               2>/dev/null \
               | grep -v 'paths\.sh' \
@@ -54,12 +57,15 @@ else
   printf '%s\n' "$flat_hits" | sed 's/^/    /' >&2
 fi
 
-# Also assert the singular query-trace.md is fully gone from skills + lib.
-qt_hits=$(grep -RIn '\.yoke/query-trace\.md' skills/ lib/ hooks/ 2>/dev/null || true)
+# query-traces/ retired in ask-source-agnostic-read Part 1; ensure no
+# live references survived in skills/ or lib/.
+qt_hits=$(grep -RIn -E '\.yoke/query-traces?(/<slug>)?\.md' skills/ lib/ hooks/ 2>/dev/null \
+           | grep -viE 'do not (read|write)|does not exist|retired|removed' \
+           || true)
 if [ -z "$qt_hits" ]; then
-  pass "(c) singular .yoke/query-trace.md removed everywhere"
+  pass "(c) no live query-trace references in skills/ lib/ hooks/"
 else
-  err "(c) singular .yoke/query-trace.md still referenced:"
+  err "(c) live query-trace references found:"
   printf '%s\n' "$qt_hits" | sed 's/^/    /' >&2
 fi
 
@@ -119,9 +125,7 @@ MD
   echo "1" > "$(wm_cycle_counter_path)"
   printf 'results:\n  - sensor: smoke\n    status: pass\n' > "$(wm_snapshots_dir)/cycle-1.yaml"
 
-  # Ask: query-trace (versioned).
-  mkdir -p "$(dirname "$(wm_query_trace_path)")"
-  printf '# Query trace\n' > "$(wm_query_trace_path)"
+  # /yoke:ask is a pure read in v1.2 — no working-memory side effects.
 )
 
 # Now scan everything written under .yoke/ and validate locations.
@@ -139,7 +143,6 @@ while IFS= read -r f; do
     .yoke/tech-specs/"$SLUG".md) ;;
     .yoke/acceptance-contracts/"$SLUG".md) ;;
     .yoke/contracts/"$SLUG".md) ;;
-    .yoke/query-traces/"$SLUG".md) ;;
     .yoke/runtime/*) ;;
     *) unexpected+=("$rel") ;;
   esac
@@ -159,7 +162,6 @@ forbidden=(
   "$TMP/.yoke/acceptance-contract.md"
   "$TMP/.yoke/contracts.md"
   "$TMP/.yoke/progress.md"
-  "$TMP/.yoke/query-trace.md"
 )
 flat_present=()
 for f in "${forbidden[@]}"; do

--- a/tests/smoke/sprint-2.test.sh
+++ b/tests/smoke/sprint-2.test.sh
@@ -102,10 +102,11 @@ for skill in discover tech-spec; do
   fi
 done
 
-# 8. /yoke:ask is the canonical-memory adaptive read skill
-#    (Part 3 of the bedrock canonical-memory port retired direct query.sh
-#    invocation — the skill now resolves the memory via Part 1's
-#    resolve-memory.sh and reads the filesystem directly).
+# 8. /yoke:ask is the canonical-memory adaptive read skill.
+#    Part 3 of the bedrock canonical-memory port retired the standalone
+#    query.sh shell-out; ask-source-agnostic-read Part 1 retired the
+#    query-trace write and the .yoke/.current pre-condition. The skill
+#    is now a pure source-agnostic read.
 ask="skills/ask/SKILL.md"
 ask_allowed=$(awk '/^allowed-tools:/{print; exit}' "$ask" || true)
 if echo "$ask_allowed" | grep -qw "Task"; then
@@ -113,12 +114,22 @@ if echo "$ask_allowed" | grep -qw "Task"; then
 else
   pass "/yoke:ask allowed-tools excludes Task"
 fi
+if echo "$ask_allowed" | grep -qw "Write"; then
+  err "/yoke:ask allowed-tools includes Write (skill must be pure read)"
+else
+  pass "/yoke:ask allowed-tools excludes Write (pure read)"
+fi
 grep -q "resolve-memory.sh" "$ask" \
   && pass "/yoke:ask resolves the active memory via Part 1's lib" \
   || err "/yoke:ask does not reference resolve-memory.sh"
-grep -qE 'query-traces/<slug>\.md|wm_query_trace_path' "$ask" \
-  && pass "/yoke:ask writes to versioned .yoke/query-traces/<slug>.md" \
-  || err "/yoke:ask does not write query trace"
+if grep -qE 'query-traces|wm_query_trace_path|\.yoke/\.current' "$ask"; then
+  err "/yoke:ask still references retired query-trace / active-task pre-condition"
+else
+  pass "/yoke:ask is source-agnostic (no query-trace, no active-task pre-condition)"
+fi
+grep -qiE 'source-agnostic|callable from any|no active-task' "$ask" \
+  && pass "/yoke:ask declares its source-agnostic contract" \
+  || err "/yoke:ask missing source-agnostic declaration"
 grep -qiE 'never.*(clone|pull|fetch)' "$ask" \
   && pass "/yoke:ask declares the no-clone invariant (Part 3 DoD-1)" \
   || err "/yoke:ask missing no-clone invariant"

--- a/tests/smoke/sprint-5.test.sh
+++ b/tests/smoke/sprint-5.test.sh
@@ -83,24 +83,16 @@ grep -qE "Termination|termination|canonize handoff" "$imp" \
   && pass "$imp documents termination canonization handoff" \
   || err "$imp missing termination handoff documentation"
 
-# 5. /yoke:ask — adaptive read against the registered memory (Part 3 of
+# 5. /yoke:ask — adaptive read against the registered memory. Part 3 of
 #    the bedrock canonical-memory port retired the query.sh shell-out;
-#    the skill now resolves via Part 1's resolve-memory.sh and reads
-#    the filesystem directly).
+#    ask-source-agnostic-read Part 1 retired the query-trace write.
+#    Detailed shape assertions for /yoke:ask now live in sprint-2; here
+#    we only verify the Orchestrator's read path (Mode A) is wired to the
+#    Part 1 resolution lib.
 ask="skills/ask/SKILL.md"
-grep -qE 'query-traces|query-trace' "$ask" \
-  && pass "$ask references the query-traces directory" \
-  || err "$ask does not declare query trace"
 grep -q "resolve-memory.sh" "$ask" \
   && pass "$ask resolves the active memory via Part 1's lib" \
   || err "$ask does not reference resolve-memory.sh"
-
-ask_allowed=$(awk '/^allowed-tools:/{print; exit}' "$ask" || true)
-if echo "$ask_allowed" | grep -qw "Task"; then
-  err "$ask allowed-tools includes Task (should not spawn subagents)"
-else
-  pass "$ask does not spawn subagents (no Task)"
-fi
 
 # 6. canonization-criteria.sh against missing contracts.md
 tmpdir="$(mktemp -d)"
@@ -244,22 +236,11 @@ echo "$out" | grep -qi "auto-merge" \
   || err "propose-write.sh missing auto-merge in dry-run output"
 fi  # end-skip block opened earlier (Part 4 retired propose-write.sh)
 
-# 13. /yoke:ask trace contract (Part 3): the SKILL document declares the
-#     YAML trace shape that lands in .yoke/query-traces/<slug>.md. The
-#     standalone query.sh path was retired; runtime trace verification
-#     is exercised by tests/smoke/ask-no-clone.test.sh.
-grep -qE 'mode: ask' "$ask" \
-  && pass "/yoke:ask trace declares 'mode: ask' value" \
-  || err "/yoke:ask trace missing 'mode: ask'"
-grep -q 'entities_read' "$ask" \
-  && pass "/yoke:ask trace records entities_read count" \
-  || err "/yoke:ask trace missing entities_read field"
-grep -q 'capped' "$ask" \
-  && pass "/yoke:ask trace records capping flag" \
-  || err "/yoke:ask trace missing capped flag"
-grep -q 'invoker' "$ask" \
-  && pass "/yoke:ask trace records invoker" \
-  || err "/yoke:ask trace missing invoker"
+# 13. ask-source-agnostic-read Part 1 retired the YAML query-trace
+#     contract. The detailed shape assertions formerly here are now
+#     deleted (the trace no longer exists); /yoke:ask is verified by
+#     sprint-2 (allowed-tools, source-agnostic declaration) and
+#     ask-no-clone (no clone/pull/fetch on resolution).
 
 # 14. Anti-scope: status skill still placeholder.
 # Part 6 of the bedrock canonical-memory port (2026-04-25) extended


### PR DESCRIPTION
## Summary

- `/yoke:ask` becomes a pure source-agnostic read against the registered canonical memory — no `.yoke/.current` pre-condition, no on-disk side effects, callable from any caller (Generator, Validator, Orchestrator, spec-phase skills, ad-hoc human queries).
- Retires the `.yoke/query-traces/<slug>.md` archive, the `wm_query_trace_path` helper, and the trace-as-bypass-detection contract end-to-end. Bypass discipline becomes declarative — direct filesystem reads of the registered memory are prohibited; the Orchestrator may raise observed bypasses as Trigger-4 sprint-contract divergence.
- Six-part split (PRD + 6 specs + 6 audits in `.vibeflow/`): skill/lib → runtime agents → tests → doctrine → repo+main docs → trailing docs+CHANGELOG.

## Breaking

Host projects already bootstrapped against v1.1 must delete the orphaned `.yoke/query-traces/` directory if it exists:

\`\`\`bash
rm -rf .yoke/query-traces/
\`\`\`

No further migration required — skills, agents, templates, and doctrine all ship with the new contract on \`/plugin upgrade\`.

## Test plan

- [x] 13/13 smoke tests pass: \`sprint-2/3/4/5/6/7/8\`, \`ask-no-clone\`, \`folder-isolation\`, \`memory-migration\`, \`preserve-model-c\`, \`status-readonly\`, \`teach-ingest\`
- [x] \`lib/working-memory/paths.sh\` smoke-loads cleanly under bash 4; \`wm_query_trace_path\` confirmed absent; remaining \`wm_*\` helpers resolve as functions
- [x] Repo-wide grep confirms no live \`wm_query_trace_path\` or \`.yoke/query-traces/<slug>.md\` mechanism references outside historical narrative (\`docs/lineage.md\`, \`.vibeflow/decisions.md\`) or negative-assertion guards (\`tests/smoke/sprint-2.test.sh\` regex asserting the contract has not returned)
- [x] Cross-document consistency: \`CLAUDE.md\`, \`.vibeflow/patterns/memory-model.md\`, and \`docs/architecture.md\` all describe the same 5-file working-memory tuple
- [ ] Verify on a fresh \`/plugin install\` before tagging the next release; bump \`plugin.json\`, \`marketplace.json\`, and \`README.md\` from 1.1.0 to the chosen release version (kept at \`[Unreleased]\` in the CHANGELOG to avoid cascading test-assertion edits inside this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)