### PR TITLE
feat: post-implement runtime cleanup + .current into runtime/

### DIFF
--- a/.vibeflow/audits/current-into-runtime-part-1-audit.md
+++ b/.vibeflow/audits/current-into-runtime-part-1-audit.md
@@ -1,0 +1,172 @@
+# Audit Report: current-into-runtime — Part 1 (functional)
+
+> Audited 2026-04-27 against
+> `.vibeflow/specs/current-into-runtime-part-1.md`. Full framework test
+> matrix (18 suites) PASS. Budget revision (≤ 8) honored exactly.
+
+**Verdict: PASS**
+
+## DoD Checklist
+
+- [x] **1. `WM_CURRENT_FILE` resolves to `${WM_RUNTIME_DIR}/.current`;
+      `wm_active_slug` / `wm_set_active` / `wm_clear_active` operate on
+      the new path; `wm_set_active` ensures `${WM_RUNTIME_DIR}` exists.**
+      Evidence: `lib/working-memory/paths.sh:50-51` shows the constant
+      reorder (`WM_RUNTIME_DIR` declared before `WM_CURRENT_FILE`) and
+      the new path; `paths.sh:81-85` (`wm_set_active`) does
+      `mkdir -p "$WM_RUNTIME_DIR"` before writing. The three accessors
+      (`wm_active_slug` line 70, `wm_set_active` line 81,
+      `wm_clear_active` line 88) all reference `WM_CURRENT_FILE`
+      unchanged — the constant indirection takes care of the path
+      change. Smoke (e) in
+      `tests/working-memory.test.sh` reads the slug from
+      `.yoke/runtime/.current` and asserts byte length — PASS.
+
+- [x] **2. `_WM_GITIGNORE_CONTENT` is `runtime/`; notice text updated.**
+      Evidence: `lib/working-memory/cleanup.sh:39` — single-line literal
+      `'runtime/'`. Notice at `cleanup.sh:57` reads
+      `[yoke] repaired .yoke/.gitignore (wrote: runtime/)`. Smoke (h)
+      in `tests/working-memory.test.sh:204-244` re-passes against the
+      new `expected_gi_full='runtime/'` and the empty-file incomplete
+      fixture. Result: PASS.
+
+- [x] **3. `skills/bootstrap/SKILL.md` Step 5 declares single-line
+      gitignore content with updated rationale.**
+      Evidence: `skills/bootstrap/SKILL.md:115-120` — code block
+      contains exactly `runtime/`; rationale prose names
+      `runtime/.current` as the per-worktree pointer location.
+      `tests/bootstrap.test.sh` PASS reproduces the expected literal
+      end-to-end (assertion at line 84-85: `expected='runtime/'`).
+
+- [x] **4. `hooks/verify-acceptance.sh` comment uses new path.**
+      Evidence: `hooks/verify-acceptance.sh:24` reads
+      `comes from .yoke/runtime/.current`.
+
+- [x] **5. All four impacted test files PASS after the change.**
+      Evidence:
+      - `tests/working-memory.test.sh`: PASS (9/9), including new
+        gitignore expectation (d) and `runtime/.current` size
+        assertion (e).
+      - `tests/bootstrap.test.sh`: PASS (7/7), gitignore content
+        check on the new literal.
+      - `tests/perf-quickwins-part-1.test.sh`: PASS, fixture writes
+        slug to `.yoke/runtime/.current`.
+      - `tests/ack-sensors-inferential.test.sh`: PASS, helper-tmp
+        fixture creates `.yoke/runtime/` and writes
+        `.yoke/runtime/.current`.
+
+- [x] **6. Craftsmanship — zero hardcoded `.yoke/.current` outside the
+      five SKILL.md files Part 2 will touch.**
+      Evidence:
+      `grep -rn "\.yoke/\.current" lib/ hooks/ skills/bootstrap/SKILL.md tests/ agents/`
+      returns no hits. The remaining occurrences are confined to
+      `skills/discover/SKILL.md`, `skills/status/SKILL.md`,
+      `skills/tech-spec/SKILL.md`, `skills/acceptance-contract/SKILL.md`,
+      `skills/implement/SKILL.md` — exactly the Part-2 scope. No
+      conventions.md Don'ts violated; no canonical-memory access added,
+      no agentic surfaces added.
+
+- [x] **7. Integration smoke — `wm_runtime_cleanup "merge-ready" "0"`
+      wipes `.current` along with cycle artifacts.**
+      Evidence: `wm_wipe_runtime` (`paths.sh:241`) uses
+      `find "$WM_RUNTIME_DIR" -mindepth 1 -delete` — path-agnostic, so
+      `.current` (now under runtime/) is wiped automatically without
+      special-casing. Runtime-cleanup smoke (f) in
+      `tests/working-memory.test.sh:147-167` still PASSes — the test
+      seeds runtime with progress, cycle counter, and a snapshot, runs
+      cleanup with `(merge-ready, 0)`, then asserts an empty runtime
+      tree (`find "$(wm_runtime_dir)" -mindepth 1 -print | wc -l == 0`).
+      The seed didn't include `.current`, but the path-agnostic find
+      sweep guarantees the same result if it had.
+
+## Pattern Compliance
+
+- [x] **`patterns/memory-model.md` — working-memory lifetime ("task /
+      sprint / PR scope").** Consolidating `.current` into
+      `runtime/` reinforces the lifetime claim — there is now a single
+      ephemeral surface and a single ignore rule. The pattern's
+      working-memory file table still maps writers/readers correctly:
+      `.current` is a write product of `wm_set_active` (called by
+      `/yoke:discover`) and a read product of every skill that uses
+      `wm_active_slug`. No table edits needed.
+
+- [x] **`patterns/ralph-loop.md` — termination semantics.** No new
+      branch in the termination path; `wm_runtime_cleanup`'s gating
+      logic is unchanged (still `merge-ready && canonize_exit == 0`).
+      `.current` simply joins the set of files cleared by the
+      pre-existing `wm_wipe_runtime` primitive.
+
+- [x] **`patterns/plugin-structure.md` — repo layout discipline.**
+      The canonical layout-doc comment at `paths.sh:7-22` is updated
+      to show `.current` under `runtime/`, keeping the
+      single-source-of-truth tree current.
+
+- [x] **conventions.md "Environment designers, not code writers".**
+      The simplification reduces gitignore rules from 2 → 1 and
+      collapses two adjacent ephemeral surfaces into one — fewer
+      failure modes for users to hit.
+
+- [x] **conventions.md "Back-pressure: success silent, failures
+      verbose".** `wm_gitignore_self_heal` notice line shrinks to
+      match the simpler content; silent-on-correct still holds.
+
+## Convention Violations
+
+None.
+
+## Tests
+
+Full framework test matrix — 18 / 18 PASS:
+
+| Suite | Result |
+|---|---|
+| acceptance-and-sensors | PASS |
+| ack-sensors-catalog | PASS |
+| ack-sensors-discoverers | PASS |
+| ack-sensors-inferential | PASS |
+| ack-sensors-parallel | PASS |
+| agents-surface | PASS |
+| bootstrap | PASS |
+| canonical-memory-read | PASS |
+| canonical-memory-write | PASS |
+| docs-and-lineage | PASS |
+| example-project | PASS |
+| perf-quickwins-part-1 | PASS |
+| perf-quickwins-part-2 | PASS |
+| perf-quickwins-part-3 | PASS |
+| plugin-distribution | PASS |
+| ralph-loop-bounds | PASS |
+| skills-surface | PASS |
+| working-memory | PASS |
+
+## Architectural Decision Recorded
+
+This audit resolves the runtime-cleanup spec's Open Question #3
+("`.current` cleanup. Leaning leave-it") **against leave-it**: the
+active-task pointer now lives inside `runtime/` and is cleared on
+MERGE-READY + canonize-success along with cycle artifacts.
+Trade-off accepted: "last task touched" signal is lost on
+MERGE-READY exit; mitigation is the host project's git history (PR
+URLs printed in the canonize summary) carrying that context.
+
+## Gaps
+
+None. All 7 DoD checks pass; full framework test matrix green; no
+convention violations; pattern compliance preserved.
+
+## Verdict
+
+**PASS** — Ready to ship.
+
+Files changed (8 of ≤ 8 budget):
+1. `lib/working-memory/paths.sh`
+2. `lib/working-memory/cleanup.sh`
+3. `skills/bootstrap/SKILL.md`
+4. `hooks/verify-acceptance.sh`
+5. `tests/working-memory.test.sh`
+6. `tests/bootstrap.test.sh`
+7. `tests/perf-quickwins-part-1.test.sh`
+8. `tests/ack-sensors-inferential.test.sh`
+
+Next: implement `.vibeflow/specs/current-into-runtime-part-2.md`
+(prose alignment in 5 downstream skill SKILL.md files).

--- a/.vibeflow/audits/current-into-runtime-part-2-audit.md
+++ b/.vibeflow/audits/current-into-runtime-part-2-audit.md
@@ -1,0 +1,108 @@
+# Audit Report: current-into-runtime — Part 2 (doc alignment)
+
+> Audited 2026-04-27 against
+> `.vibeflow/specs/current-into-runtime-part-2.md`. Pure prose
+> substitution across 5 SKILL.md files; full framework test matrix
+> (18 suites) PASS.
+
+**Verdict: PASS**
+
+## DoD Checklist
+
+- [x] **1. `skills/discover/SKILL.md` has zero `.yoke/.current`
+      occurrences; every reference reads `.yoke/runtime/.current`.**
+      Evidence: `grep -c "\.yoke/\.current" skills/discover/SKILL.md`
+      returns `0`; `grep -c "\.yoke/runtime/\.current"
+      skills/discover/SKILL.md` returns `5`. Original gen-spec
+      occurrence count was 5; all five replaced.
+- [x] **2. `skills/status/SKILL.md` has zero `.yoke/.current`.**
+      Evidence: 0 old / 2 new.
+- [x] **3. `skills/tech-spec/SKILL.md` has zero `.yoke/.current`.**
+      Evidence: 0 old / 2 new.
+- [x] **4. `skills/acceptance-contract/SKILL.md` has zero
+      `.yoke/.current`.** Evidence: 0 old / 3 new.
+- [x] **5. `skills/implement/SKILL.md` has zero `.yoke/.current`.**
+      Evidence: 0 old / 3 new.
+- [x] **6. Craftsmanship — repo-wide grep shows zero hits in live
+      surfaces.** Evidence: `grep -rn "\.yoke/\.current" lib/ hooks/
+      skills/ agents/ tests/ templates/ docs/` returns no hits.
+      `.vibeflow/` retains 65 historical mentions
+      (audits/decisions/specs/prds — immutable history per spec
+      anti-scope). All live surfaces clean.
+
+## Pattern Compliance
+
+- [x] **`patterns/plugin-structure.md` — repo layout discipline.**
+      Doc-prose accuracy now matches the canonical layout-doc comment
+      in `lib/working-memory/paths.sh:7-22` (updated by Part 1).
+      No drift between code and prose.
+
+- [x] **conventions.md "Lineage is documented honestly".** Skill
+      SKILL.md references to the active-task pointer accurately
+      reflect what the code does after Part 1 landed. No misleading
+      `.yoke/.current` literals remain in user-facing instructions.
+
+## Convention Violations
+
+None.
+
+## Tests
+
+Full framework test matrix — 18 / 18 PASS. Although Part 2 is
+doc-only (no executable behavior), running the matrix confirms
+that `skills-surface.test.sh` (which scans SKILL.md content for
+declared invariants) does not regress against any of the rewritten
+references.
+
+| Suite | Result |
+|---|---|
+| acceptance-and-sensors | PASS |
+| ack-sensors-catalog | PASS |
+| ack-sensors-discoverers | PASS |
+| ack-sensors-inferential | PASS |
+| ack-sensors-parallel | PASS |
+| agents-surface | PASS |
+| bootstrap | PASS |
+| canonical-memory-read | PASS |
+| canonical-memory-write | PASS |
+| docs-and-lineage | PASS |
+| example-project | PASS |
+| perf-quickwins-part-1 | PASS |
+| perf-quickwins-part-2 | PASS |
+| perf-quickwins-part-3 | PASS |
+| plugin-distribution | PASS |
+| ralph-loop-bounds | PASS |
+| skills-surface | PASS |
+| working-memory | PASS |
+
+## Gaps
+
+None. All 6 DoD checks pass; full framework test matrix green; no
+convention violations; pattern compliance preserved.
+
+## Verdict
+
+**PASS** — Ready to ship.
+
+Files changed (5 of ≤ 5 budget):
+1. `skills/discover/SKILL.md`
+2. `skills/status/SKILL.md`
+3. `skills/tech-spec/SKILL.md`
+4. `skills/acceptance-contract/SKILL.md`
+5. `skills/implement/SKILL.md`
+
+## Combined work summary (3 specs across 2 sessions)
+
+- `runtime-cleanup` — PASS — automatic runtime/ cleanup at MERGE-READY
+  + gitignore self-heal + tracked-files hint.
+  See `.vibeflow/audits/runtime-cleanup-audit.md`.
+- `current-into-runtime-part-1` — PASS — `.current` moved into
+  `runtime/`; gitignore collapsed to single line; all impacted tests
+  updated atomically.
+  See `.vibeflow/audits/current-into-runtime-part-1-audit.md`.
+- `current-into-runtime-part-2` — PASS (this audit) — 5 SKILL.md
+  files aligned with new path.
+
+All work is DONE. The implement+audit loop terminates: 3 specs
+shipped, 16 files changed in total, 0 test regressions, 0 convention
+violations.

--- a/.vibeflow/audits/runtime-cleanup-audit.md
+++ b/.vibeflow/audits/runtime-cleanup-audit.md
@@ -1,0 +1,182 @@
+# Audit Report: runtime-cleanup
+
+> Audited 2026-04-27 against `.vibeflow/specs/runtime-cleanup.md`.
+
+**Verdict: PASS**
+
+## DoD Checklist
+
+- [x] **1. Cleanup deletes contents of `wm_runtime_dir` for the active
+      task on a MERGE-READY exit, only after the canonize handoff
+      returns exit 0; the directory itself remains.**
+      Evidence: `lib/working-memory/cleanup.sh:81-94` — `wm_runtime_cleanup`
+      requires both args, returns early when `reason != "merge-ready"`
+      or `canonize_exit != "0"`, and otherwise delegates to
+      `wm_wipe_runtime` (which uses
+      `find "$WM_RUNTIME_DIR" -mindepth 1 -delete`,
+      preserving the directory). Smoke (f) in
+      `tests/working-memory.test.sh:163-167` writes
+      `progress.md`, a cycle counter, and a snapshot, calls cleanup
+      with `(merge-ready, 0)`, then asserts zero remaining files.
+      Result: PASS.
+
+- [x] **2. No deletion on paused exits (`divergence`,
+      `contract-conflict`, `hard-bound`, `infeasibility`).**
+      Evidence: same gate at `cleanup.sh:88-93`. Smoke (g) in
+      `tests/working-memory.test.sh:172-191` exercises both the
+      paused-exit case (`hard-bound`) and the canonize-failure case
+      (`merge-ready`, exit 7); both leave runtime contents intact.
+      Result: PASS.
+
+- [x] **3. Gitignore self-heal at preflight: writes/repairs missing or
+      incomplete `.yoke/.gitignore`; exactly one notice line on
+      repair, zero lines when correct.**
+      Evidence: `cleanup.sh:48-58` — branches: file-correct returns
+      silently; otherwise overwrites with `_WM_GITIGNORE_CONTENT`
+      (`.current\nruntime/`) and prints
+      `[yoke] repaired .yoke/.gitignore (wrote: .current, runtime/)`.
+      Smoke (h) in `tests/working-memory.test.sh:204-244` covers
+      missing-file, incomplete-file, and already-correct cases;
+      verifies output cardinality and final content. Wired into
+      `/yoke:implement` preflight at `skills/implement/SKILL.md:36-46`.
+      Result: PASS.
+
+- [x] **4. Tracked-files hint when `.yoke/runtime/` has tracked
+      paths; never executes `git rm` automatically.**
+      Evidence: `cleanup.sh:65-73` — uses `git ls-files
+      --error-unmatch` (read-only); on hit prints exactly
+      `[yoke] .yoke/runtime/ has tracked files. Run: git rm -r --cached .yoke/runtime/`;
+      short-circuits silently outside a git work tree. Smoke (i)
+      in `tests/working-memory.test.sh:248-296` initializes a git
+      repo, force-tracks a runtime file, asserts the hint fires,
+      asserts `git status --porcelain` is byte-identical before and
+      after, then untracks and asserts the helper goes silent.
+      Result: PASS.
+
+- [x] **5. `tests/working-memory.test.sh` asserts (a) cleanup wipes
+      on merge-ready+canonize-success, (b) preserves on paused
+      termination, (c) gitignore self-heal repairs, (d) tracked
+      hint fires without state change.**
+      Evidence: cases (f) through (i) added at
+      `tests/working-memory.test.sh:147-298`; full test suite output
+      `PASS (9 check(s))` covers the four new assertions plus the
+      five pre-existing ones. Result: PASS.
+
+- [x] **6. Craftsmanship — deterministic bash functions in
+      `lib/working-memory/cleanup.sh`, reuse `wm_runtime_dir` from
+      `paths.sh`, zero hardcoded `.yoke/runtime/` strings; no
+      conventions.md Don'ts violated.**
+      Evidence:
+      - cleanup.sh sources nothing externally; declares hard
+        dependency on paths.sh via the `_WM_PATHS_LOADED` guard at
+        `cleanup.sh:32-35`.
+      - All path references go through `WM_ROOT`/`WM_RUNTIME_DIR`
+        constants from paths.sh; the only literal string is
+        `_WM_GITIGNORE_CONTENT` at `cleanup.sh:39`, which is
+        gitignore *content* (necessarily a literal), not a
+        filesystem path.
+      - No agentic calls in cleanup.sh — all functions are pure
+        bash.
+      - Conventions Don'ts: no canonical-memory access, no agent
+        permissioning changes, no sensor changes, no acceptance
+        contract changes, no canonize bypass. All clear.
+      Result: PASS.
+
+## Pattern Compliance
+
+- [x] **`patterns/ralph-loop.md` — termination semantics.**
+      Cleanup attaches to §4 ("Termination paths") in
+      `skills/implement/SKILL.md:308-323` *after* the canonize
+      handoff in §3 returns. The five termination reasons in the
+      pattern (`merge-ready` | `divergence` | `contract-conflict` |
+      `hard-bound` | `infeasibility`) are honored: only
+      `merge-ready` triggers cleanup; the others remain pause
+      states with cycle history preserved. No change to parallel
+      spawn, hard bounds, or sprint-contract semantics.
+
+- [x] **`patterns/memory-model.md` — working-memory lifetime
+      ("task / sprint / PR scope").**
+      The implementation operationalizes the pattern's lifetime
+      declaration: at PR-readiness (MERGE-READY + canonize success),
+      runtime contents are reclaimed. The pattern itself is
+      unchanged. The `.yoke/.current` pointer remains outside
+      `runtime/` per the spec's Open Question #3 ("leaning leave-it"),
+      so it is not affected by `wm_runtime_cleanup`.
+
+- [x] **conventions.md — "Blueprints wrapping agentic nodes".**
+      `cleanup.sh` is a pure deterministic node — three bash
+      functions, no LLM calls, no Task spawns, no MCP queries.
+      Invoked by `/yoke:implement` from preflight (silent or one-line)
+      and termination (gated no-op or wipe). Aligns exactly with
+      "LLM only where judgment is genuinely necessary".
+
+- [x] **conventions.md — "Back-pressure: success is silent,
+      failures are verbose".**
+      `wm_gitignore_self_heal` is silent when the file is already
+      correct; emits one line on repair. `wm_check_runtime_tracked`
+      is silent when nothing is tracked; emits one line on hit.
+      `wm_runtime_cleanup` is silent on success and on no-op paths;
+      stderr-noisy only on missing-arg (a programming error, not
+      a runtime state).
+
+- [x] **conventions.md — "Environment designers, not code
+      writers".**
+      The fix treats the leak as an environment-design problem —
+      gitignore self-heal + automatic sweep — instead of a code
+      problem requiring user discipline. Matches the convention's
+      framing.
+
+- [x] **Implementation Plan convention — "Test file per framework
+      concept".**
+      No new test file; the four assertions extend the existing
+      `tests/working-memory.test.sh`. Working-memory hygiene is the
+      same concept as path resolution and bootstrap output (per
+      the test file's own header comment), so adding to it is the
+      correct placement.
+
+## Convention Violations
+
+None.
+
+## Tests
+
+- `tests/working-memory.test.sh` — PASS (9/9)
+- `tests/bootstrap.test.sh` — PASS (7/7) — gitignore literal still
+  asserted at `tests/bootstrap.test.sh:84` matches the literal in
+  `cleanup.sh:39`; spec-anti-scope ("no shared template") respected.
+- `tests/skills-surface.test.sh` — PASS (75/75) — `implement/SKILL.md`
+  edits did not break declared surface invariants.
+- `tests/ralph-loop-bounds.test.sh` — PASS (23/23) — termination
+  taxonomy intact.
+- `tests/perf-quickwins-part-2.test.sh` — PASS — Generator/Validator
+  contracts undisturbed.
+- `tests/perf-quickwins-part-3.test.sh` — PASS — model resolution
+  contracts undisturbed.
+- `tests/ack-sensors-inferential.test.sh` — PASS — judge-verdict
+  paths still resolved through paths.sh helpers.
+
+## Positive Deviations from Spec
+
+- **Reused `wm_wipe_runtime` from `lib/working-memory/paths.sh:239-245`
+  instead of re-implementing the wipe primitive in `cleanup.sh`.**
+  The spec described `wm_runtime_cleanup` as the wipe function; the
+  pre-existing `wm_wipe_runtime` already implements
+  `find "$WM_RUNTIME_DIR" -mindepth 1 -delete` with idempotent
+  directory recreation. Treating `wm_runtime_cleanup` as a *gate*
+  around that primitive (rather than a fresh implementation)
+  removes a duplication risk and aligns with the craftsmanship DoD.
+  No spec field violated.
+
+## Gaps
+
+None. All 6 DoD checks pass; all referenced patterns and conventions
+respected; all impacted tests green.
+
+## Verdict
+
+**PASS** — Ready to ship.
+
+Files changed (3 of ≤ 4 budget):
+1. `lib/working-memory/cleanup.sh` (NEW, 94 lines)
+2. `skills/implement/SKILL.md` (preflight + termination wiring + anti-pattern)
+3. `tests/working-memory.test.sh` (4 new assertions added)

--- a/.vibeflow/prds/runtime-cleanup.md
+++ b/.vibeflow/prds/runtime-cleanup.md
@@ -1,0 +1,168 @@
+# PRD: Runtime cleanup post-implementation
+
+> Generated via /vibeflow:discover on 2026-04-27
+
+## Problem
+
+Yoke-managed projects are leaking `.yoke/runtime/` artifacts into pull
+requests. The folder holds ephemeral working state for the ralph loop —
+per-cycle judge verdicts, sensor snapshots, deferred-sensor queues,
+cycle counters, status snapshots, the spawn log — that has zero value
+after the canonize handoff has lifted the durable signal into canonical
+memory. When this content rides along into a PR, reviewers see noise
+that obscures the real change set, and the host repository accretes
+ephemeral state forever.
+
+The leak has two root causes:
+
+1. **Gitignore not effective in the host project.** Bootstrap *does*
+   write `.yoke/.gitignore` with `runtime/` excluded
+   (`skills/bootstrap/SKILL.md:115-119`), but projects that adopted
+   Yoke before that gitignore existed — or that already staged
+   `runtime/` files manually — keep tracking them; `.gitignore` does
+   not untrack already-tracked paths.
+2. **No automatic cleanup at loop termination.** `/yoke:implement`
+   exits and hands off to a canonize call, but never deletes the
+   runtime working set. The user's manual commit/PR step then sweeps
+   the leftover files into the PR.
+
+Today the user is expected to remember to `rm -rf .yoke/runtime/`
+before opening a PR. They do not, and the artifacts ship.
+
+## Target Audience
+
+Developers using Yoke in a host project — i.e. anyone who runs
+`/yoke:implement` and then commits + opens a PR (manually or via a
+commit/PR skill). Plugin maintainers feel the same pain when running
+smoke tests against fixture projects.
+
+## Proposed Solution
+
+Two coordinated interventions, both inside `/yoke:implement` and
+`/yoke:bootstrap` — no new commands, no new agents.
+
+1. **Cleanup at termination.** After the canonize handoff completes
+   on a MERGE-READY exit, `/yoke:implement` deletes the contents of
+   `.yoke/runtime/` for the active task. The directory itself stays
+   (`mkdir -p` is idempotent on the next run); only its content is
+   wiped. Cleanup runs only after a *successful* canonize call —
+   if canonize fails, runtime is preserved so the user can re-run.
+2. **Gitignore self-heal.** When `/yoke:implement` starts, it checks
+   that `.yoke/.gitignore` exists and contains `runtime/` and
+   `.current`. If absent or incomplete, the skill writes/repairs it
+   and prints a one-line notice. If `.yoke/runtime/` is *already
+   tracked* in git (`git ls-files --error-unmatch .yoke/runtime`
+   succeeds), the skill prints a remediation hint pointing at
+   `git rm -r --cached .yoke/runtime` — but does not run it
+   automatically (untracking a path is the user's call, not the
+   skill's).
+
+The cleanup is unconditional on MERGE-READY: if the canonization
+process is the durable handoff (it is — that is the whole Phase-5
+contract), runtime files have no remaining purpose.
+
+## Success Criteria
+
+- After a MERGE-READY `/yoke:implement` run on a host project,
+  `git status` shows no `.yoke/runtime/` paths.
+- A subsequent `git add -A` in the host project does not stage any
+  `.yoke/runtime/` content.
+- A host project bootstrapped *before* the gitignore feature can
+  upgrade and run `/yoke:implement` once; afterwards the gitignore
+  is self-repaired and the user has been told (in a single line of
+  output) what to run to untrack legacy files.
+- Smoke test (added under `tests/`) drives `/yoke:implement` to
+  MERGE-READY in a fixture project, then asserts the runtime/
+  directory is empty and not staged.
+
+## Scope v0
+
+- Cleanup of `.yoke/runtime/` contents inside `/yoke:implement`,
+  fired only on MERGE-READY, and only after the canonize handoff
+  returns success.
+- Gitignore self-heal at the start of `/yoke:implement`: write or
+  repair `.yoke/.gitignore` if missing/incomplete; print a one-line
+  remediation hint if `.yoke/runtime/` is already tracked.
+- Smoke test asserting both behaviors.
+- Documentation update: anti-pattern note in `skills/implement/SKILL.md`
+  ("do not skip the cleanup; do not run it on non-MERGE-READY exits");
+  one line in `templates/project-claude-md.md` clarifying that
+  `.yoke/runtime/` is ephemeral.
+
+## Anti-scope
+
+- **No deletion on paused exits** (Trigger-4 divergence, hard-bound,
+  infeasibility, contract-conflict). Those are arbitration pauses,
+  not terminations; the user must be able to resume the loop with
+  full cycle history. See Open Questions for the case to revisit
+  this later.
+- **No new "cleanup-runtime" command.** This is a behavior of
+  `/yoke:implement`, not a user-facing skill. The user already
+  invokes implement; they should not also have to invoke a sweeper.
+- **No archiving of runtime to a `.yoke/archive/`** or similar
+  long-term store. The canonize handoff is the durable record; if
+  something needed to be kept, it should already be in canonical
+  memory.
+- **No automatic `git rm -r --cached .yoke/runtime`.** Untracking a
+  user's tracked files without consent is destructive. The skill
+  prints the command; the user runs it.
+- **No retroactive cleanup of already-tracked files.** v0 only
+  prevents *future* leakage and writes the gitignore. Files already
+  in the user's git history stay there until the user removes them.
+- **No change to the canonize handoff itself.** Canonization stays
+  as today; cleanup is a *post-canonize* step inside
+  `/yoke:implement`, not a new responsibility for the Orchestrator.
+- **No change to `/yoke:preserve`'s ability to be invoked manually
+  later.** Re-canonization workflows that require old runtime/
+  files are explicitly out of scope (see Open Questions).
+
+## Technical Context
+
+Relevant facts gathered from `.vibeflow/` and the codebase:
+
+- Bootstrap already declares the runtime/ + `.current` ignore
+  pattern (`skills/bootstrap/SKILL.md:115-119`,
+  `tests/bootstrap.test.sh:67`,
+  `tests/working-memory.test.sh:59`). The pattern is correct; the
+  problem is that pre-existing projects do not have it.
+- `/yoke:implement` already has a deterministic preflight section
+  (`skills/implement/SKILL.md` §1) and a deterministic termination
+  step (§3 → §4) — both are the right insertion points. No new
+  agentic call needed; this is a deterministic node, fits the
+  "blueprints wrapping agentic nodes" invariant in the manifesto.
+- Runtime paths are computed via `lib/working-memory/paths.sh`
+  (`wm_runtime_dir`) — cleanup must use that helper, not hardcode
+  `.yoke/runtime/`. Pattern hygiene per `.vibeflow/conventions.md`.
+- The canonize handoff is foreground (`SKILL.md` §3) and returns
+  inline; checking its exit before cleanup is straightforward.
+- Smoke tests live under `tests/smoke/sprint-N.test.sh` and use
+  external `timeout 600` (per CLAUDE.md). The new smoke fits the
+  same shape.
+- Manifesto invariant **"Environment designers, not code writers"**:
+  this PRD treats the leak as an environment-design fix (gitignore
+  + automatic sweep) rather than asking the user to remember a
+  manual step.
+
+## Open Questions
+
+1. **Paused-exit cleanup.** Is there a future need to clean up
+   runtime/ on Trigger-4 / hard-bound / infeasibility *after* the
+   user has finished arbitration and decided not to resume? If yes,
+   the right shape is a separate, explicit user action (e.g. a
+   `/yoke:implement --abandon` flag or a small `/yoke:cleanup`
+   skill), not auto-cleanup on paused exits. Out of scope for v0.
+2. **Manual re-canonization.** `skills/implement/SKILL.md:310`
+   advertises that `/yoke:preserve` can be re-invoked manually to
+   re-canonize stale working memory (e.g. after a model upgrade).
+   Auto-deleting runtime on MERGE-READY breaks this. Two options:
+   (a) accept the trade-off — re-canonization is a niche workflow,
+   the canonical memory itself is the right re-canonization target;
+   (b) gate cleanup behind an opt-out config field (e.g.
+   `runtime.preserve_after_canonize: true` in `.yoke/config.yaml`)
+   for users who need the niche workflow. Recommend (a) for v0;
+   revisit if a real user surfaces the need.
+3. **`.current` cleanup.** The active-task pointer is also
+   gitignored. Should `/yoke:implement` clear it on MERGE-READY,
+   or leave it for the next `/yoke:discover` to overwrite? Leaning
+   leave-it (no harm, signals "this was the last task touched").
+   Confirm during gen-spec.

--- a/.vibeflow/specs/current-into-runtime-part-1.md
+++ b/.vibeflow/specs/current-into-runtime-part-1.md
@@ -1,0 +1,278 @@
+# Spec: Move `.yoke/.current` into `.yoke/runtime/` — Part 1 (functional)
+
+> Generated via /vibeflow:gen-spec on 2026-04-27. Atomic functional cut
+> + all impacted tests. Budget revised to ≤ 8 files for atomicity (the
+> alternative is a CI-red intermediate state, which violates the
+> implementation-plan convention "every sprint ships an installable
+> plugin"). Index.md "≤ 4 files per task (minimum; revise upward as the
+> codebase grows)" expressly allows the upward revision.
+
+## Objective
+
+Consolidate the active-task pointer (`.yoke/.current`) into
+`.yoke/runtime/.current` so the host project has a single ephemeral
+working-memory directory instead of two adjacent ignored paths.
+
+## Context
+
+Today `.yoke/` carries two gitignored items at the root:
+`.yoke/.current` (per-worktree active-task pointer, 1 file) and
+`.yoke/runtime/` (cycle artifacts, many files). Both have the same
+lifetime ("task / sprint / PR scope" per `patterns/memory-model.md`)
+and the same blast radius (per-worktree, never shared, never durable).
+Splitting them across two locations means:
+
+- Two gitignore rules instead of one (`.current` + `runtime/`).
+- `wm_runtime_cleanup` (just landed in `runtime-cleanup`) only
+  reclaims `runtime/`, leaving `.current` to dangle until
+  `/yoke:discover` overwrites it.
+- The bootstrap `.gitignore` template, four downstream skill SKILL.md
+  files, four test files, and one hook comment all carry the
+  `.yoke/.current` literal.
+
+Folding `.current` into `runtime/` collapses the layout: one ignore
+rule (`runtime/`), one cleanup primitive (`wm_runtime_cleanup`
+already wipes everything inside), one ephemeral directory.
+Side-effect: on MERGE-READY + canonize-success, the active-task
+pointer is also cleared. That is the desired behavior — the next
+`/yoke:discover` writes a fresh pointer, and "last task touched"
+state is genuinely ephemeral.
+
+This is a *deliberate revision* of the runtime-cleanup spec's
+anti-scope ("No change to `/yoke:bootstrap`. Its existing gitignore
+write is correct.") — that anti-scope is now superseded; bootstrap's
+gitignore literal must drop the `.current` line.
+
+## Definition of Done
+
+1. `lib/working-memory/paths.sh` defines `WM_CURRENT_FILE` as
+   `${WM_RUNTIME_DIR}/.current`; `wm_active_slug`, `wm_set_active`,
+   and `wm_clear_active` operate on the new path; `wm_set_active`
+   ensures `${WM_RUNTIME_DIR}` exists (`mkdir -p`) before writing
+   so first-discover on a fresh repo succeeds.
+2. `lib/working-memory/cleanup.sh` `_WM_GITIGNORE_CONTENT` is
+   exactly `runtime/` (single line, no `.current`); the self-heal
+   notice text is updated to mention only `runtime/`.
+3. `skills/bootstrap/SKILL.md` Step 5 declares the new gitignore
+   content (single line `runtime/`) and updates the rationale prose
+   accordingly.
+4. `hooks/verify-acceptance.sh` comment block referencing
+   `.yoke/.current` reflects the new path.
+5. All four impacted test files
+   (`tests/working-memory.test.sh`, `tests/bootstrap.test.sh`,
+   `tests/perf-quickwins-part-1.test.sh`,
+   `tests/ack-sensors-inferential.test.sh`) read/write `.current`
+   at the new location and assert the new gitignore content. Every
+   test file PASSes after the change.
+6. **(craftsmanship)** Zero hardcoded `.yoke/.current` strings remain
+   in `lib/`, `hooks/`, or `skills/bootstrap/SKILL.md`; downstream
+   skill SKILL.md prose (covered in Part 2) is the only place the
+   literal still appears, and that is intentional. No conventions.md
+   Don'ts violated.
+7. **(integration smoke)** Running `wm_runtime_cleanup "merge-ready"
+   "0"` on a populated runtime/ directory wipes `.current` along
+   with cycle artifacts; the runtime-cleanup smoke (cases f/g) still
+   passes because the wipe primitive (`wm_wipe_runtime`) is
+   path-agnostic.
+
+## Scope
+
+- `lib/working-memory/paths.sh`:
+  - Change `readonly WM_CURRENT_FILE="${WM_ROOT}/.current"` to
+    `readonly WM_CURRENT_FILE="${WM_RUNTIME_DIR}/.current"`. The
+    constant ordering already declares `WM_RUNTIME_DIR` before
+    `WM_CURRENT_FILE` (line 50 vs 49 today — re-order if needed
+    so the new declaration sees `WM_RUNTIME_DIR`).
+  - In `wm_set_active`, replace `mkdir -p "$WM_ROOT"` with
+    `mkdir -p "$WM_RUNTIME_DIR"`. The runtime dir is the new home
+    for `.current`; the parent `.yoke/` is implicitly created by
+    `mkdir -p`.
+  - Update the layout-doc comment block at the top of paths.sh
+    (lines 8-22) to show `.current` under `runtime/`.
+- `lib/working-memory/cleanup.sh`:
+  - Change `_WM_GITIGNORE_CONTENT` from `$'.current\nruntime/'` to
+    `'runtime/'` (single line).
+  - Update the notice string in `wm_gitignore_self_heal` from
+    `repaired .yoke/.gitignore (wrote: .current, runtime/)` to
+    `repaired .yoke/.gitignore (wrote: runtime/)`.
+- `skills/bootstrap/SKILL.md`:
+  - Step 5 (lines 115-120 today): change the embedded code block
+    from two lines to one (`runtime/`); update the rationale prose
+    to reflect that `runtime/` now also covers `.current` because
+    `.current` lives inside it.
+- `hooks/verify-acceptance.sh`:
+  - Update the comment at line 24 from `.yoke/.current` to
+    `.yoke/runtime/.current`.
+- `tests/working-memory.test.sh`:
+  - The `.gitignore` setup at line 59:
+    `printf 'runtime/\n' > .yoke/.gitignore`.
+  - The allowed-location whitelist (around line 88) replaces
+    `.yoke/.current)` with `.yoke/runtime/.current)`.
+  - Assertion (d) gitignore-content expectation: change from
+    `$'.current\nruntime/'` to `'runtime/'`. Header comment in the
+    file (line 13) updates to match.
+  - Assertion (e) `.current` size check: read from
+    `.yoke/runtime/.current` instead of `.yoke/.current`.
+  - Cleanup-helper smoke (h): the `expected_gi_full` constant
+    becomes `'runtime/'`; the incomplete-content fixture used to
+    trigger repair stays as a plausible incomplete-state seed (e.g.
+    empty file, or a stray `runtime`-without-slash) — pick whatever
+    plausibly exercises the "needs repair" branch.
+- `tests/bootstrap.test.sh`:
+  - The `.gitignore` write at line 67:
+    `printf 'runtime/\n' > .yoke/.gitignore`.
+  - The expectation at line 84:
+    `expected=$'runtime/'`.
+  - Header comment (line 6) and any other prose mentioning
+    `.current\nruntime/` updates.
+- `tests/perf-quickwins-part-1.test.sh`:
+  - Line 146: replace
+    `echo -n "$slug" > .yoke/.current` with
+    `mkdir -p .yoke/runtime && echo -n "$slug" > .yoke/runtime/.current`.
+- `tests/ack-sensors-inferential.test.sh`:
+  - Line 255: replace
+    `echo 2026-04-26-test-slug > "$helper_tmp/.yoke/.current"` with
+    `mkdir -p "$helper_tmp/.yoke/runtime" && echo 2026-04-26-test-slug > "$helper_tmp/.yoke/runtime/.current"`.
+
+## Anti-scope
+
+- **No change to skill SKILL.md prose** in `discover`, `status`,
+  `tech-spec`, `acceptance-contract`, `implement`. Doc-only edits
+  ship as Part 2 — they don't affect runtime correctness, so
+  splitting them out keeps Part 1 focused.
+- **No transition shim / dual-write.** Yoke is pre-1.0 (manifesto +
+  CLAUDE.md). No backwards-compat constraint with old `.yoke/.current`
+  layouts. Cut over atomically.
+- **No new helper functions.** `wm_active_slug`, `wm_set_active`,
+  `wm_clear_active` retain their signatures; only the file path
+  they read/write changes.
+- **No changes to `wm_runtime_cleanup` semantics.** The wipe
+  helper already deletes `find $WM_RUNTIME_DIR -mindepth 1` —
+  `.current` simply joins the set of files wiped. No new gating,
+  no new args.
+- **No change to canonize handoff or `/yoke:preserve`.**
+- **No deprecation warning for old `.yoke/.current` paths.**
+  Tests own the breakage signal; users who upgrade in place will
+  see `wm_active_slug` print "no active task" because the old file
+  is no longer read. They can run `/yoke:discover` to recover. A
+  one-line note in the eventual release CHANGELOG covers this; not
+  in this spec.
+- **No `.yoke/.current` migration script.** Pre-1.0 + manual
+  bootstrap convention says no.
+
+## Technical Decisions
+
+### 1. New path is `${WM_RUNTIME_DIR}/.current`, not `${WM_RUNTIME_DIR}/current`
+
+Keep the leading dot. Rationale:
+- Preserves the "hidden ephemeral state" semantic that justified the
+  dot in the original location.
+- Matches sibling files inside `runtime/`: `.cycle-counter`,
+  `.snapshots/`, `.judge-verdicts/`, `.task-spawn-log`,
+  `.trigger4-packet.yaml`, `.merge-ready-snapshot.yaml`,
+  `.deferred-sensors.json`. The dot prefix is the established
+  convention for runtime internals.
+- No naming collision risk with archive directories (which are
+  versioned and live as siblings of `runtime/`, not inside it).
+
+### 2. Re-order constants in paths.sh so `WM_RUNTIME_DIR` declares first
+
+`WM_CURRENT_FILE` will reference `WM_RUNTIME_DIR`. Bash `readonly`
+declarations are evaluated top-to-bottom; the dependent constant
+must follow its dependency. Today the order is `WM_CURRENT_FILE`
+(line 49) then `WM_RUNTIME_DIR` (line 50). Swap.
+
+### 3. `wm_set_active` mkdir-s `WM_RUNTIME_DIR`, not `WM_ROOT`
+
+First `/yoke:discover` runs in a freshly-bootstrapped `.yoke/` that
+has only `config.yaml` and `.gitignore` — no `runtime/`. The set-
+active call must succeed without prior `wm_wipe_runtime` or
+implement-preflight `mkdir`. `mkdir -p "$WM_RUNTIME_DIR"` creates
+both `.yoke/` and `.yoke/runtime/` if absent (mkdir is recursive
+under `-p`).
+
+### 4. Side-effect: `wm_runtime_cleanup` clears `.current`
+
+Documented intent. The helper's spec'd behavior (DoD #1 of
+runtime-cleanup) is "delete contents of `$WM_RUNTIME_DIR`" —
+`.current` is a content of that directory after this spec lands.
+No special-casing. Open Question #3 of the runtime-cleanup PRD
+("`.current` cleanup. Leaning leave-it") is hereby resolved
+against leave-it: clear it on MERGE-READY, let `/yoke:discover`
+write a fresh pointer for the next task. Trade-off accepted: the
+"last task touched" signal is lost on MERGE-READY exit. Mitigation:
+the host project's git history retains the last task's PR.
+
+### 5. Header comment in paths.sh becomes the canonical layout doc
+
+The block at lines 8-22 of `paths.sh` is the single source of truth
+for the working-memory tree shape. Update it to show `.current`
+under `runtime/`. Skill SKILL.md prose can drift; paths.sh cannot.
+
+## Applicable Patterns
+
+- **`patterns/memory-model.md`** — working-memory lifetime ("task /
+  sprint / PR scope"). Consolidating two ephemeral surfaces into
+  one strengthens the lifetime claim. Pattern itself unchanged.
+- **`patterns/ralph-loop.md`** — termination semantics. Cleanup
+  behavior at MERGE-READY now also covers `.current` as a natural
+  consequence; no new code path, no new branch.
+- **`patterns/plugin-structure.md`** — repo layout discipline. The
+  paths.sh layout-doc comment block is the canonical declaration;
+  this spec keeps it accurate.
+- **conventions.md "Environment designers, not code writers"** —
+  the simplification (one ephemeral dir, one ignore rule) reduces
+  the number of failure modes a user can hit. No new sensors, no
+  new agentic surface.
+- **conventions.md "Back-pressure: success silent, failures
+  verbose"** — `wm_gitignore_self_heal`'s notice line shrinks to
+  match the simpler content; silent on correct still holds.
+
+## Risks
+
+- **R1 — Tests outside the listed four also reference
+  `.yoke/.current` indirectly.** Mitigation: re-grep the codebase
+  during implementation (`grep -rn "\.yoke/\.current\|WM_CURRENT_FILE"
+  lib/ skills/ hooks/ tests/ agents/`) before declaring DoD #5
+  complete. The grep done during gen-spec found exactly the four
+  test files in scope; if a fifth shows up, expand DoD #5 to cover
+  it.
+- **R2 — `wm_set_active` race on first run.** If two
+  `/yoke:discover` invocations race to write `.current`, both could
+  attempt `mkdir -p` and one of the writes could clobber the other.
+  Mitigation: not a regression — same race exists today against
+  `.yoke/.current`. No new exposure.
+- **R3 — Open repos with `.yoke/.current` already present.**
+  Existing host projects upgrading in place will have a stale
+  `.yoke/.current` (now ignored by code) and no
+  `.yoke/runtime/.current`. `wm_active_slug` returns "no active
+  task". Recovery: `/yoke:discover` (continue or new). Acceptable
+  for pre-1.0; a one-line note in the next release notes is
+  enough. Not in this spec's scope.
+- **R4 — Tests asserting `.gitignore` line count fail
+  unexpectedly.** Some tests assert the exact two-line content.
+  All four listed test files have been audited and updated in the
+  scope above. Re-grep R1 catches stragglers.
+- **R5 — `wm_runtime_cleanup` clearing `.current` surprises a
+  user mid-debug.** They MERGE-READY a task, then try to inspect
+  what task was last active and find no pointer. Mitigation: the
+  exit summary already prints the slug + PR URLs (via the canonize
+  handoff in `skills/implement/SKILL.md` §3), so the information
+  is on stdout. The `.current` file is not the source of truth
+  for "what was the last task" — git/PR history is.
+
+## Files touched (≤ 8, atomicity revision)
+
+1. `lib/working-memory/paths.sh` — constant reorder + path change
+   + `wm_set_active` mkdir target + layout-doc update.
+2. `lib/working-memory/cleanup.sh` — gitignore literal + notice text.
+3. `skills/bootstrap/SKILL.md` — Step 5 gitignore literal +
+   rationale prose.
+4. `hooks/verify-acceptance.sh` — comment line 24.
+5. `tests/working-memory.test.sh` — `.gitignore` literal,
+   allowed-location whitelist, assertion (d) expectation, assertion
+   (e) path, helper-smoke (h) `expected_gi_full`.
+6. `tests/bootstrap.test.sh` — `.gitignore` literal + expected
+   constant + header comment.
+7. `tests/perf-quickwins-part-1.test.sh` — `.current` write path.
+8. `tests/ack-sensors-inferential.test.sh` — `.current` write path.

--- a/.vibeflow/specs/current-into-runtime-part-2.md
+++ b/.vibeflow/specs/current-into-runtime-part-2.md
@@ -1,0 +1,141 @@
+# Spec: Move `.yoke/.current` into `.yoke/runtime/` — Part 2 (doc alignment)
+
+> Generated via /vibeflow:gen-spec on 2026-04-27. Pure prose alignment
+> across five skill SKILL.md files; ships after Part 1 lands.
+
+## Dependencies
+
+- `.vibeflow/specs/current-into-runtime-part-1.md` — must be
+  implemented and audited PASS before Part 2 begins. Part 1
+  changes the actual path; Part 2 just updates docs to match.
+
+## Objective
+
+Replace every prose reference to `.yoke/.current` with
+`.yoke/runtime/.current` across the five skill SKILL.md files that
+mention the active-task pointer, so docs stay accurate to the code
+that landed in Part 1.
+
+## Context
+
+After Part 1 lands, `.current` lives at `.yoke/runtime/.current`,
+but five skill SKILL.md files still say `.yoke/.current` in their
+prose:
+
+- `skills/discover/SKILL.md` — 4 references (`grep` 2026-04-27).
+- `skills/status/SKILL.md` — 2 references.
+- `skills/tech-spec/SKILL.md` — 2 references.
+- `skills/acceptance-contract/SKILL.md` — 3 references.
+- `skills/implement/SKILL.md` — 3 references.
+
+Each is in user-facing prose: pre-conditions sections, "what this
+skill writes" headers, error messages embedded in command examples.
+Stale prose misleads users (`/yoke:status` won't find `.yoke/.current`
+on a freshly-cleaned project) and conflicts with the canonical layout
+doc in `lib/working-memory/paths.sh`.
+
+The change is doc-only — no code path is exercised, no test
+fixture is touched. Tests already pass after Part 1; Part 2 is
+about user-facing accuracy.
+
+## Definition of Done
+
+1. `skills/discover/SKILL.md` has zero occurrences of the literal
+   `.yoke/.current`; every reference reads `.yoke/runtime/.current`.
+2. `skills/status/SKILL.md` has zero occurrences of `.yoke/.current`.
+3. `skills/tech-spec/SKILL.md` has zero occurrences of `.yoke/.current`.
+4. `skills/acceptance-contract/SKILL.md` has zero occurrences of
+   `.yoke/.current`.
+5. `skills/implement/SKILL.md` has zero occurrences of `.yoke/.current`.
+6. **(craftsmanship)** A repo-wide grep
+   `grep -rn '\.yoke/\.current' .` returns only matches inside
+   `.vibeflow/audits/`, `.vibeflow/decisions.md`, or `.vibeflow/specs/`
+   (historical references in audit/decision/spec records, which
+   are immutable history and should NOT be edited). Zero matches
+   in `lib/`, `hooks/`, `skills/`, `agents/`, `tests/`, `templates/`,
+   `docs/`, or other live surfaces.
+
+## Scope
+
+- `skills/discover/SKILL.md` — replace each of the 4 prose
+  references found at lines 7, 146, 194, 205, 232 (line numbers
+  approximate; use grep at implement time). Pre-condition lists,
+  "writes" sections, "continue active task" branch description.
+- `skills/status/SKILL.md` — replace at lines ~52 and ~206.
+- `skills/tech-spec/SKILL.md` — replace at lines ~84 and ~325.
+- `skills/acceptance-contract/SKILL.md` — replace at lines ~9, ~54,
+  ~214.
+- `skills/implement/SKILL.md` — replace at lines ~38, ~51, ~355.
+
+Each replacement is `.yoke/.current` → `.yoke/runtime/.current`. No
+restructuring, no rewording, no examples added.
+
+## Anti-scope
+
+- **No edits outside the five skill SKILL.md files.** All other
+  occurrences (`lib/`, `hooks/`, `tests/`, `templates/`,
+  `skills/bootstrap/SKILL.md`) were handled in Part 1.
+- **No prose reflow / restructuring.** Find-and-replace only.
+- **No edits to historical records** (`.vibeflow/audits/*`,
+  `.vibeflow/decisions.md`, `.vibeflow/specs/*`). Those are
+  immutable audit trails.
+- **No new examples or callouts** about the new path.
+- **No README / docs/ updates.** Those mention `.yoke/` at a higher
+  level; the `.yoke/.current` literal does not appear in them per
+  the gen-spec grep.
+
+## Technical Decisions
+
+### 1. Find-and-replace, not rewrite
+
+The five files have established voice and structure. A pure literal
+substitution preserves the surrounding sentences and section flow.
+Rewriting would introduce review surface for no gain.
+
+### 2. Skip historical records
+
+`.vibeflow/audits/`, `.vibeflow/decisions.md`, `.vibeflow/specs/*`,
+and `.vibeflow/prds/*` mention `.yoke/.current` in records that
+were accurate at the time they were written. Mutating them
+rewrites history. Future audit/decision/spec records will use the
+new path naturally.
+
+### 3. Verification by grep, not by re-running smoke
+
+Part 2 ships no executable behavior. The DoD #6 craftsmanship
+gate is "grep returns zero hits in live surfaces" — that is the
+verification. No smoke needed.
+
+## Applicable Patterns
+
+- **`patterns/plugin-structure.md`** — repo layout discipline.
+  Doc-prose accuracy follows the same hygiene as the layout-doc
+  comment block updated in Part 1.
+- **conventions.md "Lineage is documented honestly"** — accurate
+  references to working-memory paths are part of honest
+  documentation.
+
+## Risks
+
+- **R1 — Hidden references in code blocks within SKILL.md.** The
+  five files contain code-fenced examples that may use
+  `.yoke/.current`. Replacement should also touch code-fenced
+  literals (those are user-facing instructions). Mitigation: the
+  grep used in DoD #6 is content-agnostic; it catches both prose
+  and code-fenced occurrences.
+- **R2 — Replacement breaks markdown formatting.** Unlikely — the
+  literal is a path, surrounded by backticks in every observed
+  occurrence. Mitigation: visual scan of each touched line during
+  implement.
+- **R3 — Drift between Part 1 ship and Part 2 ship.** If Part 2
+  doesn't ship promptly after Part 1, users hit doc/code drift.
+  Mitigation: ship Parts 1 and 2 in adjacent PRs (sequenced by the
+  Dependencies field above).
+
+## Files touched (≤ 5)
+
+1. `skills/discover/SKILL.md`
+2. `skills/status/SKILL.md`
+3. `skills/tech-spec/SKILL.md`
+4. `skills/acceptance-contract/SKILL.md`
+5. `skills/implement/SKILL.md`

--- a/.vibeflow/specs/runtime-cleanup.md
+++ b/.vibeflow/specs/runtime-cleanup.md
@@ -1,0 +1,252 @@
+# Spec: Runtime cleanup post-implementation
+
+> Generated via /vibeflow:gen-spec on 2026-04-27 from
+> `.vibeflow/prds/runtime-cleanup.md`. Budget: ≤ 4 files.
+
+## Objective
+
+Make `/yoke:implement` self-healing for `.yoke/.gitignore` at preflight
+and self-cleaning for `.yoke/runtime/` contents on a successful
+MERGE-READY exit, so host-project PRs never carry ephemeral cycle
+artifacts.
+
+## Context
+
+`.yoke/runtime/` holds per-cycle judge verdicts, sensor snapshots,
+deferred-sensor queues, the cycle counter, status snapshots and the
+spawn log — all ephemeral per the two-tier memory model
+(`patterns/memory-model.md`: lifetime = "task / sprint / PR scope").
+`/yoke:bootstrap` already writes `.yoke/.gitignore` with `runtime/` +
+`.current` (`skills/bootstrap/SKILL.md:115-119`,
+`tests/bootstrap.test.sh:67`). Two real-world failure modes still
+ship runtime artifacts into pull requests:
+
+1. Host projects bootstrapped before the gitignore was added keep
+   `.yoke/runtime/` files in the index; `.gitignore` does not untrack.
+2. `/yoke:implement` exits without sweeping its own working set, so
+   the user's manual commit step (or any `git add -A` wrapper) drags
+   leftover files into the PR.
+
+The canonize handoff (`skills/implement/SKILL.md` §3) is the durable
+hand-off point — once it returns success, the runtime working set has
+no remaining purpose. This spec wires that fact into the skill.
+
+## Definition of Done
+
+1. `/yoke:implement` deletes the contents of `wm_runtime_dir` for the
+   active task on a MERGE-READY exit, **only after** the canonize
+   handoff returns exit 0. The directory itself remains.
+2. `/yoke:implement` does **not** delete runtime contents on any
+   non-MERGE-READY termination (`divergence`, `contract-conflict`,
+   `hard-bound`, `infeasibility`) — those are arbitration pauses; the
+   user must be able to resume with full cycle history.
+3. `/yoke:implement` writes or repairs `.yoke/.gitignore` at preflight
+   when missing or when either `runtime/` or `.current` is absent;
+   prints exactly one line of notice when it does, and zero lines
+   when the file is already correct.
+4. `/yoke:implement` prints a one-line remediation hint pointing at
+   `git rm -r --cached .yoke/runtime` when `git ls-files` shows any
+   tracked path under `.yoke/runtime/`; never executes the command
+   itself.
+5. `tests/working-memory.test.sh` asserts (a) `wm_runtime_dir` is
+   empty after a simulated MERGE-READY+canonize-success path, (b)
+   `wm_runtime_dir` contents are preserved on a simulated paused
+   termination, (c) gitignore self-heal repairs a missing/incomplete
+   `.yoke/.gitignore`, (d) the tracked-files hint fires without
+   modifying git state.
+6. **(craftsmanship)** Cleanup and gitignore-heal are deterministic
+   bash functions in `lib/working-memory/cleanup.sh`, not agentic
+   calls; they reuse `wm_runtime_dir` from
+   `lib/working-memory/paths.sh` and contain zero hardcoded
+   `.yoke/runtime/` strings. Conforms to "Blueprints wrapping
+   agentic nodes" and "Environment designers, not code writers"
+   (conventions.md), and violates none of conventions.md Don'ts.
+
+## Scope
+
+- New helper module: `lib/working-memory/cleanup.sh` exposing three
+  bash functions:
+  - `wm_gitignore_self_heal` — idempotently writes/repairs
+    `.yoke/.gitignore` (literal content `.current\nruntime/\n`).
+    Single notice line on repair; silent when correct.
+  - `wm_check_runtime_tracked` — emits the remediation hint when
+    `git ls-files --error-unmatch -- .yoke/runtime` succeeds for
+    any path; returns 0 otherwise. Read-only against git state.
+  - `wm_runtime_cleanup` — accepts `<termination_reason>` and
+    `<canonize_exit_code>`; deletes contents of `wm_runtime_dir`
+    (preserving the directory itself) iff reason == `merge-ready`
+    and canonize exit == 0. Otherwise no-op.
+- Hook the helper into `/yoke:implement`:
+  - Preflight (Step 1, after `mkdir -p` of runtime/contracts):
+    invoke `wm_gitignore_self_heal` then `wm_check_runtime_tracked`.
+  - Termination (Step 4, after the canonize handoff in Step 3
+    returns): invoke `wm_runtime_cleanup` with the loop's
+    termination reason and the canonize call's exit code. Must run
+    before the skill's exit summary line so the cleanup state is
+    final at exit.
+- Documentation in `skills/implement/SKILL.md`:
+  - One sentence in Step 1 noting the gitignore-heal preflight call.
+  - One sentence in Step 4 noting the MERGE-READY-only cleanup,
+    cross-referenced to the helper function.
+  - One bullet under Anti-patterns: "Do NOT call `wm_runtime_cleanup`
+    on non-MERGE-READY exits — paused loops require cycle history
+    for resumption."
+- Tests in `tests/working-memory.test.sh`: extend the existing concept
+  test with the four assertions in DoD #5. Use a temp git repo
+  fixture; do not invoke the live ralph loop. Each assertion stages
+  the input state, calls the helper directly, and asserts on
+  filesystem + `git ls-files` output.
+
+## Anti-scope
+
+- **No new skill, no new agent.** Cleanup is a deterministic node of
+  `/yoke:implement`, not a user-facing surface.
+- **No deletion on paused exits.** Trigger-4 / hard-bound /
+  contract-conflict / infeasibility leave runtime untouched.
+- **No archival.** Nothing under `.yoke/runtime/` is moved to a
+  long-term store. Canonize handoff already captured durable
+  signal.
+- **No automatic `git rm -r --cached`.** Hint only; the user runs it.
+- **No retroactive sweep of historical PRs.** Files already merged
+  into the host repo's `main` stay there until the user removes them.
+- **No change to `/yoke:bootstrap`.** Its existing gitignore write is
+  correct; the self-heal in `/yoke:implement` covers the upgrade
+  path for projects bootstrapped before the gitignore landed.
+- **No change to canonize handoff or `/yoke:preserve`.** Cleanup runs
+  *after* canonize returns — does not alter what canonize does.
+- **No new template file.** The two-line gitignore literal is
+  duplicated between `skills/bootstrap/SKILL.md` and
+  `lib/working-memory/cleanup.sh`. Drift surface is two lines and
+  test-asserted in both places (DoD #5 + `tests/bootstrap.test.sh`),
+  so a shared template is over-engineered for v0.
+- **No config flag.** Cleanup-on-MERGE-READY is unconditional.
+  Re-canonization workflows that need stale runtime are explicitly
+  deferred (see Risks).
+
+## Technical Decisions
+
+### 1. Helper lives in `lib/working-memory/cleanup.sh`, not `lib/ralph-loop/`
+
+Cleanup operates on working-memory artifacts and reuses
+`wm_runtime_dir` from `lib/working-memory/paths.sh`. Co-locating it
+with `paths.sh` keeps working-memory hygiene in one module.
+`lib/ralph-loop/` owns loop *coordination* (`escalate.sh`,
+`status-snapshot.sh`, `orchestrate.sh`); cleanup is a hygiene
+concern, not a coordination concern. Trade-off: the helper is
+*invoked* from the ralph loop's termination path, so a reader
+chasing the cleanup call from `skills/implement/SKILL.md` Step 4 has
+to follow one extra hop into `lib/working-memory/`. Acceptable —
+the alternative (splitting wm-hygiene across two lib modules) is
+worse.
+
+### 2. Gate cleanup on `(reason == merge-ready && canonize_exit == 0)`
+
+Both conditions are necessary:
+
+- Reason gate protects paused exits (DoD #2). Without it, a user
+  arbitrating a Trigger-4 divergence would lose cycle history.
+- Canonize-success gate protects against the "canonize crashed,
+  signal not captured" case. If canonize fails and we still wipe
+  runtime, the failure is unrecoverable. Holding runtime intact
+  lets the user re-invoke `/yoke:preserve` manually.
+
+This pair is the minimum sufficient guard. A future config opt-out
+(see Risk R3) could relax one without breaking the other.
+
+### 3. `wm_runtime_cleanup` deletes contents, not the directory
+
+`rm -rf "$(wm_runtime_dir)"/*` (with dotglob) over `rm -rf` of the
+directory itself. Reason: subsequent `/yoke:implement` runs do
+`mkdir -p` of `wm_runtime_dir` in preflight (Step 1, line 51 of
+existing SKILL.md), so deleting the directory is equivalent — but
+keeping the directory means the working-tree shape stays stable
+between runs, easier to reason about in tests and debugging.
+
+### 4. Self-heal is silent when correct, single-line when repaired
+
+Convention "Back-pressure: success is silent, failures are verbose"
+(conventions.md). Correct gitignore = no output. Repaired gitignore
+= one line: `[yoke] repaired .yoke/.gitignore (added: runtime/, .current)`.
+Tracked-files hint = one line: `[yoke] .yoke/runtime/ has tracked files. Run: git rm -r --cached .yoke/runtime/`.
+Three states, three deterministic outputs.
+
+### 5. Tests use direct helper invocation, not live ralph loop
+
+`tests/working-memory.test.sh` already follows the pattern of staging
+filesystem state and asserting on outcomes (`tests/working-memory.test.sh:59-127`).
+The new assertions stage `.yoke/runtime/` content + git index state,
+call `wm_runtime_cleanup` / `wm_gitignore_self_heal` /
+`wm_check_runtime_tracked` directly, then assert. No need to spawn
+a real implement run — the helpers are pure filesystem functions and
+testing them directly is faster and more deterministic. The
+integration-level guarantee that `/yoke:implement` calls them in the
+right places is enforced by the SKILL.md prose (DoD #1, #2, #3, #4).
+
+## Applicable Patterns
+
+- **`patterns/ralph-loop.md`** — termination semantics. Cleanup
+  attaches to Step 4 ("Termination paths") and respects the existing
+  termination-reason taxonomy (`merge-ready` | `divergence` |
+  `contract-conflict` | `hard-bound` | `infeasibility`). The five
+  termination paths are not changed; cleanup is a *post-canonize*
+  step that branches only on reason == `merge-ready`.
+- **`patterns/memory-model.md`** — working-memory lifetime is
+  declared "task / sprint / PR scope". This spec operationalizes the
+  lifetime declaration: at PR-readiness (= MERGE-READY + canonize
+  success), runtime contents are reclaimed. No change to the pattern
+  itself.
+- **conventions.md "Blueprints wrapping agentic nodes"** — cleanup
+  is a deterministic node, not an LLM call.
+- **conventions.md "Back-pressure: success is silent, failures are
+  verbose"** — applied to gitignore-heal and tracked-files hint
+  output.
+- **Implementation Plan convention "Test file per framework
+  concept"** — extends `tests/working-memory.test.sh`; does not
+  introduce a new concept file. Working-memory hygiene is the same
+  concept as path resolution and bootstrap output.
+
+## Risks
+
+- **R1 — Cleanup runs before canonize PRs are visible.** Canonize
+  may open Model C PRs that take seconds to register on GitHub;
+  if the user inspects `.yoke/runtime/` immediately after exit,
+  it will be empty even if the PRs are still being created.
+  *Mitigation:* the skill's exit summary already prints PR URLs
+  (`SKILL.md:275-276` "Canonization summary: <count> PRs opened.").
+  The user reads URLs from stdout, not from runtime/. Acceptable.
+- **R2 — Tracked-files hint fails inside non-git directories.**
+  `git ls-files` errors when run outside a repo. *Mitigation:*
+  `wm_check_runtime_tracked` short-circuits on `git rev-parse
+  --is-inside-work-tree` returning non-zero. No hint, no error.
+- **R3 — Manual re-canonization workflow breaks.**
+  `skills/implement/SKILL.md:310` advertises `/yoke:preserve` as
+  re-invocable for re-canonizing stale working memory after a model
+  upgrade. With auto-cleanup, runtime is gone before the user can
+  re-canonize. *Mitigation accepted in v0:* canonical memory itself
+  is the right re-canonization surface — if a model upgrade should
+  re-evaluate stored doctrine, it should re-evaluate canonical
+  memory entries directly, not stale working memory. If a real user
+  surfaces this need, add `runtime.preserve_after_canonize: true`
+  to `.yoke/config.yaml` as an opt-out. Not part of v0.
+- **R4 — Ordering bug: cleanup before canonize PR-URL summary
+  printed.** If cleanup runs *between* canonize-handoff and the
+  exit summary, and the summary references files inside runtime
+  (it doesn't today, but a future change might), the summary
+  would print stale references. *Mitigation:* DoD #1 specifies
+  cleanup runs *after* canonize returns and *before* the exit
+  summary. The skill's own contract enforces the order; review
+  in CR step.
+- **R5 — Test fixture pollution.** Tests staging
+  `.yoke/runtime/` content in the repo's tmp dirs may leak into
+  commits if the tmp path is wrong. *Mitigation:* follow the
+  existing pattern in `tests/working-memory.test.sh:59` of using
+  `mktemp -d` per assertion and trapping cleanup in EXIT. Already
+  the convention; no new risk.
+
+## Files touched (≤ 4)
+
+1. `lib/working-memory/cleanup.sh` (NEW) — three helper functions.
+2. `skills/implement/SKILL.md` (EDIT) — preflight + termination
+   integration, anti-pattern bullet.
+3. `tests/working-memory.test.sh` (EDIT) — four new assertions.
+4. — (held in reserve; v0 does not need a fourth file).

--- a/hooks/verify-acceptance.sh
+++ b/hooks/verify-acceptance.sh
@@ -21,7 +21,7 @@
 #
 # Default contract path: resolved via lib/working-memory/paths.sh::wm_acceptance_contract_path
 #                        (i.e., .yoke/acceptance-contracts/<slug>.md, where <slug>
-#                        comes from .yoke/.current).
+#                        comes from .yoke/runtime/.current).
 #
 # v0.3.0 supports only "shell command" sensor types (e.g. `npm test`,
 # `pytest`). Richer sensor types (structural fixtures, inferential

--- a/lib/working-memory/cleanup.sh
+++ b/lib/working-memory/cleanup.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# cleanup.sh — working-memory hygiene helpers for /yoke:implement.
+#
+# Three deterministic functions, all idempotent and silent-on-success:
+#   wm_gitignore_self_heal     — write/repair .yoke/.gitignore
+#   wm_check_runtime_tracked   — emit a one-line remediation hint when
+#                                .yoke/runtime/ has tracked files
+#   wm_runtime_cleanup         — delete contents of .yoke/runtime/ iff
+#                                termination was MERGE-READY *and* the
+#                                canonize handoff returned exit 0
+#
+# Convention: "Back-pressure: success is silent, failures are verbose."
+# Correct state produces no output; repaired/violation states produce
+# exactly one line on stdout. Errors go to stderr with the "wm:" prefix.
+#
+# Usage from /yoke:implement:
+#   source lib/working-memory/paths.sh
+#   source lib/working-memory/cleanup.sh
+#   # preflight
+#   wm_gitignore_self_heal
+#   wm_check_runtime_tracked
+#   # ...loop...
+#   # termination (after canonize handoff)
+#   wm_runtime_cleanup "$termination_reason" "$canonize_exit_code"
+
+if [[ -n "${_WM_CLEANUP_LOADED:-}" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+readonly _WM_CLEANUP_LOADED=1
+
+# Hard dependency on paths.sh: wm_runtime_dir + wm_wipe_runtime.
+# Intentionally not auto-sourced — callers source paths.sh first.
+if [[ -z "${_WM_PATHS_LOADED:-}" ]]; then
+    echo "wm: cleanup.sh requires lib/working-memory/paths.sh — source it first" >&2
+    return 1 2>/dev/null || exit 1
+fi
+
+readonly _WM_GITIGNORE_PATH="${WM_ROOT}/.gitignore"
+readonly _WM_GITIGNORE_CONTENT='runtime/'
+
+# wm_gitignore_self_heal
+#   Idempotently writes .yoke/.gitignore with the canonical two-line
+#   content (".current" + "runtime/"). When the file is already correct,
+#   produces no output. When missing or incomplete, writes/overwrites
+#   it and prints exactly one line of notice.
+#
+#   Returns 0 always (creating .yoke/ if absent so the write succeeds).
+wm_gitignore_self_heal() {
+    mkdir -p "$WM_ROOT"
+    if [[ -f "$_WM_GITIGNORE_PATH" ]]; then
+        local current
+        current="$(cat "$_WM_GITIGNORE_PATH")"
+        if [[ "$current" == "$_WM_GITIGNORE_CONTENT" ]]; then
+            return 0
+        fi
+    fi
+    printf '%s\n' "$_WM_GITIGNORE_CONTENT" > "$_WM_GITIGNORE_PATH"
+    echo "[yoke] repaired .yoke/.gitignore (wrote: runtime/)"
+}
+
+# wm_check_runtime_tracked
+#   When run inside a git work tree, checks whether any path under
+#   .yoke/runtime/ is tracked. If so, prints exactly one line with
+#   the remediation command. Read-only — never modifies git state.
+#   Silently returns 0 outside a git work tree.
+wm_check_runtime_tracked() {
+    git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+    if git ls-files --error-unmatch -- "$WM_RUNTIME_DIR" >/dev/null 2>&1; then
+        echo "[yoke] .yoke/runtime/ has tracked files. Run: git rm -r --cached .yoke/runtime/"
+    fi
+    return 0
+}
+
+# wm_runtime_cleanup <termination_reason> <canonize_exit_code>
+#   Deletes the contents of .yoke/runtime/ iff:
+#     reason == "merge-ready" AND canonize_exit == 0
+#   Otherwise no-op. The directory itself is preserved.
+#
+#   Reasons that intentionally skip cleanup:
+#     divergence, contract-conflict, hard-bound, infeasibility
+#   These are arbitration pauses; the user must be able to resume the
+#   loop with full cycle history.
+#
+#   A non-zero canonize exit also skips cleanup so the user can
+#   re-invoke /yoke:preserve manually against intact runtime state.
+wm_runtime_cleanup() {
+    local reason="${1:-}"
+    local canonize_exit="${2:-}"
+    if [[ -z "$reason" || -z "$canonize_exit" ]]; then
+        echo "wm: wm_runtime_cleanup requires <termination_reason> <canonize_exit_code>; got reason='$reason' canonize_exit='$canonize_exit'" >&2
+        return 1
+    fi
+    if [[ "$reason" != "merge-ready" ]]; then
+        return 0
+    fi
+    if [[ "$canonize_exit" != "0" ]]; then
+        return 0
+    fi
+    wm_wipe_runtime
+}

--- a/lib/working-memory/paths.sh
+++ b/lib/working-memory/paths.sh
@@ -8,13 +8,13 @@
 #   .yoke/
 #   ├── config.yaml                                # versioned
 #   ├── .gitignore                                 # versioned
-#   ├── .current                                   # gitignored, per-worktree
 #   ├── prds/<slug>.md                             # versioned archive
 #   ├── specs/<slug>.md                            # versioned archive  (tech-spec-task-split sprint index)
 #   ├── tasks/<slug>-s<NN>-t<MM>.md                # versioned archive  (tech-spec-task-split per-task body)
 #   ├── acceptance-contracts/<slug>.md             # versioned archive
 #   ├── contracts/<slug>.md                        # versioned archive
 #   └── runtime/                                   # gitignored
+#       ├── .current                               # per-worktree active-task pointer
 #       ├── progress.md
 #       ├── .cycle-counter
 #       ├── .trigger4-packet.yaml
@@ -46,8 +46,8 @@ fi
 readonly _WM_PATHS_LOADED=1
 
 readonly WM_ROOT=".yoke"
-readonly WM_CURRENT_FILE="${WM_ROOT}/.current"
 readonly WM_RUNTIME_DIR="${WM_ROOT}/runtime"
+readonly WM_CURRENT_FILE="${WM_RUNTIME_DIR}/.current"
 readonly WM_SLUG_REGEX='^[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9][a-z0-9-]{0,49}$'
 readonly WM_TASK_NUM_REGEX='^[1-9][0-9]{0,2}$'
 readonly WM_ARCHIVE_CATEGORIES=(prds specs tasks acceptance-contracts contracts)
@@ -79,7 +79,7 @@ wm_active_slug() {
 wm_set_active() {
     local slug="${1:-}"
     wm_validate_slug "$slug" || return 1
-    mkdir -p "$WM_ROOT"
+    mkdir -p "$WM_RUNTIME_DIR"
     printf '%s' "$slug" > "$WM_CURRENT_FILE"
 }
 

--- a/skills/acceptance-contract/SKILL.md
+++ b/skills/acceptance-contract/SKILL.md
@@ -6,7 +6,7 @@ description: >
   functional requirements, applicable policies, and the sensors that
   will run during Phase 4. Saves to
   `.yoke/acceptance-contracts/<slug>.md`, where <slug> comes from
-  `.yoke/.current`. Pauses for Trigger-3 ratification with the binding
+  `.yoke/runtime/.current`. Pauses for Trigger-3 ratification with the binding
   statement printed verbatim.
 argument-hint: ""
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash
@@ -51,7 +51,7 @@ the Generator captures intent, you express measurable rigor:
 - Source `lib/working-memory/paths.sh`. All paths below resolve through `wm_*_path`.
 - Verify `.yoke/config.yaml` exists. If not, abort: "Run
   `/yoke:bootstrap` first."
-- Resolve the active task: `slug="$(wm_active_slug)"`. If `.yoke/.current` is missing, surface the helper's "no active task" error and instruct the user to run `/yoke:discover`.
+- Resolve the active task: `slug="$(wm_active_slug)"`. If `.yoke/runtime/.current` is missing, surface the helper's "no active task" error and instruct the user to run `/yoke:discover`.
 - Verify `wm_prd_path "$slug"` exists AND is approved. Abort otherwise:
   "PRD missing or unapproved at <path>. Run `/yoke:discover` first."
 - Verify `wm_spec_path "$slug"` exists AND is approved. Abort
@@ -211,7 +211,7 @@ rejected (no `Status: ratified` is written) and the skill exits cleanly.
 ## Pre-conditions
 
 - `.yoke/config.yaml` exists.
-- `.yoke/.current` exists and points at a valid slug.
+- `.yoke/runtime/.current` exists and points at a valid slug.
 - `.yoke/prds/<slug>.md` exists and is approved.
 - `.yoke/specs/<slug>.md` exists and is approved.
 - `.yoke/tasks/<slug>-s*-t*.md` is non-empty AND every task file

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -112,12 +112,11 @@ Create:
   - `canonical_memory.name` (from Step 4 — registered slug, or empty if deferred)
   - `created_at` (today's date, ISO 8601)
   - `yoke_version` (from this plugin's `plugin.json`)
-- `.yoke/.gitignore` with exactly two lines:
+- `.yoke/.gitignore` with exactly one line:
   ```
-  .current
   runtime/
   ```
-  Rationale: archive categories (`prds/`, `specs/`, `tasks/`, `acceptance-contracts/`, `contracts/`) are versioned by the host project. Only the per-worktree active-task pointer (`.current`) and the runtime working directory (`runtime/`) are ephemeral. See `lib/working-memory/paths.sh`.
+  Rationale: archive categories (`prds/`, `specs/`, `tasks/`, `acceptance-contracts/`, `contracts/`) are versioned by the host project. The runtime working directory (`runtime/`) is the single ephemeral surface — the per-worktree active-task pointer lives at `runtime/.current`, so one ignore rule covers all per-worktree state. See `lib/working-memory/paths.sh`.
 
 Do **not** pre-create archive category folders or any flat working-memory files (`prd.md`, `tech-spec.md`, etc.) — those are created lazily by `/yoke:discover` and downstream skills. After bootstrap completes, `.yoke/` contains exactly `config.yaml` and `.gitignore`.
 

--- a/skills/discover/SKILL.md
+++ b/skills/discover/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Phase 1 — Discovery. Runs an interactive dialogue (1–5 rounds) to turn
   an idea into an approved PRD with product invariants, business context,
   known constraints, risks, and open questions. Saves to
-  `.yoke/prds/<YYYY-MM-DD>-<slug>.md` and sets `.yoke/.current` to the
+  `.yoke/prds/<YYYY-MM-DD>-<slug>.md` and sets `.yoke/runtime/.current` to the
   slug. Pauses for explicit human approval (Trigger 1) before completing.
 argument-hint: "<idea>"
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash
@@ -143,7 +143,7 @@ After slug confirmation, in this order:
 - Technical Context (`.yoke/`-grounded if available)
 - Open Questions (TODOs to resolve before `/yoke:tech-spec`)
 
-4. `wm_set_active "<slug>"` — write the slug to `.yoke/.current` (no
+4. `wm_set_active "<slug>"` — write the slug to `.yoke/runtime/.current` (no
    trailing newline).
 
 ### 6. Canonical memory consultation
@@ -191,7 +191,7 @@ the skill records approval and stops (collapses to `approve`).
 ### 8. Re-invocation semantics
 
 Every `/yoke:discover` invocation starts a *new* task. There is no
-"continue active task" branch. If `.yoke/.current` exists when the
+"continue active task" branch. If `.yoke/runtime/.current` exists when the
 skill starts, it will be overwritten with the new slug after step 5;
 the previous task's archive files (in `prds/`, `specs/`, `tasks/`, etc.)
 remain on disk untouched. Different git worktrees get independent
@@ -202,7 +202,7 @@ remain on disk untouched. Different git worktrees get independent
 On `approve` or `approve_and_continue`:
 - The versioned PRD (`wm_prd_path "$slug"`) carries `Status: approved`,
   `Approved by`, `Approved at` in its frontmatter.
-- `.yoke/.current` contains exactly `<slug>`.
+- `.yoke/runtime/.current` contains exactly `<slug>`.
 - `.yoke/runtime/` exists and is empty.
 - No flat working-memory files at the legacy paths exist.
 - On `approve_and_continue` (after the open-questions warning, when
@@ -229,7 +229,7 @@ cleanly.
 ## Output contract
 
 - Exit 0 with the versioned PRD populated and approved, and
-  `.yoke/.current` containing exactly the slug.
+  `.yoke/runtime/.current` containing exactly the slug.
 - Exit non-zero on missing `.yoke/config.yaml`, user abort, slug-collision
   exhaustion without user choice, or unrecoverable dialogue stall after
   5 rounds.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -33,12 +33,22 @@ termination.
 
 ### 1. Pre-flight (deterministic)
 
-- Source `lib/working-memory/paths.sh`. All paths below resolve through
-  `wm_*_path` helpers; the active task slug comes from `.yoke/.current`
+- Source `lib/working-memory/paths.sh` and
+  `lib/working-memory/cleanup.sh`. All paths below resolve through
+  `wm_*_path` helpers; the active task slug comes from `.yoke/runtime/.current`
   via `wm_active_slug`.
+- **Working-memory hygiene (deterministic, silent on success).** Call
+  `wm_gitignore_self_heal` to write/repair `.yoke/.gitignore` if
+  missing or incomplete (canonical content: `.current` + `runtime/`).
+  Then call `wm_check_runtime_tracked` to detect host projects that
+  bootstrapped before the gitignore landed and still track
+  `.yoke/runtime/`; on detection it prints a one-line remediation hint
+  pointing at `git rm -r --cached .yoke/runtime/` and never modifies
+  git state. Both are read-only against the loop's working memory and
+  must run *before* the orchestrate.sh preflight call below.
 - Run `lib/ralph-loop/orchestrate.sh preflight`. The script verifies:
   - `.yoke/config.yaml` exists.
-  - `.yoke/.current` exists and points at a valid slug.
+  - `.yoke/runtime/.current` exists and points at a valid slug.
   - `wm_prd_path "$slug"`, `wm_spec_path "$slug"`, and
     `wm_acceptance_contract_path "$slug"` all exist and carry
     `Status: approved` (PRD/Spec) or `Status: ratified` (Contract).
@@ -304,11 +314,25 @@ PRs opened (count + URLs).
 
 ### 4. Termination paths
 
+After the canonize handoff in §3 returns, call
+`wm_runtime_cleanup "$termination_reason" "$canonize_exit_code"`
+(from `lib/working-memory/cleanup.sh`) **before** printing the exit
+summary. The helper is gated on `(reason == merge-ready &&
+canonize_exit == 0)` and is a no-op otherwise — so paused
+terminations (divergence, contract-conflict, hard-bound,
+infeasibility) and canonize failures preserve `.yoke/runtime/`
+intact for the user to arbitrate, resume, or manually re-canonize.
+
 - **All criteria pass** → loop returns MERGE-READY; canonize handoff
   fires (Orchestrator invokes `/yoke:preserve` via the Skill tool).
-  Print: "Merge-ready. Canonization summary: <count> PRs opened."
+  On canonize success, `wm_runtime_cleanup` deletes the contents of
+  `wm_runtime_dir` (the directory itself stays). Print:
+  "Merge-ready. Canonization summary: <count> PRs opened."
   `/yoke:preserve` can also be invoked manually for re-canonization
-  (e.g. after a model upgrade or to re-evaluate stale working memory).
+  against canonical memory (e.g. after a model upgrade) — note that
+  runtime working memory has been cleared by the cleanup step, so
+  manual re-canonization re-evaluates canonical entries directly,
+  not stale runtime state.
 - **Sprint contract contradicts Acceptance Contract** → invoke
   `lib/ralph-loop/escalate.sh --reason contract-conflict`; emits
   Trigger-4 packet; canonize handoff still fires (with termination
@@ -328,7 +352,7 @@ see `.vibeflow/patterns/human-triggers.md`.
 ## Pre-conditions
 
 - `.yoke/config.yaml` exists.
-- `.yoke/.current` exists and points at a valid slug.
+- `.yoke/runtime/.current` exists and points at a valid slug.
 - `.yoke/prds/<slug>.md` (approved), `.yoke/specs/<slug>.md`
   (approved), every `.yoke/tasks/<slug>-s*-t*.md`
   (`status: approved`), `.yoke/acceptance-contracts/<slug>.md`
@@ -367,6 +391,12 @@ see `.vibeflow/patterns/human-triggers.md`.
 - Do NOT skip `hooks/verify-acceptance.sh` between cycles — sensor
   output is the structured channel through which the Validator
   judges the next cycle.
+- Do NOT call `wm_runtime_cleanup` on non-MERGE-READY exits — paused
+  loops (Trigger-4 divergence, contract-conflict, hard-bound,
+  infeasibility) require cycle history for resumption. The helper is
+  internally gated on `(reason == merge-ready && canonize_exit == 0)`;
+  bypassing the gate destroys the user's ability to resume after
+  arbitration.
 - Do NOT silently relax the Acceptance Contract. Sprint contracts
   that contradict the Contract pause the loop.
 - Do NOT proceed past 5–8 cycles without an external `timeout`

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -49,7 +49,7 @@ Source `lib/working-memory/paths.sh`.
 ### 1.1 Active task
 
 1. Read the active slug via `wm_active_slug`.
-2. If `.yoke/.current` is missing, print `no active task` and skip
+2. If `.yoke/runtime/.current` is missing, print `no active task` and skip
    to Section 2 (this is not an error — the host may simply not have
    a task in flight).
 
@@ -203,7 +203,7 @@ to keep `--all` output readable.
 - Auto-fixing detected issues — that's `/yoke:compress`'s job.
 - Writing the report to a file inside the memory — output to stdout
   only.
-- Failing on missing `.yoke/.current` — degrade to "no active task"
+- Failing on missing `.yoke/runtime/.current` — degrade to "no active task"
   and continue.
 - Claiming a section as `OK` without actually running its checks.
 

--- a/skills/tech-spec/SKILL.md
+++ b/skills/tech-spec/SKILL.md
@@ -81,7 +81,7 @@ prose.
 
 - Source `lib/working-memory/paths.sh`. All paths below resolve through `wm_*` helpers.
 - Verify `.yoke/config.yaml` exists. If not, abort: "Run `/yoke:bootstrap` first."
-- Resolve the active task: `slug="$(wm_active_slug)"`. If `.yoke/.current` is missing, the helper aborts with "no active task" — surface that and instruct the user to run `/yoke:discover`.
+- Resolve the active task: `slug="$(wm_active_slug)"`. If `.yoke/runtime/.current` is missing, the helper aborts with "no active task" — surface that and instruct the user to run `/yoke:discover`.
 - Verify `wm_prd_path "$slug"` exists AND is approved (header carries
   `Status: approved`). If missing or unapproved, abort: "PRD missing
   or unapproved at <path>. Run `/yoke:discover` first."
@@ -322,7 +322,7 @@ skill exits cleanly.
 ## Pre-conditions
 
 - `.yoke/config.yaml` exists.
-- `.yoke/.current` exists and points at a valid slug.
+- `.yoke/runtime/.current` exists and points at a valid slug.
 - `.yoke/prds/<slug>.md` exists and is approved.
 
 ## Output contract

--- a/tests/ack-sensors-inferential.test.sh
+++ b/tests/ack-sensors-inferential.test.sh
@@ -251,8 +251,8 @@ else
   # family uses printf without trailing newline, so capture each
   # invocation in its own subshell and compare exactly.
   helper_tmp=$(mktemp -d)
-  mkdir -p "$helper_tmp/.yoke"
-  echo 2026-04-26-test-slug > "$helper_tmp/.yoke/.current"
+  mkdir -p "$helper_tmp/.yoke/runtime"
+  echo 2026-04-26-test-slug > "$helper_tmp/.yoke/runtime/.current"
   dir_actual=$(
     cd "$helper_tmp" \
       && bash -c "source \"$PATHS_LIB\" && wm_judge_verdict_dir 2026-04-26-test-slug 3" 2>&1

--- a/tests/bootstrap.test.sh
+++ b/tests/bootstrap.test.sh
@@ -3,7 +3,7 @@
 #
 # /yoke:bootstrap host-project scaffolding:
 #   (a) simulating bootstrap's file effects creates .yoke/config.yaml and
-#       .yoke/.gitignore (content exactly .current\nruntime/)
+#       .yoke/.gitignore (content exactly runtime/)
 #   (b) the host repo's working tree shows the new .yoke/ files but no
 #       auto-commit was made by the simulation (mirroring the SKILL's
 #       declared no-host-pollution invariant)
@@ -64,7 +64,7 @@ canonical_memory:
   name: ""
 created_at: "2026-04-25"
 YAML
-  printf '.current\nruntime/\n' > .yoke/.gitignore
+  printf 'runtime/\n' > .yoke/.gitignore
 )
 
 # (a) Files exist
@@ -81,9 +81,9 @@ else
 fi
 
 gi=$(cat "$TMP/.yoke/.gitignore")
-expected=$'.current\nruntime/'
+expected='runtime/'
 if [ "$gi" = "$expected" ]; then
-  pass "(a) .yoke/.gitignore content is exactly .current\\nruntime/"
+  pass "(a) .yoke/.gitignore content is exactly runtime/"
 else
   err "(a) .yoke/.gitignore content unexpected:"
   printf '%s\n' "$gi" | sed 's/^/    /' >&2

--- a/tests/perf-quickwins-part-1.test.sh
+++ b/tests/perf-quickwins-part-1.test.sh
@@ -143,7 +143,7 @@ cd "$yoke_root"
 mkdir -p .yoke/runtime .yoke/acceptance-contracts
 echo "config_version: 1" > .yoke/config.yaml
 slug="2026-04-25-counter-fixture"
-echo -n "$slug" > .yoke/.current
+echo -n "$slug" > .yoke/runtime/.current
 
 counter_file="$tmpdir/exec-counter"
 echo 0 > "$counter_file"

--- a/tests/working-memory.test.sh
+++ b/tests/working-memory.test.sh
@@ -3,15 +3,15 @@
 #
 # Working-memory layout invariants:
 #   (a) every file written under .yoke/ lands in an allowed location
-#       (config.yaml, .gitignore, .current, prds/<slug>.md,
+#       (config.yaml, .gitignore, prds/<slug>.md,
 #        tech-specs/<slug>.md, acceptance-contracts/<slug>.md,
-#        contracts/<slug>.md, runtime/*)
+#        contracts/<slug>.md, runtime/* — including runtime/.current)
 #   (b) no flat .yoke/<file>.md exists for
 #       prd|tech-spec|acceptance-contract|contracts|progress
 #   (c) static grep over skills/, lib/, hooks/ finds no flat-path strings
 #       outside paths.sh
-#   (d) .gitignore content is exactly .current\nruntime/
-#   (e) .current size equals the slug byte length (no trailing newline)
+#   (d) .gitignore content is exactly runtime/
+#   (e) .yoke/runtime/.current size equals the slug byte length (no trailing newline)
 #
 # The dynamic flow exercises lib/working-memory/paths.sh directly in a
 # tmpdir; skills are markdown — exercising prose belongs to spec phase,
@@ -56,7 +56,7 @@ yoke_version: "test"
 canonical_memory:
   url: ""
 YAML
-  printf '.current\nruntime/\n' > .yoke/.gitignore
+  printf 'runtime/\n' > .yoke/.gitignore
 
   wm_wipe_runtime
   mkdir -p "$(dirname "$(wm_prd_path "$SLUG")")"
@@ -85,7 +85,6 @@ while IFS= read -r f; do
   case "$rel" in
     .yoke/config.yaml) ;;
     .yoke/.gitignore) ;;
-    .yoke/.current) ;;
     .yoke/prds/"$SLUG".md) ;;
     .yoke/specs/"$SLUG".md) ;;
     .yoke/tasks/*) ;;
@@ -125,21 +124,173 @@ fi
 
 # (d) .gitignore content exact
 gi=$(cat "$TMP/.yoke/.gitignore")
-expected_gi=$'.current\nruntime/'
+expected_gi='runtime/'
 if [ "$gi" = "$expected_gi" ]; then
-  pass "(d) .gitignore content is exactly .current\\nruntime/"
+  pass "(d) .gitignore content is exactly runtime/"
 else
   err "(d) .gitignore content unexpected:"
   printf '%s\n' "$gi" | sed 's/^/    /' >&2
 fi
 
-# (e) .current size = slug byte length (no trailing newline)
-on_disk=$(wc -c < "$TMP/.yoke/.current" | tr -d ' ')
+# (e) runtime/.current size = slug byte length (no trailing newline)
+on_disk=$(wc -c < "$TMP/.yoke/runtime/.current" | tr -d ' ')
 expected_size=$(printf %s "$SLUG" | wc -c | tr -d ' ')
 if [ "$on_disk" = "$expected_size" ]; then
-  pass "(e) .current is exactly the slug ($on_disk bytes; no trailing newline)"
+  pass "(e) runtime/.current is exactly the slug ($on_disk bytes; no trailing newline)"
 else
-  err "(e) .current size mismatch (on_disk=$on_disk expected=$expected_size)"
+  err "(e) runtime/.current size mismatch (on_disk=$on_disk expected=$expected_size)"
+fi
+
+# ---------------------------------------------------------------------
+# (f, g, h, i) cleanup.sh helpers — gated runtime wipe + gitignore heal
+# ---------------------------------------------------------------------
+
+# (f) wm_runtime_cleanup deletes contents on MERGE-READY + canonize-success
+# (g) wm_runtime_cleanup is a no-op on paused exits / canonize failure
+TMP_F=$(mktemp -d)
+trap 'rm -rf "$TMP" "$TMP_F" "$TMP_GH" "$TMP_TR"' EXIT
+
+(
+  cd "$TMP_F"
+  # shellcheck source=/dev/null
+  source "$PLUGIN_ROOT/lib/working-memory/paths.sh"
+  # shellcheck source=/dev/null
+  source "$PLUGIN_ROOT/lib/working-memory/cleanup.sh"
+
+  mkdir -p "$(wm_runtime_dir)/.snapshots"
+  printf '# Progress\n' > "$(wm_progress_path)"
+  printf '1\n' > "$(wm_cycle_counter_path)"
+  printf 'cycle: 1\n' > "$(wm_snapshots_dir)/cycle-1.yaml"
+
+  # MERGE-READY + canonize success → wipe
+  wm_runtime_cleanup "merge-ready" "0" >/dev/null
+
+  remaining=$(find "$(wm_runtime_dir)" -mindepth 1 -print 2>/dev/null | wc -l | tr -d ' ')
+  echo "$remaining" > /tmp/.yoke-cleanup-remaining-merge-ready
+
+  # Stage runtime again for the paused-exit assertion
+  mkdir -p "$(wm_snapshots_dir)"
+  printf '# Progress\n' > "$(wm_progress_path)"
+  printf 'cycle: 1\n' > "$(wm_snapshots_dir)/cycle-1.yaml"
+
+  # Paused exit → no-op
+  wm_runtime_cleanup "hard-bound" "0" >/dev/null
+  remaining_paused=$(find "$(wm_runtime_dir)" -mindepth 1 -print 2>/dev/null | wc -l | tr -d ' ')
+  echo "$remaining_paused" > /tmp/.yoke-cleanup-remaining-paused
+
+  # MERGE-READY but canonize failed → no-op
+  wm_runtime_cleanup "merge-ready" "7" >/dev/null
+  remaining_canonize_fail=$(find "$(wm_runtime_dir)" -mindepth 1 -print 2>/dev/null | wc -l | tr -d ' ')
+  echo "$remaining_canonize_fail" > /tmp/.yoke-cleanup-remaining-canonize-fail
+)
+
+f_remaining=$(cat /tmp/.yoke-cleanup-remaining-merge-ready)
+g_paused=$(cat /tmp/.yoke-cleanup-remaining-paused)
+g_canonize_fail=$(cat /tmp/.yoke-cleanup-remaining-canonize-fail)
+rm -f /tmp/.yoke-cleanup-remaining-merge-ready /tmp/.yoke-cleanup-remaining-paused /tmp/.yoke-cleanup-remaining-canonize-fail
+
+if [ "$f_remaining" = "0" ]; then
+  pass "(f) wm_runtime_cleanup wipes runtime contents on merge-ready + canonize-success"
+else
+  err "(f) wm_runtime_cleanup left $f_remaining file(s) after merge-ready + canonize-success"
+fi
+
+if [ "$g_paused" -gt 0 ] && [ "$g_canonize_fail" -gt 0 ]; then
+  pass "(g) wm_runtime_cleanup preserves runtime on paused exits and canonize failure"
+else
+  err "(g) wm_runtime_cleanup wiped runtime when it should have preserved it (paused=$g_paused canonize_fail=$g_canonize_fail)"
+fi
+
+# (h) wm_gitignore_self_heal repairs missing/incomplete .yoke/.gitignore
+TMP_GH=$(mktemp -d)
+(
+  cd "$TMP_GH"
+  # shellcheck source=/dev/null
+  source "$PLUGIN_ROOT/lib/working-memory/paths.sh"
+  # shellcheck source=/dev/null
+  source "$PLUGIN_ROOT/lib/working-memory/cleanup.sh"
+
+  # Case 1: missing → repaired
+  rm -rf .yoke
+  output_missing=$(wm_gitignore_self_heal)
+  echo "$output_missing" > /tmp/.yoke-heal-output-missing
+  cp .yoke/.gitignore /tmp/.yoke-heal-content-missing
+
+  # Case 2: incomplete (empty file) → repaired
+  : > .yoke/.gitignore
+  output_incomplete=$(wm_gitignore_self_heal)
+  echo "$output_incomplete" > /tmp/.yoke-heal-output-incomplete
+  cp .yoke/.gitignore /tmp/.yoke-heal-content-incomplete
+
+  # Case 3: already correct → silent
+  output_correct=$(wm_gitignore_self_heal)
+  echo "$output_correct" > /tmp/.yoke-heal-output-correct
+)
+
+heal_missing=$(cat /tmp/.yoke-heal-output-missing)
+heal_incomplete=$(cat /tmp/.yoke-heal-output-incomplete)
+heal_correct=$(cat /tmp/.yoke-heal-output-correct)
+heal_content_missing=$(cat /tmp/.yoke-heal-content-missing)
+heal_content_incomplete=$(cat /tmp/.yoke-heal-content-incomplete)
+rm -f /tmp/.yoke-heal-output-missing /tmp/.yoke-heal-output-incomplete /tmp/.yoke-heal-output-correct \
+      /tmp/.yoke-heal-content-missing /tmp/.yoke-heal-content-incomplete
+
+expected_gi_full='runtime/'
+if [ -n "$heal_missing" ] \
+   && [ -n "$heal_incomplete" ] \
+   && [ -z "$heal_correct" ] \
+   && [ "$heal_content_missing" = "$expected_gi_full" ] \
+   && [ "$heal_content_incomplete" = "$expected_gi_full" ]; then
+  pass "(h) wm_gitignore_self_heal: silent on correct, one-line on repair, content canonical"
+else
+  err "(h) wm_gitignore_self_heal misbehaved (missing='$heal_missing' incomplete='$heal_incomplete' correct='$heal_correct')"
+fi
+
+# (i) wm_check_runtime_tracked emits a hint when runtime/ is tracked,
+#     never modifies git state, and is silent when not tracked
+TMP_TR=$(mktemp -d)
+(
+  cd "$TMP_TR"
+  git init -q
+  git config user.email "test@example.com"
+  git config user.name  "Test"
+  # shellcheck source=/dev/null
+  source "$PLUGIN_ROOT/lib/working-memory/paths.sh"
+  # shellcheck source=/dev/null
+  source "$PLUGIN_ROOT/lib/working-memory/cleanup.sh"
+
+  mkdir -p "$(wm_runtime_dir)"
+  printf '# leaked\n' > "$(wm_runtime_dir)/progress.md"
+  git add -f "$(wm_runtime_dir)/progress.md"
+  git commit -q -m "leak"
+
+  before_status=$(git status --porcelain)
+  output_tracked=$(wm_check_runtime_tracked)
+  after_status=$(git status --porcelain)
+  echo "$output_tracked" > /tmp/.yoke-tr-output-tracked
+  echo "$before_status" > /tmp/.yoke-tr-status-before
+  echo "$after_status"  > /tmp/.yoke-tr-status-after
+
+  # Untrack and re-check: silent
+  git rm -q --cached "$(wm_runtime_dir)/progress.md"
+  git commit -q -m "untrack"
+  rm -f "$(wm_runtime_dir)/progress.md"
+  output_untracked=$(wm_check_runtime_tracked)
+  echo "$output_untracked" > /tmp/.yoke-tr-output-untracked
+)
+
+tr_tracked=$(cat /tmp/.yoke-tr-output-tracked)
+tr_before=$(cat /tmp/.yoke-tr-status-before)
+tr_after=$(cat /tmp/.yoke-tr-status-after)
+tr_untracked=$(cat /tmp/.yoke-tr-output-untracked)
+rm -f /tmp/.yoke-tr-output-tracked /tmp/.yoke-tr-status-before /tmp/.yoke-tr-status-after /tmp/.yoke-tr-output-untracked
+
+if echo "$tr_tracked" | grep -q "git rm -r --cached .yoke/runtime/" \
+   && [ "$tr_before" = "$tr_after" ] \
+   && [ -z "$tr_untracked" ]; then
+  pass "(i) wm_check_runtime_tracked emits hint when tracked, silent when not, never mutates git"
+else
+  err "(i) wm_check_runtime_tracked misbehaved (tracked='$tr_tracked' status_changed='$([ "$tr_before" != "$tr_after" ] && echo yes || echo no)' untracked='$tr_untracked')"
 fi
 
 harness::summary


### PR DESCRIPTION
## Summary

Three spec cycles, one PR. End state: `/yoke:implement` self-cleans `.yoke/runtime/` on MERGE-READY (with canonize-success gate), `.yoke/.gitignore` self-heals at preflight, and the active-task pointer lives at `.yoke/runtime/.current` — collapsing two ephemeral surfaces into one with a single ignore rule.

- **runtime-cleanup** (3 files) — `lib/working-memory/cleanup.sh` with three deterministic helpers (`wm_runtime_cleanup`, `wm_gitignore_self_heal`, `wm_check_runtime_tracked`); wired into `/yoke:implement` preflight + termination. Cleanup is gated on `(reason == merge-ready && canonize_exit == 0)` so paused exits (Trigger-4 divergence, hard-bound, infeasibility, contract-conflict) preserve cycle history for resumption.
- **current-into-runtime-part-1** (8 files, atomic) — `WM_CURRENT_FILE` now resolves to `${WM_RUNTIME_DIR}/.current`; bootstrap gitignore collapses to a single line (`runtime/`); all four impacted tests updated in the same commit so CI stays green.
- **current-into-runtime-part-2** (5 files, doc-only) — every prose reference to `.yoke/.current` across `discover`, `status`, `tech-spec`, `acceptance-contract`, and `implement` SKILL.md files now reads `.yoke/runtime/.current`.

Architectural note: this resolves the `runtime-cleanup` spec's Open Question #3 (`.current` cleanup) **against** "leave-it" — the active-task pointer is now genuinely ephemeral and is cleared on MERGE-READY along with cycle artifacts. Next `/yoke:discover` writes a fresh pointer; PR URLs printed in the canonize summary carry the "last task touched" signal.

Audits (PASS): `.vibeflow/audits/runtime-cleanup-audit.md`, `.vibeflow/audits/current-into-runtime-part-1-audit.md`, `.vibeflow/audits/current-into-runtime-part-2-audit.md`.

## Test plan

- [x] `bash tests/working-memory.test.sh` — 9/9 (added f/g/h/i for cleanup helpers)
- [x] `bash tests/bootstrap.test.sh` — 7/7 (gitignore literal collapsed to `runtime/`)
- [x] `bash tests/perf-quickwins-part-1.test.sh` — PASS (`.current` write path updated)
- [x] `bash tests/ack-sensors-inferential.test.sh` — PASS (helper-tmp fixture updated)
- [x] Full 18-suite framework matrix — all PASS, no regressions
- [x] `grep -rn "\.yoke/\.current" lib/ hooks/ skills/ agents/ tests/ templates/ docs/` returns zero hits (only `.vibeflow/` historical records retain old refs, intentional per spec anti-scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)