### PR TITLE
feat: sensor cost tiering — per-sensor files + --tier filter + Validator scheduling

### DIFF
--- a/.vibeflow/audits/perf-quickwins-baseline.yaml
+++ b/.vibeflow/audits/perf-quickwins-baseline.yaml
@@ -1,9 +1,9 @@
 baseline:
-  serial_ns: 3266483000
-  parallel_ns: 1162444000
-  ratio_pct: 35
+  serial_ns: 3434194000
+  parallel_ns: 1257442000
+  ratio_pct: 36
   target_ratio_pct: 70
   fixture_sensors: 3
   fixture_per_sensor_sleep_s: 1
-  measured_at: "2026-04-25T23:56:49Z"
-  recorded_by: tests/smoke/perf-quickwins-part-1.test.sh
+  measured_at: "2026-04-27T18:04:40Z"
+  recorded_by: tests/perf-quickwins-part-1.test.sh

--- a/.vibeflow/audits/sensor-cost-tiering-part-1-audit.md
+++ b/.vibeflow/audits/sensor-cost-tiering-part-1-audit.md
@@ -1,0 +1,145 @@
+# Audit Report: sensor-cost-tiering — Part 1 (Working-memory layout)
+
+> Audited on 2026-04-27
+> Spec: `.vibeflow/specs/sensor-cost-tiering-part-1.md`
+> Source PRD: `.vibeflow/prds/sensor-cost-tiering.md`
+
+**Verdict: PASS**
+
+## Test execution
+
+- Command: `bash tests/sensor-tiering.test.sh` (new) and
+  `bash tests/run-all.sh` (full suite).
+- Result: **PASS** — 18/18 assertions in the new test; **19/19 test
+  files PASS** in the full suite (no regressions).
+
+## DoD Checklist
+
+- [x] **DoD 1 — `templates/sensor.md` schema.** Template exists with
+  YAML frontmatter (`id`, `command`, `class`, `tier` optional,
+  `applies_to`, `runs`) and body sections `## Caveats` +
+  `## Calibration notes`. Inline HTML-comment guidance documents the
+  class-based default rule and references the source PRD.
+  *Evidence:* `templates/sensor.md`; new test (a) — 4 assertions PASS.
+
+- [x] **DoD 2 — `wm_sensors_dir` helper.** Resolves to `.yoke/sensors`,
+  consistent with the existing `wm_*_dir` family. Companion
+  `wm_sensor_path "<id>"` added with id-validation regex
+  (`^[a-z0-9][a-z0-9_.-]{0,63}$`) — same pattern used by every other
+  dir helper in the file (every dir has at least one path helper).
+  *Evidence:* `lib/working-memory/paths.sh`:75 (constant), :191
+  (`wm_sensors_dir`), :207 (`wm_sensor_path`); new test (b) — 7
+  assertions PASS, including path-traversal guard rejection.
+
+- [x] **DoD 3 — Acceptance Contract by-ID.** Contract scenarios
+  reference sensors via `Sensors: [<sensor-id>]` only. New
+  `## Sensors registry` section provides the place to register each
+  sensor's `id`, `command`, and `class`. Inline guidance explicitly
+  references `templates/sensor.md` (gap closed during audit — see
+  "Audit-time corrections" below). No inline `command:`, `class:`,
+  or `tier:` declarations remain in the template.
+  *Evidence:* `templates/acceptance-contract.md`; new test (c) — 7
+  assertions PASS (registry section present, registry block declares
+  id+command+class, no inline command bullets, no inline `tier:`,
+  bracketed `Sensors: [...]` references retained).
+
+- [x] **DoD 4 — Test coverage.** `tests/sensor-tiering.test.sh`
+  exercises template presence + frontmatter keys, body sections,
+  `wm_sensors_dir`/`wm_sensor_path` happy and invalid-input paths,
+  and contract-by-ID layout assertions. All 18 assertions PASS.
+  *Evidence:* `tests/sensor-tiering.test.sh`.
+
+- [x] **DoD 5 — Craftsmanship.** Bash 4+ idioms in `paths.sh`
+  (regex match, `printf`, `[[ ]]`); structured failure on invalid
+  sensor id (`wm:`-prefixed message + non-zero exit) — back-
+  pressure preserved. PRD reference inline in all four touched
+  files for traceability. No manifesto invariant weakened: working
+  memory remains per-project; canonical memory untouched; binding
+  Acceptance Contract semantics unchanged; sensors-pattern
+  structured-output rule preserved.
+  *Evidence:* `templates/sensor.md` HTML comment; `paths.sh:184-209`;
+  `templates/acceptance-contract.md` (Sensors registry intro);
+  `tests/sensor-tiering.test.sh` header.
+
+## Pattern Compliance
+
+- [x] **`patterns/sensors.md`** — followed. Sensor metadata moved to
+  per-sensor file; structured-output rule observed in id-validation
+  failure path. The pattern doc itself is intentionally untouched in
+  Part 1 (the tier-and-scheduling subsection lands in Part 5 per the
+  multi-part split).
+
+- [x] **`patterns/acceptance-contract.md`** — followed. Binding
+  semantics unchanged: BDD scenarios, functional requirements,
+  fixtures, policies, and the binding statement are untouched. Only
+  the sensor declaration shape changed (inline → by-ID). Generation
+  contract (Validator producing the artifact) is preserved.
+
+- [x] **`patterns/memory-model.md`** — followed. `.yoke/sensors/` is
+  added as a project-scoped working-memory category. The path layout
+  comment in `paths.sh` was updated to document the new category
+  alongside the existing slug-keyed and runtime ones. Sensors are
+  *not* added to `WM_ARCHIVE_CATEGORIES` (correct: that array drives
+  slug-collision detection, and sensors are id-keyed, not
+  slug-keyed). No canonical-memory writes.
+
+- [x] **`conventions.md`** — followed. Bash 4+; back-pressure (loud
+  failure with `wm:`-prefixed structured message + non-zero exit on
+  invalid id); machine-parseable error output; traceability via
+  inline PRD reference. The Don'ts list is respected — no canonical-
+  memory access added; no agent given write authority outside its
+  domain; no infinite-loop risk introduced.
+
+## Convention Violations
+
+None identified.
+
+## Scope Discipline
+
+Files changed: **4 / ≤ 4 budget** (exactly at limit).
+
+- `templates/sensor.md` (created)
+- `templates/acceptance-contract.md` (modified)
+- `lib/working-memory/paths.sh` (modified)
+- `tests/sensor-tiering.test.sh` (created)
+
+Anti-scope respected: no `lib/sensors/ack-sensors.sh` changes; no
+runtime / hook / Validator / coordinator changes; no actual
+`.yoke/sensors/<id>.md` files seeded; no migration tooling; no skill
+SKILL.md edits; no `runs:` retention policy; no schema versioning.
+
+### Note on `wm_sensor_path` adjunct
+
+Implementation added `wm_sensor_path "<id>"` alongside `wm_sensors_dir`.
+DoD 2 only required the dir helper, but every other dir helper in
+`paths.sh` is paired with at least one artifact-path helper
+(`wm_runtime_dir` → `wm_progress_path`, `wm_cycle_counter_path`,
+`wm_snapshots_dir`, etc.). Adding `wm_sensor_path` follows the
+established library convention and is consumed by Parts 2/3/5
+without those parts needing to reach into `paths.sh`. The
+id-validation regex it carries is also a security-relevant
+boundary (path-traversal guard). Treated as a justifiable
+extension of the existing pattern, not scope creep.
+
+## Audit-time corrections
+
+One small gap surfaced and was closed during audit:
+
+- `templates/acceptance-contract.md` originally pointed authors at
+  `.yoke/sensors/<id>.md` and `/yoke:ack-sensors --mode upsert` but
+  did not literally reference `templates/sensor.md`, which DoD 3
+  specifies. Edited the Sensors-registry intro to add the explicit
+  reference; tests still pass (test does not encode this assertion,
+  but the human-readable guidance now matches the spec verbatim).
+
+## Gaps
+
+None. Verdict is PASS.
+
+## Next steps
+
+Ready to ship. Proceed to Part 2 (`/yoke:ack-sensors` upsert mode):
+
+```
+/vibeflow:implement .vibeflow/specs/sensor-cost-tiering-part-2.md
+```

--- a/.vibeflow/audits/sensor-cost-tiering-part-2-audit.md
+++ b/.vibeflow/audits/sensor-cost-tiering-part-2-audit.md
@@ -1,0 +1,202 @@
+# Audit Report: sensor-cost-tiering — Part 2 (`/yoke:ack-sensors` upsert)
+
+> Audited on 2026-04-27
+> Spec: `.vibeflow/specs/sensor-cost-tiering-part-2.md`
+> Source PRD: `.vibeflow/prds/sensor-cost-tiering.md`
+> Depends on: `sensor-cost-tiering-part-1` (audit verdict PASS)
+
+**Verdict: PASS**
+
+## Test execution
+
+- Command: `bash tests/sensor-tiering.test.sh` (extended) and
+  `bash tests/run-all.sh` (full suite).
+- Result: **PASS** — 36/36 assertions in `sensor-tiering.test.sh`;
+  **19/19 test files PASS** in the full suite (0 regressions).
+
+## DoD Checklist
+
+- [x] **DoD 1 — `--mode upsert` accepted.** Dispatcher in
+  `lib/sensors/ack-sensors.sh` routes the new mode alongside `catalog`
+  and `readiness`. SKILL.md `argument-hint` includes `upsert`.
+  *Evidence:* `lib/sensors/ack-sensors.sh` (case statement), test
+  "(d) upsert created .yoke/sensors/<id>.md" — 4 PASS.
+
+- [x] **DoD 2 — Create path renders from `templates/sensor.md`.**
+  When `.yoke/sensors/<id>.md` is absent, `render_sensor_file`
+  substitutes `id` / `command` / `class` / `tier` / `applies_to` from
+  the contract registry + scenario references, applying class-based
+  default for `tier`. Body sections (`## Caveats`, `## Calibration
+  notes`) are seeded empty.
+  *Evidence:* `render_sensor_file()` and `upsert_mode()` in
+  `ack-sensors.sh`; tests covering all 4 fixture sensors PASS;
+  applies_to populated correctly.
+
+- [x] **DoD 3 — Update path: field-level merge.** `update_applies_to`
+  rewrites only the `applies_to` line; everything else preserved
+  byte-for-byte. Author-edited `command`, `class`, explicit
+  `tier:` overrides, body content (caveats / calibration notes), and
+  `runs:` history all survive. Atomic write via `mv` from `.tmp.$$`.
+  *Evidence:* tests "(d) upsert preserved author tier override
+  (expensive) on update", "(d) upsert preserved author caveat in
+  body", "(d) upsert refreshed playwright-e2e applies_to with both
+  task ids" — all PASS.
+
+- [x] **DoD 4 — Class-based default applied only on create.**
+  `default_tier` is computed and substituted exclusively on the create
+  branch. The update branch never touches `tier`. Computational
+  defaults to `cheap`, inferential defaults to `expensive`.
+  *Evidence:* tests "(d) computational sensor 'linter-ruff' defaulted
+  to tier: cheap" + "(d) inferential sensor 'judge-voice' defaulted
+  to tier: expensive" — PASS. Update test confirms explicit override
+  survives.
+
+- [x] **DoD 5 — Readiness checks sensor files.** `readiness_mode`
+  rewritten end-to-end. For every sensor referenced by the contract
+  (registry ids ∪ scenario ids), it verifies the file exists at
+  `.yoke/sensors/<id>.md` and contains required frontmatter keys
+  (`id`, `command`, `class`, `applies_to`, `runs`). Failure surfaces
+  structured violation with `sensor`, `expected`, `actual`, `reason`,
+  `correction` — the correction names the upsert command verbatim.
+  *Evidence:* `readiness_mode()`; tests "(e) readiness reports ready
+  ...", "(e) readiness exits 4 ...", "(e) readiness reports status:
+  not-ready ...", "(e) readiness names the missing sensor ...",
+  "(e) readiness suggests `/yoke:ack-sensors --mode upsert` correction"
+  — all PASS.
+
+- [x] **DoD 6 — SKILL.md documents upsert.** Added "Upsert mode"
+  section with create vs update semantics, idempotency guarantee,
+  validation rules, output schema, and exit-code table. The mode
+  table at the top of the file lists all three modes.
+  *Evidence:* `skills/ack-sensors/SKILL.md` — "Upsert mode" section
+  + table updates + `argument-hint` field.
+
+- [x] **DoD 7 — Test coverage.** `tests/sensor-tiering.test.sh`
+  extended from 18 to 36 assertions covering: create case (4 sensors
+  materialized + tier defaults + applies_to populated); update case
+  (applies_to expanded, tier override preserved, body caveat
+  preserved); idempotency (sha256 hash equality before/after second
+  run); readiness happy path; readiness missing-file failure (exit 4
+  + structured violation + correction instruction); upsert
+  unregistered-reference validation (exit 4 + named in failures).
+  *Evidence:* the test file itself — 36/36 PASS.
+
+- [x] **DoD 8 — Craftsmanship.** Idempotency proven by hash equality
+  test. Structured failures everywhere (every error path emits
+  `sensor / expected / actual / reason / correction`). Bash 4+
+  idioms throughout. No destructive operations: upsert never deletes
+  a sensor file, even when the contract drops a reference (orphan
+  handling deferred to drift-sense per PRD anti-scope). Atomic write
+  via temp + `mv`. PRD reference inline at the top of
+  `ack-sensors.sh` and in SKILL.md.
+
+## Pattern Compliance
+
+- [x] **`patterns/sensors.md`** — followed. Sensor metadata is now
+  per-file (the structured-output rule applies to readiness + upsert
+  failures uniformly). Catalog mode unchanged. The pattern doc
+  itself is intentionally untouched in Part 2 — the sensors-pattern
+  subsection on tiering + scheduling lands in Part 5.
+
+- [x] **`patterns/memory-model.md`** — followed. `.yoke/sensors/`
+  is treated as project-scoped working memory. Upsert writes only
+  to working memory; no canonical-memory access. Field-level merge
+  preserves the working-memory tier's "free-write within files"
+  contract.
+
+- [x] **`patterns/acceptance-contract.md`** — followed. Contract
+  binding semantics unchanged: BDD scenarios + functional
+  requirements + fixtures + policies + binding statement preserved.
+  The Sensors registry block is metadata that materializes per-
+  sensor files — it is not part of the binding scope.
+
+- [x] **`conventions.md`** — followed. Bash 4+ throughout.
+  Back-pressure (loud failures, structured) on every error path.
+  Deterministic node — no LLM in the upsert path; SKILL.md
+  `allowed-tools` remains `Bash, Read` only. No `Task`, no `Agent`.
+  No canonical-memory writes.
+
+## Convention Violations
+
+None identified.
+
+## Scope Discipline
+
+Files changed: **4 / ≤ 4 budget** (exactly at limit).
+
+- `lib/sensors/ack-sensors.sh` (modified) — upsert + new readiness
+- `skills/ack-sensors/SKILL.md` (modified) — upsert documentation
+- `tests/sensor-tiering.test.sh` (modified) — Part 2 assertions
+- `tests/ack-sensors-catalog.test.sh` (modified) — collateral
+
+### Note on the catalog-test edit
+
+The 4th file (`tests/ack-sensors-catalog.test.sh`) was not in the
+spec's Scope section but was a **necessary collateral** of the
+spec-mandated readiness rewrite (DoD 5). The catalog test had a
+~70-line section asserting the OLD readiness contract (binary-on-
+PATH, output fields like `reachable: true`, `expected: "on-PATH"`,
+`reason: "binary not found: ..."`). Those assertions are by
+construction invalidated by the new readiness behavior the spec
+requires; leaving them in place would have left the test suite
+broken (the implement skill's "tests must pass" rule applies).
+
+The edit removed the obsolete sub-tests (no replacement assertions
+added — the new readiness behavior is comprehensively tested in
+`tests/sensor-tiering.test.sh` with 7 readiness-specific
+assertions). The test file's header was updated to point future
+readers at the new home for readiness coverage. Mode-dispatch
+error-path assertions (missing contract → exit 3, missing arg →
+exit 2, unknown --mode → exit 2) were retained.
+
+This counts as scope discipline rather than scope creep: the
+deletion is minimal, the coverage moved (not vanished), and the
+alternative (keep readiness behavior intact) would have violated
+the spec's DoD 5.
+
+Anti-scope respected: no `hooks/verify-acceptance.sh` changes; no
+`agents/`, `skills/implement`, or coordinator changes; no automatic
+upsert hooks; no orphan deletion; no `runs:` history writes from
+upsert (the field is initialized to `[]` and only the coordinator
+in Part 5 will append); no interactive prompting; no schema
+versioning; no migration tooling beyond what authors do manually
+when editing the contract.
+
+## Architectural notes / pitfalls discovered
+
+1. **Existing test files coupled to implementation behavior.**
+   `ack-sensors-discoverers.test.sh`, `ack-sensors-inferential.test.sh`,
+   and `ack-sensors-parallel.test.sh` each invoke the catalog test
+   as a smoke check (`bash tests/ack-sensors-catalog.test.sh`),
+   creating a 4-way dependency chain. This means a single regression
+   in catalog cascades to all four files. Worth noting for future
+   refactors — the existing tech debt is documented in the catalog-
+   test header now.
+
+2. **Sensor `id` validation is the boundary for path safety.**
+   `wm_sensor_path` (Part 1) and the upsert path both rely on the
+   regex `^[a-z0-9][a-z0-9_.-]{0,63}$` to prevent path traversal
+   (no slashes, no leading `..`). This is the only line of defense
+   between contract content and filesystem writes. If we ever
+   relax the regex (e.g. to allow uppercase), revisit the
+   `mkdir -p .yoke/sensors` and atomic-write paths.
+
+## Gaps
+
+None. Verdict is PASS.
+
+## Next steps
+
+Ready to ship Part 2. Proceed to Parts 3 + 4 (which can run in
+parallel — both depend only on Parts 1+2):
+
+- Part 3 — `verify-acceptance.sh --tier` filter:
+  ```
+  /vibeflow:implement .vibeflow/specs/sensor-cost-tiering-part-3.md
+  ```
+- Part 4 — Validator scheduling reads sensor files:
+  ```
+  /vibeflow:implement .vibeflow/specs/sensor-cost-tiering-part-4.md
+  ```
+
+Part 5 (coordinator + pattern doc) requires both 3 and 4.

--- a/.vibeflow/audits/sensor-cost-tiering-part-3-audit.md
+++ b/.vibeflow/audits/sensor-cost-tiering-part-3-audit.md
@@ -1,0 +1,194 @@
+# Audit Report: sensor-cost-tiering — Part 3 (Hook tier filter)
+
+> Audited on 2026-04-27
+> Spec: `.vibeflow/specs/sensor-cost-tiering-part-3.md`
+> Source PRD: `.vibeflow/prds/sensor-cost-tiering.md`
+> Depends on: Parts 1 (PASS) and 2 (PASS)
+
+**Verdict: PASS**
+
+## Test execution
+
+- Commands: `bash tests/sensor-tiering.test.sh`; `bash tests/run-all.sh`.
+- Result: **PASS** — 60/60 assertions in `sensor-tiering.test.sh`
+  (24 new in (g)+(h) for hook tier filtering / format detection /
+  old-format rejection); **19/19 test files PASS** in the full suite
+  (zero regressions in `acceptance-and-sensors`, `perf-quickwins-part-*`,
+  or any other consumer of `verify-acceptance.sh`).
+
+## DoD Checklist
+
+- [x] **DoD 1 — `--tier` parsed alongside `--criterion`.**
+  Argparse extended; both flags parseable in any order, both can be
+  combined.
+  *Evidence:* `hooks/verify-acceptance.sh` argparse block; tests
+  "(g) --tier cheap + --criterion Scenario 1 intersected to 2 sensors"
+  + "(g) intersection includes the right sensors" — PASS.
+
+- [x] **DoD 2 — Tier resolved per sensor from sensor files.**
+  New-format path reads `command`, `class`, `tier` from
+  `.yoke/sensors/<id>.md` frontmatter and applies the class-based
+  default (`computational` → `cheap`, `inferential` → `expensive`)
+  when `tier:` is absent. Computed at pair-build time and stored in
+  `sensor_tier[<id>]` for the filter step.
+  *Evidence:* tests "(g) --tier cheap excludes inferential sensor
+  judge-voice" (inferential→expensive default) and "(g) --tier
+  expensive includes inferential + overridden-expensive sensors" —
+  PASS.
+
+- [x] **DoD 3 — Default behavior preserved.** No `--tier` flag →
+  `filter_tier="all"` → no filter step → identical to current full-
+  suite behavior. Old-format contracts continue to work end-to-end:
+  the format-detection branch in
+  `hooks/verify-acceptance.sh` falls back to the existing
+  inline-bullet parser when `## Sensors registry` is absent.
+  *Evidence:* "(g) default (no --tier) ran all 4 sensors" + "(h)
+  old-format contract works with no --tier (backward compat)" —
+  PASS; `acceptance-and-sensors.test.sh` and
+  `perf-quickwins-part-*.test.sh` (which use old-format contracts)
+  continue to PASS in the full suite.
+
+- [x] **DoD 4 — `--tier cheap` and `--tier expensive` filter.**
+  Verified via tier-override scenario: `playwright-e2e` is
+  computational but the fixture sets `tier: expensive` explicitly;
+  it's correctly excluded from `--tier cheap` and included in
+  `--tier expensive`.
+  *Evidence:* "(g) --tier cheap excludes overridden-expensive
+  playwright-e2e" + "(g) --tier expensive includes inferential +
+  overridden-expensive sensors" — PASS.
+
+- [x] **DoD 5 — Combined filters intersect.** `--tier` and
+  `--criterion` are independent narrowing filters; both apply to
+  the same `sensor_pairs` list. Empty intersection produces 0
+  sensor entries with exit 0.
+  *Evidence:* "(g) --tier cheap + --criterion Scenario 1 intersected
+  to 2 sensors", "(g) empty intersection produces 0 sensor entries",
+  "(g) empty intersection exits 0" — PASS.
+
+- [x] **DoD 6 — Unknown `--tier` value → exit 2 + structured
+  violation.** Argparse-level rejection with `expected: cheap |
+  expensive | all` and a corrective re-run instruction on stderr
+  before any sensor execution.
+  *Evidence:* "(g) unknown --tier value exits 2" + "(g) unknown
+  --tier emits structured violation with allowed set" — PASS.
+
+- [x] **DoD 7 — Missing / malformed sensor file under tier filter
+  → exit 4 + structured violation.** When tier filtering is active
+  (`filter_tier != all`), a referenced sensor with a missing or
+  malformed `.yoke/sensors/<id>.md` triggers a structured violation
+  emitting `expected/actual/correction` and exits 4. The correction
+  names `/yoke:ack-sensors --mode upsert` verbatim.
+  *Evidence:* "(g) missing sensor file under --tier exits 4" +
+  "(g) missing-sensor violation names the offending id" + "(g)
+  missing-sensor violation suggests upsert correction" — PASS.
+
+- [x] **DoD 8 — Test coverage.** 24 new assertions in `(g)` (hook
+  tier filter) and `(h)` (old-format rejection) covering: 4
+  sensor-files-present preconditions, default vs `--tier all`
+  equivalence, cheap-tier filtering (3 assertions), expensive-tier
+  filtering (2 assertions), intersection (2 assertions), empty
+  intersection (2 assertions), unknown-value error (2 assertions),
+  missing-file error (3 assertions), old-format default OK (1),
+  old-format tier rejection (3 assertions). All PASS.
+
+- [x] **DoD 9 — Craftsmanship.** Per-sensor YAML output schema
+  unchanged; only the *set* of sensors run varies. Bash 4+ idioms
+  throughout (`declare -A` for the tier map, `[[ ... ]]` patterns,
+  `case` statements). No new external dependencies. Back-pressure
+  observed on every error path (loud, structured failures with
+  expected/actual/correction).
+
+## Pattern Compliance
+
+- [x] **`patterns/sensors.md`** — followed. The tier filter is
+  layered on top of the existing parallel-execution model (xargs
+  path untouched). Structured-output rule applied to every error
+  path. Per-sensor YAML schema preserved.
+
+- [x] **`patterns/ralph-loop.md`** — followed. Cycle-protocol
+  invariants preserved: deterministic node, structured per-cycle
+  output, hard-bound timing characteristics unchanged.
+
+- [x] **`conventions.md`** — followed. Bash 4+ throughout. Loud
+  failure with structured violation on every error path. No
+  generic sensor output. Bash-4 patterns (`declare -A`,
+  `[[ regex ]]`) only.
+
+## Convention Violations
+
+None identified.
+
+## Scope Discipline
+
+Files changed: **2 / ≤ 4 budget**.
+
+- `hooks/verify-acceptance.sh` (modified) — argparse `--tier`,
+  contract-format detection, new-format sensor pair builder
+  (reads sensor files), tier filter
+- `tests/sensor-tiering.test.sh` (modified) — Part 3 assertions
+
+Anti-scope respected: no timeout/concurrency model changes (xargs
+parallel + serial paths are byte-for-byte unchanged); no per-sensor
+YAML schema drift; no tier resolution caching across invocations
+(each run re-reads); no retry/flake handling; no new flags beyond
+`--tier`; no agent / coordinator / Validator changes.
+
+### Architectural note: implicit dual-format support
+
+The Part 3 spec's DoD 3 ("Default behavior preserved") combined with
+the Part 1 contract-template change forced the hook to support both
+contract formats simultaneously. Pure single-format adoption would
+have broken every existing test using old-format contracts
+(`acceptance-and-sensors.test.sh`, `perf-quickwins-part-*.test.sh`,
+etc.). The implementation introduces a one-line format-detection
+step (`grep -qE '^## Sensors registry'`) that selects the parser:
+
+- **New format** → registry block + `Sensors: [<id>]` references
+  + sensor-file lookup (full tier metadata available).
+- **Old format** → existing inline-bullet parser (no tier metadata;
+  `--tier cheap|expensive` is rejected with a structured violation
+  pointing the user at `/yoke:ack-sensors --mode upsert`).
+
+This dual-path approach is mentioned in the spec's "Default
+behavior preserved" intent but not explicitly called out in the
+Scope section; it's documented in the audit + the hook's header
+comment for future readers.
+
+## Architectural notes / pitfalls discovered
+
+1. **Format-detection is grep-based.** The detector relies on a
+   bare `## Sensors registry` heading match. If a future contract
+   variant uses a different heading (e.g., `## Sensors-registry`),
+   the hook will silently fall back to the old-format parser. Worth
+   considering as a future hardening (regex tightening or schema
+   validation).
+
+2. **Sensor `command` parsing is awk-based.** The hook reads the
+   sensor file's `command:` field with `awk -F': '`. If a sensor's
+   command contains `: ` literally (e.g., `bash -c 'env: blah'`),
+   the field-separator split will truncate the value. Mitigation
+   not in scope for this part — current sensor commands are simple
+   shell strings; revisit if a sensor with a `: `-bearing command
+   surfaces.
+
+3. **`acceptance-and-sensors.test.sh` runs before
+   `sensor-tiering.test.sh` alphabetically.** Both create separate
+   tmp dirs and both clean up via `trap EXIT`, so there is no
+   interference. Worth noting that the suite's lexical ordering
+   matters when tests share state (none do today).
+
+## Gaps
+
+None. Verdict is PASS.
+
+## Next steps
+
+Ready to ship Part 3. Proceed to Part 4 (Validator scheduling
+reads sensor files):
+
+```
+/vibeflow:implement .vibeflow/specs/sensor-cost-tiering-part-4.md
+```
+
+Part 5 (coordinator + pattern doc) is the final part and depends on
+Parts 1, 2, 3, and 4.

--- a/.vibeflow/audits/sensor-cost-tiering-part-4-audit.md
+++ b/.vibeflow/audits/sensor-cost-tiering-part-4-audit.md
@@ -1,0 +1,168 @@
+# Audit Report: sensor-cost-tiering — Part 4 (Validator scheduling)
+
+> Audited on 2026-04-27
+> Spec: `.vibeflow/specs/sensor-cost-tiering-part-4.md`
+> Source PRD: `.vibeflow/prds/sensor-cost-tiering.md`
+> Depends on: Parts 1 (PASS) and 2 (PASS)
+
+**Verdict: PASS**
+
+## Test execution
+
+- Commands: `bash tests/sensor-tiering.test.sh`; `bash tests/run-all.sh`.
+- Result: **PASS** — 86/86 assertions in `sensor-tiering.test.sh` (28
+  new in (i)+(j)+(k)); **19/19 test files PASS** in the full suite
+  (zero regressions).
+
+## DoD Checklist
+
+- [x] **DoD 1 — Validator reads `.yoke/sensors/<id>.md`.** Persona's
+  Memory scope and Always section both reference the per-sensor file
+  as a read source for `schedule_next` reasoning. Read is scoped to
+  sensors mapped to targeted criterion(s).
+  *Evidence:* `agents/validator.md` Memory scope + Always entry; test
+  "(i) validator persona references .yoke/sensors/<id>.md as a read"
+  — PASS.
+
+- [x] **DoD 2 — `schedule_next:` shape required.** Locked to
+  `{sensors: [...], tiers: [cheap|expensive], reason: "..."}`. Schema
+  documented in persona's Always section; at least one of `sensors:`
+  or `tiers:` must be non-empty.
+  *Evidence:* `agents/validator.md`; tests "(i) validator schedule_next
+  schema declares sensors:/tiers:/reason:" — 3 PASS.
+
+- [x] **DoD 3 — Default rule documented.** "Always include
+  `tier:cheap`"; "Include `tier:expensive` when cheap-tier was green
+  for the targeted criterion(s) on the previous cycle, OR diff
+  touches expensive-relevant surface, OR merge-ready check".
+  *Evidence:* tests "(i) validator persona documents 'cheap always'
+  default rule" + "... 'expensive when cheap-green' rule" — PASS.
+
+- [x] **DoD 4 — Cycle-1 type-aware judgment.** Documented in Always
+  section: no prior `schedule_next` exists; coordinator runs cheap
+  only; first verdict may use Tech-Spec signals + cycle diff to
+  authorize expensive starting cycle 2.
+  *Evidence:* test "(i) validator persona documents cycle-1 type-
+  aware heuristic" — PASS.
+
+- [x] **DoD 5 — `reason` cites at least one signal source.** Schema
+  enforces non-empty `reason:` with citation requirement (sensor id,
+  criterion id, Tech-Spec section, or runs-history entry); fixture
+  validator exercises both well-formed and empty-reason cases.
+  *Evidence:* tests "(k) verdict with empty reason is rejected" +
+  "well-formed verdict ... passes schema check" — PASS.
+
+- [x] **DoD 6 — Templates persist `schedule_next`.** Both
+  `templates/progress.md` (per-cycle) and `templates/contracts.md`
+  (per-consensus) gain a `schedule_next:` block with the locked
+  shape (sensors / tiers / reason). Schema notes added to both
+  templates referencing the source PRD.
+  *Evidence:* tests "(j) templates/progress.md declares
+  schedule_next:" + "(j) templates/contracts.md declares
+  schedule_next:" + 6 sub-assertions on the sub-fields — all PASS.
+
+- [x] **DoD 7 — Test coverage.** 28 new assertions: persona checks
+  (i, 11 assertions), template checks (j, 10 assertions), fixture-
+  verdict schema (k, 5 assertions covering 2 valid cases + 3 invalid
+  cases). All PASS.
+
+- [x] **DoD 8 — Craftsmanship.** Actionable-feedback rationale
+  section added with explicit reconciliation against shift-feedback-
+  left convention (`conventions.md:18-22`,
+  `patterns/sensors.md:136`); PRD reference inline in
+  `agents/validator.md`, `templates/progress.md`,
+  `templates/contracts.md`; verdict schema follows existing
+  structured-output convention (`schedule_next` is structured YAML,
+  not prose); no manifesto invariant weakened (Validator's
+  scheduling is a refinement of judgment, not a new role).
+
+## Pattern Compliance
+
+- [x] **`patterns/roles.md`** — followed. Validator scheduling is a
+  refinement of the existing judgment role; no new role introduced;
+  parallel-spawn architecture preserved (Validator emits via verdict,
+  doesn't gate inside the cycle).
+
+- [x] **`patterns/sensors.md`** — followed. The verdict and
+  `schedule_next` are both structured (machine-parseable). The
+  per-sensor file is now the runtime context for scheduling
+  decisions, consistent with Parts 1+2 establishing `.yoke/sensors/`
+  as the source of truth.
+
+- [x] **`patterns/ralph-loop.md`** — followed. Lag-by-one model
+  reused (same as the inferential-judge model documented at
+  `patterns/sensors.md:90`). Parallel-spawn 3-subagent architecture
+  unchanged.
+
+- [x] **`patterns/memory-model.md`** — followed. Validator reads
+  working memory directly (`.yoke/sensors/<id>.md` is project-scoped
+  working memory). No canonical-memory access added.
+
+- [x] **`conventions.md`** — followed. Every persona change traces
+  to source PRD; structured output throughout (verdict +
+  `schedule_next`); no canonical-memory writes; the
+  shift-feedback-left rationale is reconciled, not violated.
+
+## Convention Violations
+
+None identified.
+
+## Scope Discipline
+
+Files changed: **4 / ≤ 4 budget** (exactly at limit).
+
+- `agents/validator.md` (modified) — sensor-file reads, schedule_next
+  schema, default rule, cycle-1 heuristic, rationale section
+- `templates/progress.md` (modified) — `schedule_next:` per-cycle +
+  schema notes
+- `templates/contracts.md` (modified) — `schedule_next:` per-contract
+  + schema notes
+- `tests/sensor-tiering.test.sh` (modified) — Part 4 assertions
+
+Anti-scope respected: no coordinator gating (Part 5 owns it); no
+in-cycle scheduling (lag-by-one only, preserves parallel-spawn);
+no live-agent integration tests (fixture-based schema check only);
+no Orchestrator changes; no new persona responsibilities beyond
+scheduling; no new working-memory artifacts (reuse `progress.md`
+and `contracts.md`); no `schedule_next` schema versioning; no
+flake-detection algorithm (qualitative interpretation only).
+
+## Architectural notes / pitfalls discovered
+
+1. **Markdown line-wrap matters for grep-based persona tests.** The
+   initial draft of the "expensive when cheap-green" rule had the
+   phrase "cheap-tier was green" wrapped across two lines (line 130-
+   131 of validator.md). The persona test grepped for the literal
+   phrase and failed. Reworded the rule to keep the phrase inline.
+   Future persona tests should use multi-line-tolerant grep
+   (`grep -Pz`) or test for word fragments rather than full phrases.
+
+2. **`schedule_next` schema is asymmetric in the templates.**
+   `progress.md` is per-cycle (Validator writes one block per cycle);
+   `contracts.md` is per-contract (one block per consensus reached,
+   with its own `cycle:` field). The same `schedule_next` shape lands
+   in both, but in `contracts.md` it's a snapshot of the scheduling
+   decision active at the cycle when consensus was reached, while in
+   `progress.md` it's the live decision for the next cycle. The
+   schema notes in each template document the difference.
+
+3. **Validator's tool list does not need to change.** The persona
+   already had `Read` for sensor-file access and `Write/Edit` for
+   `contracts.md`. No new tools required for Part 4 — the existing
+   surface is sufficient.
+
+## Gaps
+
+None. Verdict is PASS.
+
+## Next steps
+
+Ready to ship Part 4. Proceed to Part 5 — coordinator two-phase
+execution + run-history persistence + pattern doc:
+
+```
+/vibeflow:implement .vibeflow/specs/sensor-cost-tiering-part-5.md
+```
+
+Part 5 is the final integration layer; it consumes Parts 1–4 and
+flips the user-visible runtime behavior.

--- a/.vibeflow/audits/sensor-cost-tiering-part-5-audit.md
+++ b/.vibeflow/audits/sensor-cost-tiering-part-5-audit.md
@@ -1,0 +1,265 @@
+# Audit Report: sensor-cost-tiering — Part 5 (Coordinator + history + pattern doc)
+
+> Audited on 2026-04-27
+> Spec: `.vibeflow/specs/sensor-cost-tiering-part-5.md`
+> Source PRD: `.vibeflow/prds/sensor-cost-tiering.md`
+> Depends on: Parts 1 (PASS), 2 (PASS), 3 (PASS), 4 (PASS)
+
+**Verdict: PASS**
+
+## Test execution
+
+- Commands: `bash tests/sensor-tiering.test.sh`; `bash tests/run-all.sh`.
+- Result: **PASS** — 110/110 assertions in `sensor-tiering.test.sh`
+  (24 new in (l)+(m)+(n) for pattern/skill content + append-runs unit
+  tests + end-to-end smoke); **19/19 test files PASS** in the full
+  suite (zero regressions).
+
+## DoD Checklist
+
+- [x] **DoD 1 — Two-phase per-cycle execution.** SKILL.md cycle protocol
+  has explicit Phase A (cheap, sync, `--tier cheap --criterion <id>`)
+  and Phase B (expensive, gated by cycle N-1's `schedule_next`,
+  `--tier expensive --criterion <id>`). Phase B parses
+  `schedule_next:` from `wm_progress_path`'s most recent cycle entry
+  and authorizes only when `tiers:` includes `expensive` or
+  `sensors:` lists explicit ids whose `applies_to` covers the
+  current criterion.
+  *Evidence:* `skills/implement/SKILL.md` Process §2 steps 2 + 3;
+  tests "(l) implement SKILL.md describes Phase A (cheap)" + "...
+  Phase B (expensive, gated)" — PASS.
+
+- [x] **DoD 2 — Cycle-1 default = Phase A only.** Hard-coded branch in
+  the SKILL.md: "Cycle 1: skip Phase B. No prior `schedule_next`
+  exists; the coordinator runs cheap-only by design. Phase B
+  becomes possible from cycle 2 onward via the Validator's
+  authorization."
+  *Evidence:* test "(l) implement SKILL.md documents cycle-1
+  Phase-A-only default" — PASS.
+
+- [x] **DoD 3 — Merge-ready convergence runs full suite (all tiers).**
+  Step 8 invokes `hooks/verify-acceptance.sh --concurrency 1
+  --tier all` (no `--criterion`); explicitly ignores
+  `schedule_next`. Documented as "non-negotiable convergence: every
+  sensor (cheap AND expensive) MUST pass before convergence,
+  regardless of what the Validator authorized in the last per-cycle
+  decision."
+  *Evidence:* test "(l) implement SKILL.md merge-ready uses
+  --tier all" — PASS.
+
+- [x] **DoD 4 — Per-sensor history persistence.** `lib/sensors/append-
+  runs.sh` invoked from SKILL.md after both phases finish. Helper
+  parses snapshot YAML for per-sensor results, locates
+  `.yoke/sensors/<id>.md`, and appends one entry: `{cycle,
+  started_at, status, criterion, evidence_snippet}`. Sensors that
+  did not run are not touched.
+  *Evidence:* `lib/sensors/append-runs.sh` (executable); SKILL.md
+  Process §2 step 4 invokes it; tests "(m) append-runs added cycle
+  1 entry to foo.md" + "(m) append-runs entry includes status /
+  criterion" — PASS.
+
+- [x] **DoD 5 — N=20 retention cap.** `CAP=20` constant in
+  `append-runs.sh:30`; cap enforced on every append by tail-N over
+  combined (old + new) entries. Verified by stress test: append 26
+  cycles, assert exactly 20 entries remain (cycles 7..26),
+  cycle-1 rolled off, boundary cycle-7 kept, newest cycle-26 kept.
+  *Evidence:* tests "(m) retention cap enforced (exactly 20 entries
+  after 26 appends)" + "(m) oldest entry (cycle 1) rolled off as
+  expected" + "(m) newest entry (cycle 26) present after retention"
+  + "(m) boundary entry (cycle 7) present after retention" — PASS.
+
+- [x] **DoD 6 — Pattern doc records new behavior.**
+  `.vibeflow/patterns/sensors.md` has a new "Cost tiering, sensor
+  persistence, and Validator-owned scheduling" subsection covering:
+  per-sensor file layout (`.yoke/sensors/<id>.md`), class-based
+  default tier rule, two-phase per-cycle execution (Phase A / Phase
+  B / merge-ready), lag-by-one Validator scheduling, run-history
+  persistence with N=20 retention, and the actionable-feedback
+  rationale (with explicit reconciliation against the
+  shift-feedback-left convention). New anti-pattern entry added at
+  the bottom: "Running all expensive sensors every cycle when the
+  feature is mid-assembly..."
+  *Evidence:* tests "(l) sensors.md adds 'Cost tiering, ...
+  Validator-owned scheduling' subsection" + "... cites actionable-
+  feedback rationale" + "... adds anti-pattern entry for
+  unconditional expensive runs" — PASS.
+
+- [x] **DoD 7 — End-to-end test coverage.** 24 new assertions across
+  three groups:
+  - **(l)** pattern + skill content: subsection presence, rationale
+    citation, anti-pattern entry, Phase A/B descriptions, append-
+    runs invocation, `--tier all` merge-ready, cycle-1 default —
+    8 assertions.
+  - **(m)** `append-runs.sh` unit tests: file present + executable,
+    single append, status / criterion captured, body preserved,
+    retention cap (3 sub-assertions), unregistered-sensor skip
+    (2 sub-assertions) — 12 assertions.
+  - **(n)** end-to-end smoke: cheap-only Phase A leaves expensive
+    sensors untouched (2 + 2 sub-assertions), Phase B authorization
+    appends to expensive sensors — 5 assertions.
+  All PASS.
+
+- [x] **DoD 8 — Craftsmanship.** Parallel-spawn architecture
+  preserved (no new in-cycle synchronization between Validator and
+  coordinator — the lag-by-one model is reused exactly as Part 4
+  established). Pattern-doc edit follows existing structure (new
+  subsection placed contiguously after parallel-execution coverage;
+  anti-patterns list extended cleanly). No manifesto invariant is
+  weakened or removed — shift-feedback-left convention is
+  **refined**, not rescinded, with explicit rationale captured in
+  the new pattern subsection. PRD reference inline in
+  `lib/sensors/append-runs.sh`, `skills/implement/SKILL.md`, and
+  `.vibeflow/patterns/sensors.md`.
+
+## Pattern Compliance
+
+- [x] **`patterns/sensors.md`** — followed and extended. The new
+  subsection layers cleanly on the existing parallel-execution
+  coverage; structured-output rule preserved (`append-runs.sh`'s
+  failure mode emits `Error:` to stderr with non-zero exit). New
+  anti-pattern entry preserves the existing list shape.
+
+- [x] **`patterns/ralph-loop.md`** — followed. Cycle-protocol
+  invariants preserved: deterministic node (sensor execution +
+  history append), structured per-cycle output, parallel-spawn
+  unchanged. The two-phase structure is a refinement of the
+  existing single-execution-per-cycle model — both phases still
+  produce a single per-cycle YAML snapshot for the Validator to
+  consume.
+
+- [x] **`patterns/roles.md`** — followed. Validator scheduling is a
+  refinement; coordinator (deterministic) consumes
+  `schedule_next:` and writes history; Generator unchanged;
+  Orchestrator unchanged.
+
+- [x] **`patterns/acceptance-contract.md`** — followed. Binding
+  semantics preserved by the merge-ready full sweep: convergence
+  requires every sensor (across all tiers) to pass against the
+  binding contract.
+
+- [x] **`patterns/memory-model.md`** — followed. `append-runs.sh`
+  writes only to working memory (`.yoke/sensors/<id>.md`); no
+  canonical-memory access. The `runs:` history grows within
+  per-task working-memory bounds (capped at N=20).
+
+- [x] **`conventions.md`** — followed. Bash 4+ throughout
+  (`declare`, `[[ regex ]]`, `case`, atomic `mv`). Structured
+  failure on every error path in `append-runs.sh` (snapshot not
+  found → exit 3, malformed cycle → exit 2, missing `runs:` key in
+  sensor file → structured `Error:` to stderr). Shift-feedback-left
+  rationale reconciled in the new pattern subsection.
+
+## Convention Violations
+
+None identified.
+
+## Scope Discipline
+
+Files changed: **4 / ≤ 4 budget**.
+
+- `skills/implement/SKILL.md` (modified) — two-phase execution,
+  cycle-1 default, append-runs invocation, merge-ready full sweep,
+  step-numbering refresh
+- `.vibeflow/patterns/sensors.md` (modified) — new subsection +
+  anti-pattern entry
+- `lib/sensors/append-runs.sh` (created) — runs-history append +
+  retention helper
+- `tests/sensor-tiering.test.sh` (modified) — 24 new assertions
+
+Anti-scope respected: parallel-spawn architecture unchanged; no
+tier authoring/parsing changes; no `schedule_next` schema changes;
+cycle budget uniform; no retry/flake handling for expensive
+sensors; no CI/Sprint-8 wiring; no flake auto-quarantine
+(`runs:` history enables it as a future addition); no `runs:` field
+schema migration; no manifesto invariant removed.
+
+### Note on the helper file (4th file beyond strict spec listing)
+
+The spec's Scope section lists 3 files (`skills/implement/SKILL.md`,
+`.vibeflow/patterns/sensors.md`, `tests/sensor-tiering.test.sh`),
+but the run-history append + retention logic is non-trivial bash
+(~150 lines). Inlining it into SKILL.md prose would make the skill
+description brittle (Claude Code synthesizes shell from the prose
+at runtime; non-trivial logic risks transcription drift) and would
+sacrifice unit-testability. The chosen split — extract a
+`lib/sensors/append-runs.sh` helper — is consistent with the
+existing repo pattern (every other lib/sensors/* helper is its own
+file invoked by the skill: `discover-from-claude-md.sh`,
+`discover-from-makefile.sh`, `discover-from-package-json.sh`,
+`discover-from-pyproject.sh`, `run-sensors.sh`, `ack-sensors.sh`).
+
+The 4th file is within the project budget of ≤ 4 (declared in
+`.vibeflow/index.md`); the spec's scope listing is a closer-fit
+than a hard limit. Treated as scope discipline rather than scope
+creep — alternative approaches were either less testable
+(inline) or required exceeding budget (helper + test fixture
+separately).
+
+## Architectural notes / pitfalls discovered
+
+1. **`runs:` MUST be the last frontmatter key.** `append-runs.sh`'s
+   three-zone parser (prefix → in_runs → suffix) assumes the closing
+   `---` of the frontmatter is what ends the runs zone. If a future
+   sensor template adds a key after `runs:`, the new key will be
+   absorbed into the in_runs zone and silently dropped. Documented
+   in `append-runs.sh`'s header comment; the Part-1 template puts
+   `runs:` last by design.
+
+2. **Stat compatibility (BSD vs GNU).** The end-to-end smoke initially
+   used `stat -f '%m'` (BSD/macOS); the test now falls back to
+   `stat -c '%Y'` (GNU/Linux) when BSD form fails. This is mtime-
+   only and not strictly required for the test (it was a leftover
+   from an earlier scaffolding) — kept for parity with how pre-
+   state would be captured for future invariants.
+
+3. **Snapshot YAML field separator.** `append-runs.sh` parses
+   `output_excerpt: "..."` with a strict double-quote pair. If a
+   future evidence string contains a literal `"` and the snapshot
+   serializer doesn't escape it consistently, parsing could split
+   the value. Current `verify-acceptance.sh` uses `esc()` to
+   backslash-escape quotes, so this is safe today; revisit if the
+   snapshot format changes.
+
+## Gaps
+
+None. Verdict is PASS.
+
+## Final integration milestone
+
+Part 5 is the last part of `sensor-cost-tiering`. With Parts 1–5
+all PASS, the full feature is shipped:
+
+- Sensors are first-class persistent artifacts in
+  `.yoke/sensors/<id>.md` (Part 1).
+- `/yoke:ack-sensors --mode upsert` materializes them from the
+  Acceptance Contract (Part 2).
+- `hooks/verify-acceptance.sh --tier cheap | expensive | all`
+  filters by cost tier (Part 3).
+- `agents/validator.md` reads sensor files and emits
+  `schedule_next:` per cycle (Part 4).
+- `skills/implement/SKILL.md` runs sensors in two phases, persists
+  per-cycle results back to sensor files with N=20 retention, and
+  runs the full suite at merge-ready (Part 5).
+
+Aggregate test coverage: **110 assertions** in
+`tests/sensor-tiering.test.sh`; **5 audit reports PASS** in
+`.vibeflow/audits/`.
+
+## Next steps
+
+Ready to ship the full feature. Suggested follow-ups (out of scope
+for sensor-cost-tiering, but flagged for future work):
+
+- **Migration tooling** — a `/yoke:bootstrap-sensors <contract>`
+  command that runs `/yoke:ack-sensors --mode upsert` automatically
+  during host-project bootstrap, so users adopting the new contract
+  format don't have to remember to run it manually.
+- **Drift-sense for orphan sensor files** — Phase 6 drift-sense
+  pass that flags `.yoke/sensors/<id>.md` files referenced by no
+  contract, candidate for archival.
+- **Quantitative flake quarantine** — built on top of the `runs:`
+  history, auto-defer sensors with `recent_pass_rate < threshold`
+  beyond the qualitative Validator-owned heuristic.
+- **Canonization of stable sensor knowledge** — `/yoke:preserve` of
+  long-lived caveats and calibration notes from `.yoke/sensors/`
+  into canonical memory under Model C.

--- a/.vibeflow/patterns/sensors.md
+++ b/.vibeflow/patterns/sensors.md
@@ -117,6 +117,68 @@ consecutive cycles, the skill invokes
 `lib/ralph-loop/escalate.sh --reason sensor-failure --sensor <id>`
 and pauses the loop.
 
+### Cost tiering, sensor persistence, and Validator-owned scheduling
+
+Sensors are first-class persistent artifacts in
+`.yoke/sensors/<id>.md` (project-scoped working memory). Each
+per-sensor file carries `id`, `command`, `class` (computational |
+inferential), `tier` (cheap | expensive — class-based default when
+omitted), `applies_to: [<criterion-id>...]`, and a `runs:` history.
+The Acceptance Contract's `## Sensors registry` block + `Sensors:
+[<id>]` references in scenarios are the contract-side declaration;
+`/yoke:ack-sensors --mode upsert <contract>` materializes the per-
+sensor files from the registry. Source PRD:
+`.vibeflow/prds/sensor-cost-tiering.md`.
+
+**Class-based default tier.** Computational sensors default to
+`tier: cheap`; inferential sensors default to `tier: expensive`.
+Authors override via explicit `tier:` per sensor — heavy
+computational sensors (Playwright, browser automation) MUST set
+`tier: expensive` explicitly.
+
+**Two-phase per-cycle execution.** Within each Phase-4 cycle, the
+coordinator (`/yoke:implement`) runs sensors in two phases:
+
+- **Phase A** (after the Generator's diff): cheap sensors fire
+  synchronously via `hooks/verify-acceptance.sh --tier cheap
+  --criterion <last-target>`. Cheap-tier feedback is in-loop —
+  shift-left preserved on actionable feedback.
+- **Phase B** (cycle boundary, after Phase A): expensive sensors
+  fire only when authorized by cycle `<N-1>`'s `schedule_next` —
+  same lag-by-one model used for inferential judges. Cycle 1 has
+  no prior `schedule_next`; coordinator runs Phase A only by
+  default. From cycle 2 onward, the Validator's per-cycle verdict
+  may include `tier:expensive` in `schedule_next.tiers` (or specific
+  expensive sensor ids in `schedule_next.sensors`), gating Phase B.
+
+The merge-ready convergence sweep (`hooks/verify-acceptance.sh
+--concurrency 1 --tier all`) ignores `schedule_next` and runs the
+**full sensor suite across all tiers**. No run is declared done
+while any sensor — cheap or expensive — fails. This is the binding-
+semantics safety net.
+
+**Run-history persistence.** After Phase A (always) and Phase B
+(when authorized), the coordinator invokes
+`bash lib/sensors/append-runs.sh <snapshot> <cycle> <criterion>`
+to append one entry to each executed sensor's `runs:` list:
+`{cycle, started_at, status, criterion, evidence_snippet}`. The
+list is capped at the most recent **N=20** entries; oldest roll
+off on overflow. Sensors that did not run (Phase B skipped, or
+filtered out by `--criterion`) are not touched. The persisted
+history is the durable record the Validator reads next cycle when
+emitting `schedule_next` — flake patterns, recent failures, and
+green streaks become first-class scheduling signals.
+
+**Rationale (shift-left only when actionable).** Cheap sensors
+still run every cycle — the convention from
+`conventions.md:18-22` and `## Cross-cutting principles > Shift
+feedback left` is upheld where feedback is **actionable**.
+Expensive sensors are gated **only** because pre-convergence
+failures are not actionable feedback: a failing Playwright run
+three cycles before the page mounts is incompleteness, not a bug;
+the Generator cannot act on it. Per-sensor `runs:` history makes
+this judgment auditable post-hoc.
+
 ### Calibration drift management
 Inferential sensors degrade as the underlying model changes. They carry:
 - `calibrated_against: <model id>`
@@ -182,6 +244,7 @@ above a threshold triggers Orchestrator-mediated review of the sensor.
 - Letting inferential sensors live without calibration metadata — invisible obsolescence the moment the model changes.
 - Treating sensor verbosity as noise — the verbosity is the contract; silencing it removes the back-pressure mechanism.
 - A failing sensor that the Validator ignores ("flaky") — either the sensor is wrong (fix it) or the implementation is wrong (fix it). There is no third option.
+- Running all expensive sensors every cycle when the feature is mid-assembly — failures are incompleteness signals, not bug signals; the Generator cannot act on them. Use cost tiering + Validator-owned `schedule_next` to defer expensive sensors to cycles where their feedback is actionable.
 
 ## Implementation Mapping
 

--- a/.vibeflow/prds/sensor-cost-tiering.md
+++ b/.vibeflow/prds/sensor-cost-tiering.md
@@ -1,0 +1,343 @@
+# PRD: Sensor Cost Tiering with Validator-Owned Scheduling
+
+> Generated via /vibeflow:discover on 2026-04-27
+> Updated 2026-04-27 — sensors promoted to first-class persistent
+> artifacts in `.yoke/sensors/<id>.md`.
+
+## Problem
+
+During autonomous `/yoke:implement` runs, expensive sensors (Playwright
+e2e, long-running inferential judges) burn ~60–120 s **every cycle** on
+tests that cannot pass until the feature is fully assembled. The
+Generator cannot act on the failure — the e2e isn't reporting a bug,
+it's reporting incompleteness. The output is wallpaper, not feedback.
+
+A second, related problem: sensor metadata today lives inline inside
+`acceptance-contract.md` and has no place to grow. There is no per-
+sensor home for accumulated caveats, recent run results, calibration
+notes, or "this sensor flakes when the test DB is cold" knowledge.
+Without that home, the Validator cannot make informed scheduling
+decisions — it has to re-derive everything from the latest sensor
+output every cycle.
+
+The right principle is **shift-left only when feedback is actionable**:
+
+- A failing unit test mid-cycle is actionable: the Generator can fix it.
+- A failing Playwright run three cycles before the page mounts is not
+  actionable: it's a known-fail by construction.
+
+The framework should encode this distinction as first-class sensor
+state — declared once, refined over time — and let the Validator
+decide per-cycle when to spend the expensive sensor budget using
+that state.
+
+## Target Audience
+
+- **Primary**: Yoke users running `/yoke:implement` on features with
+  non-trivial e2e or heavyweight inferential coverage.
+- **Initial validation**: the Yoke developer dogfooding the framework
+  on the `e2e-tests` worktree where this insight originated.
+
+## Proposed Solution
+
+Four coordinated changes, all confined to Phase 4 runtime + working
+memory:
+
+1. **Sensors as first-class persistent artifacts.** Each sensor lives
+   in `.yoke/sensors/<sensor-id>.md` — a markdown file with YAML
+   frontmatter (`command`, `class`, `tier`, `applies_to`, `runs:`
+   history) and a body for caveats, calibration notes, and accumulated
+   learnings. `/yoke:ack-sensors` gains an **upsert mode** that
+   creates / updates these files from the Acceptance Contract's sensor
+   declarations. The Acceptance Contract references sensors by ID
+   (`sensor: <id>`); the per-sensor file is the source of truth for
+   command + tier + class + history.
+
+2. **Cost tier on the sensor.** `tier: cheap | expensive` lives in the
+   sensor file's frontmatter. The default is **derived from the
+   sensor's class** (`computational` → `cheap`; `inferential` →
+   `expensive`). Authors override per sensor — the explicit field
+   always wins. Heavy computational sensors (Playwright, browser
+   automation) require an explicit `tier: expensive` annotation.
+
+3. **Validator-owned scheduling per cycle.** The Validator's per-cycle
+   verdict gains a `schedule_next` block naming the sensors (or tier
+   shorthands) the coordinator should run **next** cycle. The
+   Validator reads `.yoke/sensors/<id>.md` files when deciding —
+   caveats, recent runs, and known flake history feed the decision.
+   Default policy: `tier:cheap` always; `tier:expensive` when (a)
+   cheap-tier was green this cycle for the targeted criterion(s),
+   (b) the Validator explicitly authorizes (e.g. diff touches
+   expensive-relevant surface, or the sensor has been green for two
+   prior cycles), or (c) merge-ready.
+
+4. **Two-phase per-cycle execution + result persistence.** Within a
+   cycle:
+   - **Phase A** (after Generator diff) — cheap sensors fire
+     synchronously via `hooks/verify-acceptance.sh --tier cheap`.
+   - **Phase B** (cycle boundary, gated) — expensive sensors fire only
+     when authorized by the previous cycle's `schedule_next`
+     (lag-by-one — same model used for inferential judges per
+     `patterns/sensors.md:90`).
+   - **After both phases**, the coordinator appends the cycle's per-
+     sensor results to each sensor file's `runs:` history. This is
+     the durable record the Validator reads next cycle.
+
+The **merge-ready convergence check always runs the full sensor suite
+across all tiers** — non-negotiable. The binding contract is satisfied
+only when every sensor passes.
+
+## Success Criteria
+
+Measured on a representative feature with at least one expensive
+sensor (e.g. a Playwright suite covering the e2e-tests worktree):
+
+- **Cycle wall-clock drops ≥ 40 %** on cycles where Phase B is gated
+  off (instrumented baseline + post-change runs, archived in
+  `.vibeflow/audits/`).
+- **Expensive-sensor cycles run ≤ 30 %** of total cycles on a feature
+  with at least one declared `expensive` sensor — gating actually
+  defers most runs.
+- **Zero false-positive convergence.** Merge-ready full sweep catches
+  every failure that gated cycles skipped; no run declared done while
+  any expensive sensor fails or remains unrun.
+- **Sensor-file persistence verified.** After a multi-cycle run,
+  `.yoke/sensors/<id>.md` files exist for every contract-declared
+  sensor; their `runs:` history records the cycles run, results, and
+  durations.
+- **Validator uses sensor history.** On a fixture run where a sensor
+  has flaked in `runs:` history, the Validator's `schedule_next`
+  reasoning explicitly cites the flake — observable in
+  `progress.md` / `contracts.md`.
+- **Validator scheduling correctness on calibration fixtures.** When
+  cheap is red, no expensive authorized; when cheap green and diff
+  touches expensive-relevant surface, expensive authorized.
+
+## Scope v0
+
+### Working-memory layout
+
+- `.yoke/sensors/` directory introduced via a new `wm_sensors_dir`
+  helper in `lib/working-memory/paths.sh`.
+- `templates/sensor.md` (new) — per-sensor template:
+  ```
+  ---
+  id: <sensor-id>
+  command: <shell command>
+  class: computational | inferential
+  tier: cheap | expensive   # optional; defaults from class
+  applies_to: [<criterion-id>...]
+  runs: []                  # populated by the coordinator
+  ---
+  # <human-readable name>
+
+  ## Caveats
+  <known flakes, environmental dependencies, calibration notes>
+  ```
+
+### Acceptance Contract by reference
+
+- `templates/acceptance-contract.md`: sensor declarations become
+  references (`sensor: <id>`) rather than inline blocks. Tier and
+  command no longer appear in the contract — they live in the
+  sensor file.
+
+### `/yoke:ack-sensors` upsert mode
+
+- `lib/sensors/ack-sensors.sh` extended with an upsert path:
+  - **catalog mode** (existing): list available sensors.
+  - **readiness mode** (existing): verify every contract-referenced
+    sensor has a file at `.yoke/sensors/<id>.md` and the file is
+    well-formed.
+  - **upsert mode** (new): create / update `.yoke/sensors/<id>.md`
+    files from contract references. Class-based default applied
+    when sensor file is created without explicit tier. Author
+    edits to existing sensor files are preserved (do not clobber
+    caveats, calibration notes, runs history).
+
+### Tier-aware execution
+
+- `hooks/verify-acceptance.sh` gains `--tier cheap | expensive | all`
+  (orthogonal to the existing `--criterion <id>`). Reads sensor
+  files to resolve tier per sensor; runs only the matching subset.
+  Default (no flag): all sensors — backward compat.
+
+### Validator scheduling
+
+- `agents/validator.md`:
+  - Reads `.yoke/sensors/<id>.md` files when emitting
+    `schedule_next` — caveats and `runs:` history feed the decision.
+  - Emits `schedule_next: { sensors: [...], tiers: [...], reason:
+    "..." }` in every cycle verdict.
+  - Default rule: cheap always; expensive when prior-cycle cheap
+    green for targeted criterion OR Validator-authorized OR merge-
+    ready.
+  - Cycle-1 heuristic: with no prior `schedule_next`, the
+    coordinator runs cheap only; the Validator's first verdict may
+    use Tech-Spec signals + cycle diff to authorize expensive
+    starting cycle 2.
+- `templates/progress.md` and `templates/contracts.md` persist
+  `schedule_next` per cycle.
+
+### Coordinator two-phase + history persistence
+
+- `skills/implement/SKILL.md`:
+  - Two-phase per-cycle execution: Phase A (cheap) synchronous via
+    the hook; Phase B (expensive) gated by cycle N-1's
+    `schedule_next`.
+  - After both phases, append the cycle's per-sensor result to each
+    sensor file's `runs:` history (timestamp, status, duration,
+    cycle number, criterion targeted).
+  - Cycle-1 default: Phase A only.
+  - Merge-ready convergence: full sweep, regardless of
+    `schedule_next`.
+
+### Pattern documentation
+
+- `.vibeflow/patterns/sensors.md`: new subsection covering the
+  `.yoke/sensors/` layout, class-based tier default, two-phase
+  execution, lag-by-one Validator scheduling, run-history
+  persistence, and the actionable-feedback rationale (with explicit
+  reconciliation against shift-feedback-left).
+
+### Tests
+
+- `tests/sensor-tiering.test.sh` covering:
+  - Sensor-file format and class-based default.
+  - `ack-sensors.sh` upsert preserves author edits.
+  - Contract-by-ID references parse correctly.
+  - `verify-acceptance.sh --tier` filters by tier read from sensor
+    files.
+  - Validator verdict format includes `schedule_next` with required
+    fields, and the reasoning cites sensor history when present.
+  - End-to-end smoke: 3-cycle run with one cheap + one expensive
+    sensor, asserting Phase B gating + run-history persistence +
+    merge-ready full sweep.
+
+## Anti-scope
+
+Explicitly **not** in v0:
+
+- **No automatic tier inference from runtime, naming, or duration.**
+  Class-based default only. Author override always wins.
+- **No third tier** (`merge-ready-only`, `nightly`).
+- **No per-criterion tier overrides.** Tier is a property of the
+  sensor file, not of the (criterion, sensor) pair.
+- **No in-cycle scheduling.** Validator decides via lag-by-one.
+- **No canonization of sensor knowledge to canonical memory.** Sensor
+  files live in working memory only. Promotion to canonical memory
+  via `/yoke:preserve` is out of scope; revisit after observing
+  what accumulates in `.yoke/sensors/` over real runs.
+- **No sensor-file schema versioning.** Premature.
+- **No automatic flake detection / quarantine.** The `runs:` history
+  enables it as a future addition; v0 only persists data.
+- **No retry policy changes.**
+- **No CI workflow wiring.** Sprint-8 CI integration is separate.
+- **No tier-aware budget accounting.** Cycle budget stays uniform.
+- **No removal or weakening of any manifesto invariant.** Shift-
+  feedback-left is **refined**, not rescinded — cheap sensors still
+  run every cycle; only expensive sensors are gated, with explicit
+  rationale.
+- **No changes to canonical-memory governance, Model C, or any human
+  Trigger.**
+
+## Technical Context
+
+This PRD layers on top of `yoke-runtime-perf-quickwins.md`:
+
+- That PRD: scope sensors by criterion, run them once per cycle
+  (de-dup), full-suite serial sweep at merge-ready.
+- This PRD: among the criterion-scoped sensors, gate the expensive
+  ones via Validator-owned scheduling — and persist sensor knowledge
+  + history as first-class artifacts so the Validator's decision is
+  informed.
+
+Both PRDs touch `hooks/verify-acceptance.sh`, `agents/validator.md`,
+`skills/implement/SKILL.md`. Sequencing matters — implement
+`yoke-runtime-perf-quickwins` first or in parallel; this PRD assumes
+its `--criterion` flag, snapshot-based Validator, and once-per-cycle
+sensor execution model.
+
+Manifesto invariants verified compatible:
+
+- **Shift feedback left** (`patterns/sensors.md:136`,
+  `conventions.md:18-22`) — preserved with refinement: cheap sensors
+  still run inside the loop every cycle. Expensive sensors are gated
+  precisely because their pre-convergence failures are not actionable
+  feedback. The new sensors-pattern subsection records this rationale
+  explicitly.
+- **Structured sensor output** — unchanged. Tier and history are
+  metadata; the per-cycle output schema is untouched.
+- **Hard bounds** — unchanged. Cycle budget covers Phase A + Phase B
+  when both run.
+- **Binding spec** — unchanged. Acceptance Contract still defines
+  done; tier and per-sensor file are execution metadata, not a
+  binding-scope change. Merge-ready full sweep guarantees binding
+  semantics.
+- **Sprint contracts ⊂ Acceptance Contract** — unchanged.
+- **Adversarial loop** — Validator's scheduling is a refinement of
+  its judgment role.
+- **Working memory is per-task and short-lived** — `.yoke/sensors/`
+  fits the working-memory tier definition. Promotion of stable
+  sensor knowledge to canonical memory is a separate, later concern.
+
+Reference points in this repo:
+
+- Sensor declaration site (today): `templates/acceptance-contract.md`.
+- Sensor parser: `lib/sensors/ack-sensors.sh`.
+- Sensor execution entry: `hooks/verify-acceptance.sh`.
+- Validator persona: `agents/validator.md`.
+- Coordinator cycle protocol: `skills/implement/SKILL.md`.
+- Working-memory paths helper: `lib/working-memory/paths.sh`.
+- Inferential-judge lag-by-one model: `patterns/sensors.md:74-119`.
+- Sensors pattern doc to extend: `.vibeflow/patterns/sensors.md`.
+
+## Open Questions
+
+- **`schedule_next` schema and audit visibility.** Locked shape:
+  `{ sensors: [<id>...], tiers: [cheap|expensive], reason: "..." }`.
+  Decide in Tech Spec whether `reason` is a free-form string or a
+  structured citation list referencing sensor IDs + run-history
+  entries. Pragmatic v0: free-form string with the requirement to
+  cite at least one signal source.
+- **Interaction with `runtime.inferential_sensor_concurrency`.**
+  When expensive includes inferential, the existing concurrency cap
+  + deferred-sensors queue (`patterns/sensors.md:80-86`) still
+  apply. Verify precedence: tier gating happens **before** the
+  concurrency cap.
+- **`runs:` history retention.** Unbounded growth bloats sensor
+  files. Tech Spec must specify a cap (proposal: keep last N=20
+  cycles; older entries roll off). Pruning is a coordinator
+  responsibility on append.
+- **`ack-sensors.sh` upsert idempotency under concurrent edits.**
+  If a human edits `caveats` while a cycle is appending `runs:`,
+  ensure the upsert merges rather than overwrites. Tech Spec must
+  specify the merge strategy (preserve frontmatter fields the human
+  edited, append-only to `runs:`).
+- **Sensor-file deletion semantics.** When a sensor is removed from
+  the contract, does its `.yoke/sensors/<id>.md` file get deleted,
+  archived, or left in place? Pragmatic v0: leave in place (no
+  destructive deletion); annotate as orphan in a future drift-sense
+  pass.
+
+## Resolved decisions
+
+Locked in during discovery on 2026-04-27:
+
+- **Inferential-sensor default tier = `expensive`.** Median
+  inferential runtime exceeds the cheap-feedback threshold.
+- **Cycle 1 default = cheap only.** No prior `schedule_next` exists;
+  Validator's first verdict authorizes expensive starting cycle 2,
+  judging by the type of work being implemented (Tech-Spec signals
+  + cycle diff).
+- **Class-based default for unannotated sensors.** Parser fills in
+  the implied tier when the sensor file omits `tier:`. Authors
+  override via explicit `tier:`. No runtime / name / duration
+  inference.
+- **Sensors as first-class persistent artifacts** in
+  `.yoke/sensors/<id>.md`. Source of truth for command, class, tier,
+  caveats, and runs history. Acceptance Contract references by ID.
+- **Working-memory placement.** `.yoke/sensors/` lives in working
+  memory (per host project), not canonical memory. Cross-run
+  learning happens within a project; canonization to canonical
+  memory is out of scope.

--- a/.vibeflow/specs/sensor-cost-tiering-part-1.md
+++ b/.vibeflow/specs/sensor-cost-tiering-part-1.md
@@ -1,0 +1,176 @@
+# Spec: Sensor Cost Tiering — Part 1: Working-memory layout
+
+> Generated via /vibeflow:gen-spec on 2026-04-27 (revised 2026-04-27)
+> Source PRD: `.vibeflow/prds/sensor-cost-tiering.md`
+
+## Objective
+
+Sensors become first-class persistent artifacts in `.yoke/sensors/`,
+with a per-sensor markdown template, a working-memory path helper,
+and an Acceptance Contract that **references sensors by ID** instead
+of inlining their command, class, and tier.
+
+## Context
+
+Today, sensor metadata (command, class) is inlined inside
+`acceptance-contract.md` and has no place to grow. There is no per-
+sensor home for accumulated caveats, recent run results, calibration
+notes, or "this sensor flakes when the test DB is cold" knowledge.
+
+The PRD redirects this: sensors get their own per-file home in
+`.yoke/sensors/<id>.md`, mirroring how the rest of the framework
+treats persistent knowledge. The Acceptance Contract becomes a list
+of references; the per-sensor file is the source of truth for
+`command`, `class`, `tier`, `applies_to`, and a growing `runs:`
+history (populated by the coordinator in Part 5).
+
+This part is the **foundation**. It introduces the layout, the
+template, and the contract-by-ID convention. No execution behavior
+changes yet — Part 2 wires the upsert; Parts 3–5 wire the consumers.
+
+## Definition of Done
+
+1. `templates/sensor.md` exists and defines a per-sensor markdown
+   template with YAML frontmatter (`id`, `command`,
+   `class: computational | inferential`, `tier: cheap | expensive`
+   optional, `applies_to: [<criterion-id>...]`, `runs: []`) and a
+   body with a "Caveats" section header. Inline guidance documents
+   the class-based default rule for `tier`.
+2. `lib/working-memory/paths.sh` exposes a `wm_sensors_dir` helper
+   resolving to `.yoke/sensors/` under the host project (consistent
+   with the existing `wm_*_dir` family — `wm_runtime_dir`,
+   `wm_snapshots_dir`).
+3. `templates/acceptance-contract.md` declares sensors by reference
+   only (`sensor: <id>`) inside the per-criterion sensor list. No
+   inline `command`, no inline `tier`, no inline `class`. Inline
+   guidance points authors at `templates/sensor.md` for sensor
+   definition.
+4. `tests/sensor-tiering.test.sh` exists and asserts:
+   (a) `templates/sensor.md` is present, parses as YAML frontmatter
+   + markdown body, and contains the required frontmatter keys;
+   (b) `wm_sensors_dir` returns the expected path under a fixture
+   `.yoke/`; (c) the contract template parses successfully with a
+   pure sensor-by-ID reference.
+5. **Craftsmanship**: template follows existing template conventions
+   in `templates/` (frontmatter shape, comment-based inline
+   guidance, traceable reference to the source PRD); no manifesto
+   invariant is weakened; bash 4+ idioms in `paths.sh`.
+
+## Scope
+
+- **Create** `templates/sensor.md`:
+  - Frontmatter:
+    - `id` (required, string)
+    - `command` (required, string — shell command to execute)
+    - `class` (required, `computational | inferential`)
+    - `tier` (optional, `cheap | expensive` — defaults from class)
+    - `applies_to` (required, list of criterion IDs)
+    - `runs` (required, list — initially empty `[]`; populated by
+      coordinator in Part 5)
+  - Body:
+    - `## Caveats` heading with placeholder guidance.
+    - `## Calibration notes` heading (for inferential sensors;
+      computational sensors leave it empty).
+  - Inline guidance comment block documenting the class-based
+    default rule and a cross-reference to
+    `.vibeflow/prds/sensor-cost-tiering.md` for traceability.
+- **Edit** `lib/working-memory/paths.sh`:
+  - Add `wm_sensors_dir()` returning `${YOKE_HOME:-.yoke}/sensors`
+    (or the equivalent path used by sibling helpers — match the
+    existing convention exactly).
+  - No change to existing helpers.
+- **Edit** `templates/acceptance-contract.md`:
+  - Replace any inline sensor declarations with sensor-by-ID
+    references. Each criterion's sensor list contains only IDs:
+    ```
+    sensors:
+      - id: <sensor-id-1>
+      - id: <sensor-id-2>
+    ```
+  - Add inline guidance: "Define each sensor in
+    `.yoke/sensors/<id>.md` using `templates/sensor.md`. Reference
+    only the ID here."
+  - Preserve all other contract sections unchanged (BDD scenarios,
+    fixtures, policies).
+- **Create** `tests/sensor-tiering.test.sh`:
+  - Smoke check: `templates/sensor.md` exists and round-trips
+    through a YAML+markdown parser.
+  - `wm_sensors_dir` test: source `paths.sh`, assert function
+    returns the expected path under a temp `YOKE_HOME`.
+  - Contract round-trip: a fixture `acceptance-contract.md`
+    referencing two sensor IDs parses, and the parser surfaces
+    those IDs as a clean list (parsing into a temp variable; no
+    sensor-resolution yet — that's Part 2's upsert + Part 3's
+    runtime).
+
+## Anti-scope
+
+- **No `ack-sensors.sh` changes.** Upsert lands in Part 2.
+- **No execution / runtime changes.** No `--tier` flag, no
+  Validator changes, no coordinator changes.
+- **No actual `.yoke/sensors/<id>.md` files seeded.** The template
+  exists; the upsert that populates real sensor files is Part 2.
+- **No migration tooling for existing contracts.** Authors update
+  manually for v0; we ship the new shape and let users adopt.
+- **No sensor-file schema versioning** (`version: 1` field).
+- **No `runs:` retention policy.** The field is introduced as an
+  empty list; retention lives in Part 5.
+- **No skill (`skills/ack-sensors/SKILL.md`) edits.** Part 2 owns
+  the skill doc.
+
+## Technical Decisions
+
+- **`runs: []` introduced empty in Part 1, populated in Part 5.**
+  Rationale: locking the field name + position in the frontmatter
+  schema upfront avoids a schema break later. The retention cap
+  lives where the appending happens.
+- **`templates/sensor.md` keeps inferential-sensor calibration in
+  the body, not the frontmatter.** Rationale: calibration notes
+  vary in length and structure (false-positive examples,
+  rubric text); markdown body is the right home. Frontmatter stays
+  small + machine-parseable.
+- **Contract-by-ID is enforced in the template, not by parser
+  rejection.** Rationale: Part 1 ships the convention; Part 2's
+  readiness check verifies sensor files exist. A contract with
+  inline definitions is a Part-2-readiness failure, not a Part-1
+  template failure.
+- **`wm_sensors_dir` follows the `wm_*_dir` naming convention.**
+  Rationale: consistency with existing helpers
+  (`wm_snapshots_dir`, `wm_runtime_dir`); a maintainer reading
+  `paths.sh` should not need to learn a new naming scheme.
+
+## Applicable Patterns
+
+- `.vibeflow/patterns/sensors.md` — primary; tier metadata moves to
+  the per-sensor file, but the structured-output rule is unchanged.
+- `.vibeflow/patterns/acceptance-contract.md` — contract format
+  changes (by-reference) but binding semantics unchanged.
+- `.vibeflow/patterns/memory-model.md` — `.yoke/sensors/` lives in
+  working memory (per host project); promotion to canonical is
+  out of scope per PRD.
+- `.vibeflow/conventions.md` — framework-knowledge artifacts use
+  per-file markdown with frontmatter; bash 4+ in helpers.
+
+## Risks
+
+- **R1 — Existing `templates/acceptance-contract.md` may inline
+  sensor definitions in a format incompatible with simple
+  by-reference replacement.** Mitigation: read the file in Phase 1
+  and preserve all non-sensor sections verbatim. Document the
+  diff in `progress.md`.
+- **R2 — `lib/working-memory/paths.sh` may not exist yet, or may
+  use a different naming convention.** Mitigation: read the file
+  first; create only if missing; otherwise, add `wm_sensors_dir`
+  alongside existing helpers and match their style.
+- **R3 — Parser tooling for round-trip tests.** The test asserts
+  YAML+markdown parsing, but the project may not ship a parser
+  helper. Mitigation: use a minimal awk/grep-based round-trip
+  (verify the frontmatter delimiter and required keys), not a
+  full parser dependency.
+- **R4 — Inline guidance bloats the template.** Mitigation: keep
+  template guidance to ≤ 10 lines of HTML comments; link to PRD
+  + pattern doc for the long-form rationale.
+
+## Dependencies
+
+None. This is the foundation part.

--- a/.vibeflow/specs/sensor-cost-tiering-part-2.md
+++ b/.vibeflow/specs/sensor-cost-tiering-part-2.md
@@ -1,0 +1,201 @@
+# Spec: Sensor Cost Tiering — Part 2: `/yoke:ack-sensors` upsert mode
+
+> Generated via /vibeflow:gen-spec on 2026-04-27 (revised 2026-04-27)
+> Source PRD: `.vibeflow/prds/sensor-cost-tiering.md`
+
+## Objective
+
+`/yoke:ack-sensors` gains an **upsert mode** that creates or updates
+`.yoke/sensors/<id>.md` files from the Acceptance Contract's sensor-by-
+ID references, applying the class-based tier default on creation,
+and preserving human-edited fields (caveats, calibration notes,
+`runs:` history, explicit `tier:`) on update.
+
+## Context
+
+Part 1 introduces the per-sensor template and the contract-by-ID
+convention. Part 2 closes the loop: a deterministic upsert path that
+the human (or a future automation) can run to materialize sensor
+files in `.yoke/sensors/` from the contract, and to keep them in
+sync as the contract evolves.
+
+This is a deterministic node in the Yoke sense — no LLM, just file
+operations. It is also **idempotent**: running it twice with no
+contract changes produces no file modifications.
+
+## Definition of Done
+
+1. `lib/sensors/ack-sensors.sh` accepts `--mode upsert <contract>`
+   alongside `--mode catalog` and `--mode readiness`.
+2. **Create path**: for every sensor referenced in the contract that
+   does not yet have a file at `.yoke/sensors/<id>.md`, the upsert
+   creates the file from `templates/sensor.md` with `id` and
+   `applies_to` populated from the contract; `command` and `class`
+   prompted for or filled from the contract's metadata block; `tier`
+   filled by class-based default.
+3. **Update path**: for sensors that already have a file, the upsert
+   refreshes only frontmatter fields the contract owns (`applies_to`)
+   and **preserves all human-edited content** — `command` (if author
+   has overridden), `class`, explicit `tier:`, body content (caveats,
+   calibration notes), and `runs:` history. The merge is field-level,
+   not file-level.
+4. **Class-based default tier** is applied only on create. Once a
+   file exists, its tier (explicit or default) is treated as
+   authoritative — the upsert never silently flips it.
+5. **Readiness mode** (existing) verifies every contract-referenced
+   sensor has a corresponding `.yoke/sensors/<id>.md` and the file
+   contains the required frontmatter keys. Failure surfaces a
+   structured violation per `conventions.md` back-pressure (sensor
+   ID, expected file path, correction instruction: "run `/yoke:ack-
+   sensors --mode upsert <contract>`").
+6. `skills/ack-sensors/SKILL.md` documents the upsert mode alongside
+   catalog/readiness, including the create vs update semantics and
+   the idempotency guarantee.
+7. `tests/sensor-tiering.test.sh` extended with: (a) create case
+   (sensor file does not exist; upsert creates it with class-based
+   default); (b) update case (existing file with author-edited
+   caveats; upsert preserves the caveats while updating
+   `applies_to`); (c) idempotency (running upsert twice with no
+   contract changes produces no diff); (d) readiness mode failure
+   message format on missing sensor file.
+8. **Craftsmanship**: idempotency verified (no-op on second run);
+   structured failure on parse errors with location + correction;
+   bash 4+; no destructive operations (the upsert never deletes a
+   sensor file even if the contract drops the reference — orphan
+   handling is out of scope per PRD).
+
+## Scope
+
+- **Edit** `lib/sensors/ack-sensors.sh`:
+  - Extend the mode dispatcher to recognize `--mode upsert`.
+  - Implement the upsert algorithm:
+    1. Parse the contract; collect referenced sensor IDs and any
+       contract-level sensor metadata block (where authors register
+       command + class for new sensors).
+    2. For each ID, check `${wm_sensors_dir}/<id>.md`:
+       - If absent: create from `templates/sensor.md`, populate
+         `id`, `applies_to`, `command`, `class` from contract;
+         apply class-based default for `tier`.
+       - If present: parse the existing file's frontmatter; merge
+         only `applies_to` from contract; preserve all other fields
+         and the body verbatim.
+    3. Write back atomically (`mv` from a temp file) to avoid
+       partial writes.
+  - Strengthen `--mode readiness` to verify referenced sensor files
+    exist and parse cleanly; fail with structured violation
+    pointing at missing/malformed files.
+  - Preserve `--mode catalog` semantics (no change).
+- **Edit** `skills/ack-sensors/SKILL.md`:
+  - Document `--mode upsert <contract>`: when to run (after editing
+    a contract; before `/yoke:implement`), what it does, the
+    create-vs-update semantics, and the idempotency guarantee.
+  - Update mode list in the skill description (add upsert).
+- **Edit** `tests/sensor-tiering.test.sh` (extended from Part 1):
+  - Create case: empty `.yoke/sensors/`, run upsert with a
+    fixture contract referencing two sensors (one computational,
+    one inferential); assert both files exist with class-based
+    tier defaults.
+  - Update case: pre-seed `.yoke/sensors/foo.md` with author-edited
+    caveats and an explicit `tier: expensive` override (where the
+    class would default to cheap); run upsert with a contract
+    where `foo` now has new `applies_to`; assert
+    `applies_to` updated, caveats preserved, explicit `tier`
+    preserved.
+  - Idempotency: run upsert twice; assert second run produces no
+    file modifications (compare mtimes or hashes).
+  - Readiness failure: contract references `bar` but
+    `.yoke/sensors/bar.md` is missing; assert readiness exits
+    non-zero with structured violation including the corrective
+    invocation.
+
+## Anti-scope
+
+- **No execution / runtime changes.** No `--tier` flag, no Validator
+  reads, no coordinator integration.
+- **No automatic upsert** triggered by other skills — must be run
+  explicitly. (Future: `/yoke:implement` could call it as a
+  precondition; out of scope for v0.)
+- **No orphan deletion.** When a contract drops a sensor reference,
+  the file remains at `.yoke/sensors/<id>.md`. Drift-sense (Phase
+  6) is the right place to flag orphans; not this part.
+- **No `runs:` writes.** Coordinator owns history population in
+  Part 5.
+- **No interactive prompting** if the contract lacks a sensor's
+  command/class. Fail with structured violation telling the user
+  to add the metadata to the contract or to the sensor file
+  directly.
+- **No locking / concurrency control** beyond atomic write. We
+  assume the upsert is invoked by the human between cycles, not
+  concurrently with `/yoke:implement`.
+- **No schema migration** for sensor files (e.g. v0 → v1). Tier
+  format and runs format are stable per PRD.
+
+## Technical Decisions
+
+- **Field-level merge, not file-level.** Rationale: the contract
+  owns only `applies_to`; everything else is authored or coordinator-
+  populated. A file-level overwrite would clobber caveats and
+  history; field-level merge is the only correct semantic.
+- **Atomic write via tmp + `mv`.** Rationale: no partial-write risk
+  if the upsert is interrupted; matches existing patterns in
+  `lib/canonical-memory/*.sh` (which already use atomic moves).
+- **Idempotency by content hash, not timestamps.** Rationale: a re-
+  run that produces identical content is a no-op — don't bump
+  mtime, which would mislead `git diff` and downstream tools.
+- **No interactive prompting on missing metadata.** Rationale: Yoke
+  is an autonomous-loop framework; interactive prompts break the
+  ralph-loop assumption. Fail loud with a corrective instruction
+  instead.
+- **Readiness mode strictness increased.** Was: "verify sensors
+  reachable on the local machine". Now: "verify sensor files exist
+  and parse cleanly". Rationale: the file is now the source of
+  truth — its absence is a hard error, not a warning.
+
+## Applicable Patterns
+
+- `.vibeflow/patterns/sensors.md` — primary; sensor metadata is
+  now per-file; structured-output rule applies to readiness
+  failures.
+- `.vibeflow/patterns/memory-model.md` — `.yoke/sensors/` is
+  working memory; the upsert is a working-memory write
+  (allowed, no governance overhead).
+- `.vibeflow/patterns/acceptance-contract.md` — contract is
+  authoritative for `applies_to`; everything else is sensor-file-
+  authoritative.
+- `.vibeflow/conventions.md` — bash 4+; back-pressure (loud
+  failures, structured); deterministic node (no LLM in the upsert
+  path).
+
+## Risks
+
+- **R1 — Existing `ack-sensors.sh` mode dispatcher may make it
+  awkward to add a third mode.** Mitigation: read the file in
+  Phase 1; if the dispatcher is tightly coupled to two modes,
+  refactor minimally to a function-table style.
+- **R2 — Contract sensor-metadata block may not exist yet.** The
+  Part-1 contract change introduces sensor-by-ID references but
+  may not specify where author-supplied `command` / `class` for
+  new sensors live. Mitigation: this spec assumes a top-level
+  `sensors:` registry block in the contract listing each ID's
+  metadata. If Part 1 didn't introduce that block, extend Part 1
+  before implementing Part 2 (re-scope, don't fork).
+- **R3 — Atomic-write semantics on different filesystems.**
+  Cross-device `mv` is non-atomic; verify the temp file lives in
+  the same directory as the target.
+- **R4 — Body-content preservation under upsert is fragile.** If
+  the human edits the body and the upsert miscounts the
+  frontmatter delimiter, the body could be truncated. Mitigation:
+  use a strict frontmatter parser (delimiter pair `---`); add a
+  test specifically asserting body bytes are preserved verbatim
+  on update.
+- **R5 — `runs:` field merging.** If the human edits the body and
+  the coordinator (Part 5) appends to `runs:` between two upserts,
+  the merge must preserve `runs:` from the existing file. The
+  field-level merge rule covers this, but the test must explicitly
+  exercise it.
+
+## Dependencies
+
+- `.vibeflow/specs/sensor-cost-tiering-part-1.md` — Part 2 consumes
+  `templates/sensor.md`, `wm_sensors_dir`, and the contract-by-ID
+  convention introduced in Part 1.

--- a/.vibeflow/specs/sensor-cost-tiering-part-3.md
+++ b/.vibeflow/specs/sensor-cost-tiering-part-3.md
@@ -1,0 +1,178 @@
+# Spec: Sensor Cost Tiering — Part 3: Tier-aware sensor execution
+
+> Generated via /vibeflow:gen-spec on 2026-04-27 (revised 2026-04-27)
+> Source PRD: `.vibeflow/prds/sensor-cost-tiering.md`
+
+## Objective
+
+`hooks/verify-acceptance.sh` accepts `--tier cheap | expensive | all`
+(orthogonal to the existing `--criterion <id>`), reads tier from each
+sensor's `.yoke/sensors/<id>.md` frontmatter (with class-based default
+when `tier:` is absent), and runs only the matching subset.
+
+## Context
+
+Parts 1–2 turned sensors into per-file artifacts and made the upsert
+the canonical way to materialize them. Part 3 is the **runtime
+filter**: the hook learns to scope its execution by tier.
+
+Without Part 3, downstream consumers (the Validator's reasoning in
+Part 4 and the coordinator's two-phase per-cycle execution in Part 5)
+have no way to actually run only the cheap or only the expensive
+subset of sensors per invocation.
+
+The flag is orthogonal to `--criterion <id>` — `--criterion` filters
+*which sensors apply to a cycle*; `--tier` filters *which of those
+fire this invocation*. Both filters compose by intersection.
+
+## Definition of Done
+
+1. `hooks/verify-acceptance.sh` accepts
+   `--tier cheap | expensive | all`. The flag is parsed alongside
+   (not instead of) `--criterion <id>`; both can be combined in any
+   order on the command line.
+2. Tier is resolved per sensor by reading `.yoke/sensors/<id>.md`
+   frontmatter. When `tier:` is absent, the class-based default
+   applies (computational → `cheap`; inferential → `expensive`).
+3. **Default behavior preserved**: when `--tier` is omitted, the hook
+   runs every applicable sensor — identical to current behavior.
+   `--tier all` is explicit and equivalent.
+4. `--tier cheap` runs only sensors whose resolved tier is `cheap`;
+   `--tier expensive` runs only the `expensive` set.
+5. **Combined filters intersect**: `--tier cheap --criterion C-3`
+   runs only the cheap-tier sensors that apply to criterion `C-3`.
+   Empty intersection → exit 0 (no violations possible).
+6. **Unknown `--tier` value** (e.g. `--tier slow`) causes the hook
+   to exit non-zero with a structured violation naming the
+   offending value, the allowed set, and the corrected invocation —
+   per `conventions.md` back-pressure.
+7. **Sensor file missing or malformed** — exit non-zero with
+   structured violation pointing at the offending file and the
+   corrective instruction (`/yoke:ack-sensors --mode upsert`).
+8. `tests/sensor-tiering.test.sh` extended with assertions for each
+   case: omitted, `cheap`, `expensive`, `all`, intersection with
+   `--criterion`, empty intersection, unknown-value error, missing-
+   sensor-file error.
+9. **Craftsmanship**: per-sensor YAML output schema unchanged when
+   filtering — only the set of sensors run changes; no new fields,
+   no schema drift; bash 4+ idioms; no new external dependencies.
+
+## Scope
+
+- **Edit** `hooks/verify-acceptance.sh`:
+  - Extend the existing argparse block to recognize
+    `--tier <cheap|expensive|all>`. Default value: `all` (preserves
+    current behavior when flag is omitted).
+  - When `--tier cheap` or `--tier expensive` is passed:
+    1. Resolve sensor IDs as today (via the contract or
+       `--criterion` filter).
+    2. For each resolved sensor ID, read
+       `${wm_sensors_dir}/<id>.md` and parse `tier` from
+       frontmatter (apply class-based default if absent).
+    3. Filter the sensor list to those matching the requested tier.
+    4. Execute the filtered set via the existing parallel-execution
+       path (`xargs -P "$(yoke_sensor_concurrency)"`).
+  - When `--tier all` (or omitted): run the resolved set without
+    tier filtering.
+  - When `--tier <unknown>`: fail-fast before executing any sensor;
+    emit a structured violation message; exit non-zero.
+  - When a referenced sensor file is missing or unparseable: fail-
+    fast with a structured violation; exit non-zero.
+  - Combine cleanly with `--criterion <id>` — both filters apply
+    (intersection).
+- **Edit** `tests/sensor-tiering.test.sh` (extended from Parts 1–2):
+  - Fixture: a contract referencing 4 sensors (cheap-comp,
+    expensive-comp, cheap-inferential, expensive-inferential — to
+    cover both class+tier combinations) with corresponding
+    `.yoke/sensors/<id>.md` files (some with explicit `tier:`,
+    some relying on class default).
+  - Assert: `--tier cheap` runs exactly the cheap pair (regardless
+    of class); `--tier expensive` runs the expensive pair;
+    `--tier all` runs all four; flag-omitted runs all four.
+  - Assert intersection: `--tier expensive --criterion <id-with-
+    only-cheap-applicable>` runs zero sensors and exits 0.
+  - Assert unknown-value error: `--tier slow` exits non-zero with
+    the structured-violation format (test parses the error message
+    for the required fields).
+  - Assert missing-sensor-file: rename one sensor file to simulate
+    absence; the hook exits non-zero with the structured violation
+    pointing at the missing path.
+
+## Anti-scope
+
+- **No tier authoring or default inference changes.** Parts 1–2 own
+  the source of truth.
+- **No Validator scheduling or coordinator gating.** Parts 4–5 own
+  those.
+- **No timeout / concurrency model changes.** Existing per-sensor
+  timeouts and `xargs -P` are untouched.
+- **No output-schema changes.** Per-sensor YAML keeps every
+  existing field; tier filtering only changes which sensors appear,
+  not their shape.
+- **No caching of tier resolution across invocations.** Re-read the
+  sensor file each time — the file is the source of truth and may
+  have been edited between invocations.
+- **No retry / flake handling.**
+- **No new flags beyond `--tier`.**
+
+## Technical Decisions
+
+- **`--tier all` is first-class and explicit.** Rationale: callers
+  (CI, smoke tests) may want to pin all-tiers without relying on a
+  default; first-class `all` removes a "default vs explicit"
+  surprise.
+- **Filter at the sensor-list level, not by per-sensor early-exit.**
+  Rationale: the existing parallel execution uses `xargs -P`;
+  filtering the input list is composable. Per-sensor early-exit
+  would require touching the execution body — bigger blast radius.
+- **Re-read sensor files on every invocation.** Rationale: the
+  sensor file is the source of truth and may change between cycles.
+  Caching would introduce stale-tier risk for marginal speed gain.
+- **Unknown `--tier` is fatal**, not fallback to `all`. Same
+  rationale as Parts 1–2: silent fallback hides typos.
+- **Missing sensor file is fatal at the hook level.** Rationale:
+  Part 2's readiness mode is the *intended* place to catch missing
+  files; the hook fails as a defense-in-depth, with a corrective
+  instruction pointing at `--mode upsert`.
+- **`--tier` and `--criterion` intersect.** Rationale: both are
+  narrowing filters by user intent — "cheap sensors that apply to
+  this criterion", not "everything in either set".
+
+## Applicable Patterns
+
+- `.vibeflow/patterns/sensors.md` — primary; tier filter is a new
+  execution-stage filter; structured-output rule applies to
+  failures.
+- `.vibeflow/patterns/ralph-loop.md` — cycle protocol invariants
+  (deterministic node, structured per-cycle output) preserved.
+- `.vibeflow/conventions.md` — back-pressure on unknown flags and
+  missing sensor files; bash 4+.
+
+## Risks
+
+- **R1 — Existing argparse may not parse two flags cleanly.**
+  Mitigation: read the file in Phase 1; if argparse is positional
+  rather than flag-based, align `--tier` with the existing style.
+  This spec assumes flags; downgrade gracefully if needed.
+- **R2 — Sensor file parsing in bash adds complexity.**
+  Mitigation: parse only the frontmatter (between two `---`
+  delimiters) using awk or sed; do not depend on a YAML library.
+  Sensor frontmatter is intentionally simple.
+- **R3 — Combined-filter empty result must still pass.** Edge case:
+  `--tier expensive` against a criterion that maps only cheap
+  sensors. Without any sensor to run, the hook should exit 0 with
+  empty per-cycle YAML output — not error. Test asserts this.
+- **R4 — Class-based default fallback must match Part 1's parser.**
+  If Part 1 changes its default rule, Part 3's resolution must
+  follow. Mitigation: factor the resolution helper into
+  `lib/sensors/`-shared code so both paths use the same logic; OR
+  document the duplication and mark it as a Part-2 readiness check
+  responsibility.
+
+## Dependencies
+
+- `.vibeflow/specs/sensor-cost-tiering-part-1.md` — sensor file
+  schema, `wm_sensors_dir`.
+- `.vibeflow/specs/sensor-cost-tiering-part-2.md` — upsert
+  guarantees that referenced sensor files exist and are well-formed
+  by the time the hook runs.

--- a/.vibeflow/specs/sensor-cost-tiering-part-4.md
+++ b/.vibeflow/specs/sensor-cost-tiering-part-4.md
@@ -1,0 +1,232 @@
+# Spec: Sensor Cost Tiering — Part 4: Validator scheduling reads sensor files
+
+> Generated via /vibeflow:gen-spec on 2026-04-27 (revised 2026-04-27)
+> Source PRD: `.vibeflow/prds/sensor-cost-tiering.md`
+
+## Objective
+
+The Validator persona reads `.yoke/sensors/<id>.md` files (caveats,
+calibration notes, `runs:` history) when emitting `schedule_next:` in
+its per-cycle verdict, and the working-memory templates persist that
+decision verbatim alongside the cycle's verdict so it is auditable
+post-hoc.
+
+## Context
+
+Parts 1–3 deliver the inputs: Part 1 the per-sensor file format;
+Part 2 the upsert that materializes them; Part 3 the hook flag that
+filters by tier. Part 4 is the **decision layer**: the Validator
+uses what it observed (cheap-tier results, the diff, Tech-Spec
+signals, **plus the sensor files' caveats and run history**) to
+authorize the next cycle's expensive sensors — or not.
+
+The decision is lag-by-one — same model already used for inferential
+judges per `patterns/sensors.md:90`. This preserves the parallel-
+spawn architecture where Generator, Validator, and Orchestrator run
+concurrently in one Task batch per cycle. The Validator never gates
+execution inside the cycle it spawned in.
+
+For cycle 1, with no prior `schedule_next` to read, the coordinator
+default is cheap-only; the Validator's first verdict may use **type-
+of-work signals** (Tech-Spec content + the cycle's diff) to authorize
+expensive starting cycle 2.
+
+The new dimension this part adds: **the Validator's reasoning cites
+sensor history when present**. If `.yoke/sensors/playwright-
+checkout.md` shows two consecutive flake-failures in `runs:`, the
+Validator's `reason` field references that signal explicitly.
+
+## Definition of Done
+
+1. `agents/validator.md` requires the Validator to **read
+   `.yoke/sensors/<id>.md` files** for sensors mapped to the cycle's
+   targeted criterion when emitting `schedule_next`. Caveats body
+   and `runs:` history feed the decision.
+2. `agents/validator.md` requires `schedule_next` in every cycle
+   verdict, with a fixed shape:
+   ```
+   schedule_next:
+     sensors: [<sensor-id>...]   # explicit IDs (optional)
+     tiers:   [cheap | expensive] # tier shorthand (optional)
+     reason:  "..."               # required; cites at least one signal
+   ```
+3. `agents/validator.md` documents the **default rule**: include
+   `tier:cheap` always; include `tier:expensive` when (a) cheap-tier
+   was green this cycle for the targeted criterion(s), (b) the
+   Validator explicitly authorizes (e.g. diff touches expensive-
+   relevant surface, or a sensor's `runs:` history shows two
+   consecutive greens after a fix), or (c) the cycle is the final
+   merge-ready check.
+4. `agents/validator.md` documents the **cycle-1 type-aware
+   judgment**: with no prior `schedule_next`, the coordinator runs
+   cheap only; the Validator's first verdict may authorize
+   expensive starting cycle 2 using Tech-Spec signals + cycle diff.
+5. **`reason` field requirements**: must cite at least one signal
+   source by name — a sensor ID, a criterion ID, a Tech-Spec
+   reference, or a `runs:` history entry. Free-form text is allowed
+   beyond that requirement.
+6. `templates/progress.md` and `templates/contracts.md` schemas
+   include a per-cycle `schedule_next` block alongside the verdict
+   — field shape mirrors Validator's emission, persisted verbatim
+   for audit.
+7. `tests/sensor-tiering.test.sh` extended:
+   (a) fixture verdict has well-formed `schedule_next` with all
+   required fields;
+   (b) when sensor history shows flakes, the verdict's `reason`
+   cites the sensor ID;
+   (c) a verdict missing `schedule_next` or with empty `reason`
+   fails the schema check.
+8. **Craftsmanship**: persona content cites the actionable-feedback
+   rationale and traces to source PRD; verdict schema follows
+   existing structured-output conventions
+   (`.vibeflow/conventions.md` back-pressure: structured, machine-
+   parseable, no prose-only updates); no manifesto invariant
+   weakened.
+
+## Scope
+
+- **Edit** `agents/validator.md`:
+  - **New "Reads" section** entry: `.yoke/sensors/<id>.md` for
+    sensors mapped to the cycle's targeted criterion(s). The
+    Validator may also re-read sensor files for criteria adjacent
+    to the targeted one when the diff suggests cross-criterion
+    coupling.
+  - **Persona contract addition**: emit `schedule_next` in every
+    cycle verdict per the shape locked in DoD 2.
+  - **"Always" section addition**:
+    - "Always include `tier:cheap` in `schedule_next`."
+    - "Include `tier:expensive` when the previous cycle's cheap-
+      tier was green for the targeted criterion(s), OR when the
+      diff touches sensor-applies_to surface, OR when this is the
+      final merge-ready check."
+    - "Always cite at least one signal source (sensor ID,
+      criterion ID, Tech-Spec section, or `runs:` history entry)
+      in `reason`."
+  - **Cycle-1 heuristic**: no prior `schedule_next`; coordinator
+    runs cheap only; first Validator verdict may authorize
+    expensive starting cycle 2 using Tech-Spec signals + diff.
+  - **Rationale block**: shift-feedback-left only when actionable;
+    per-sensor file is the durable record; `runs:` history flake
+    signals are first-class for the scheduling decision.
+  - Reference `.vibeflow/prds/sensor-cost-tiering.md` for
+    traceability.
+- **Edit** `templates/progress.md`:
+  - Add a per-cycle `schedule_next:` block under the existing
+    per-cycle entry, mirroring the Validator's emission shape.
+- **Edit** `templates/contracts.md`:
+  - Add a `schedule_next:` field per cycle, persisted verbatim
+    from the Validator's verdict.
+- **Edit** `tests/sensor-tiering.test.sh` (extended from Parts
+  1–3):
+  - Fixture verdict (JSON or YAML, depending on the existing
+    verdict-schema convention): assert all three required fields
+    present (`sensors` and/or `tiers`, `reason`).
+  - History-aware fixture: pre-seed `.yoke/sensors/<id>.md` with
+    a `runs:` history showing two flakes; provide a fixture
+    verdict and assert the Validator-persona-defined `reason`
+    schema requires citing the sensor ID. (This is a contract
+    test on the persona, not a live agent run — the test verifies
+    that an incomplete verdict fails the schema check.)
+  - Negative cases: a fixture verdict missing `schedule_next` is
+    treated as malformed; a fixture with empty `reason` is
+    treated as malformed.
+
+## Anti-scope
+
+- **No coordinator gating.** Part 5 owns reading `schedule_next`
+  and acting on it.
+- **No in-cycle scheduling.** Validator stays parallel-spawn;
+  decisions are lag-by-one only.
+- **No live-agent integration tests.** Fixture-based assertions
+  only; end-to-end smoke is in Part 5.
+- **No new persona responsibilities** beyond scheduling. Sensor
+  consumption, consensus-with-Generator, and other behaviors
+  unchanged.
+- **No Orchestrator changes.** Canonization, Model C, and consult-
+  mode behavior untouched.
+- **No new working-memory artifacts.** Reuse `progress.md` and
+  `contracts.md`; sensor history reads come from `.yoke/sensors/`
+  (Part 1).
+- **No `schedule_next` schema versioning** (e.g. `version: 1`
+  field). Premature.
+- **No flake-detection algorithm.** The Validator interprets
+  `runs:` history qualitatively in `reason`; quantitative flake
+  rules (e.g. "auto-quarantine after N flakes") are out of scope.
+
+## Technical Decisions
+
+- **`schedule_next` is structured, not prose.** Rationale: must be
+  machine-parseable for Part 5's coordinator. Three keys:
+  `sensors`, `tiers`, `reason`. The `reason` field is human-readable
+  but must cite at least one signal source.
+- **Tier shorthand and explicit sensor IDs coexist.** Rationale:
+  most cycles use `tiers: [cheap]` or `tiers: [cheap, expensive]`;
+  occasionally the Validator wants to authorize a specific sensor
+  (one expensive sensor whose target surface is touched). Both
+  shapes supported keeps the common case terse.
+- **Persisted verbatim in `progress.md` / `contracts.md`.**
+  Rationale: no transformation = no impedance mismatch when humans
+  audit. Verdict schema and persisted schema are the same object.
+- **Cycle-1 heuristic in the persona, not the coordinator.**
+  Rationale: "what to authorize" is a Validator concern. The
+  coordinator's cycle-1 default (cheap only) is mechanical and
+  lives in Part 5.
+- **`reason` field has a citation requirement, but no fixed
+  format.** Rationale: forcing a structured citation list would
+  bloat the schema; requiring "at least one signal source" keeps
+  the bar high without over-engineering.
+- **Validator reads sensor files directly, not via an
+  intermediate.** Rationale: the file is in working memory (per-
+  task, ephemeral); no governance overhead. Direct read keeps the
+  decision path simple.
+
+## Applicable Patterns
+
+- `.vibeflow/patterns/roles.md` — Validator is a runtime subagent
+  with judgment authority; scheduling is a refinement.
+- `.vibeflow/patterns/sensors.md` — structured-output rule applies
+  to the verdict (including `schedule_next`); per-sensor file is
+  now the runtime context.
+- `.vibeflow/patterns/ralph-loop.md` — lag-by-one model already
+  documented; reused.
+- `.vibeflow/patterns/memory-model.md` — Validator reads working
+  memory directly (allowed); no canonical-memory access required.
+- `.vibeflow/conventions.md` — structured output, machine-
+  parseable; every persona change traces to a failure or
+  constraint.
+
+## Risks
+
+- **R1 — Validator verdict schema may already be locked elsewhere.**
+  Mitigation: read `agents/validator.md` in Phase 1; if there's an
+  existing JSON/YAML schema definition, extend it as a new top-
+  level key rather than nesting inside an existing field.
+- **R2 — `templates/progress.md` and `templates/contracts.md` may
+  have a per-cycle block format that conflicts with the new
+  field.** Mitigation: read both templates first; place
+  `schedule_next` adjacent to the verdict at the same nesting
+  level. Don't restructure the template.
+- **R3 — Sensor-file reads bloat Validator context.** Each sensor's
+  caveats body could be long; reading all of them every cycle
+  could push context limits. Mitigation: persona contract only
+  requires reading sensors mapped to the targeted criterion(s),
+  not all sensors. Document this scoping rule explicitly.
+- **R4 — `reason` citation enforcement is a soft contract.** A
+  Validator emitting an empty or token-citation `reason` is hard
+  to detect mechanically. Mitigation: schema test asserts non-
+  empty `reason`; deeper qualitative review remains a human
+  responsibility (post-hoc audit of `progress.md`).
+- **R5 — Schema-fixture drift.** If Part 5 changes the
+  `schedule_next` shape during integration, Part 4's fixture and
+  assertions become outdated. Mitigation: lock the shape here
+  (sensors / tiers / reason — three keys, no more) and treat any
+  change as a new spec.
+
+## Dependencies
+
+- `.vibeflow/specs/sensor-cost-tiering-part-1.md` —
+  `templates/sensor.md` defines the `runs:` field the Validator
+  reads.
+- `.vibeflow/specs/sensor-cost-tiering-part-2.md` — upsert
+  guarantees sensor files exist by the time the Validator reads
+  them.

--- a/.vibeflow/specs/sensor-cost-tiering-part-5.md
+++ b/.vibeflow/specs/sensor-cost-tiering-part-5.md
@@ -1,0 +1,263 @@
+# Spec: Sensor Cost Tiering — Part 5: Coordinator two-phase + run-history persistence + pattern doc
+
+> Generated via /vibeflow:gen-spec on 2026-04-27
+> Source PRD: `.vibeflow/prds/sensor-cost-tiering.md`
+
+## Objective
+
+`/yoke:implement` runs sensors per cycle in two phases (cheap first,
+expensive only when authorized by the previous cycle's
+`schedule_next`), preserves the parallel-spawn architecture, persists
+each cycle's per-sensor result back to `.yoke/sensors/<id>.md`'s
+`runs:` history, runs the full suite at merge-ready, and the sensors-
+pattern doc records the new behavior with its actionable-feedback
+rationale.
+
+## Context
+
+Parts 1–4 deliver the inputs: Part 1 the per-sensor file format;
+Part 2 the upsert path; Part 3 the hook's `--tier` filter; Part 4
+the Validator's `schedule_next` emission and persistence. Part 5 is
+the **integration point** — the coordinator that consumes all four,
+plus the durable history feedback loop that closes the design.
+
+Before Part 5, none of the user-visible runtime behavior has changed.
+Part 5 flips the switch: cycles run cheap synchronously, expensive
+only when the previous cycle's Validator authorized it; merge-ready
+runs the full suite; per-cycle results land in `.yoke/sensors/<id>.md`'s
+`runs:` history, capped at the most recent N entries. The pattern
+doc captures the rationale so future contributors don't accidentally
+re-violate "shift feedback left" by arguing the principle in
+isolation.
+
+## Definition of Done
+
+1. `skills/implement/SKILL.md` runs sensors per cycle in two phases:
+   - **Phase A** (after Generator diff): invokes
+     `hooks/verify-acceptance.sh --tier cheap --criterion <last-
+     target>` synchronously; persists results to
+     `$(wm_snapshots_dir)/cycle-<N>.yaml`.
+   - **Phase B** (after Phase A, gated): invokes
+     `hooks/verify-acceptance.sh --tier expensive --criterion
+     <last-target>` **only when** authorized by cycle N-1's
+     `schedule_next` (i.e. `tier:expensive` in tiers, or specific
+     sensor IDs whose applies_to includes the targeted criterion).
+2. **Cycle-1 default**: no prior `schedule_next` exists; Phase A
+   only. Phase B becomes possible from cycle 2 onward via the
+   Validator's authorization.
+3. **Merge-ready convergence check** runs the **full sensor suite**
+   (`--tier all`) regardless of `schedule_next`; convergence is
+   declared only when every sensor passes. No early "done" while
+   any expensive sensor is unrun or failing.
+4. **Per-sensor history persistence**: after Phase A and Phase B
+   complete (per cycle), the coordinator appends an entry to each
+   executed sensor's `.yoke/sensors/<id>.md` `runs:` list with:
+   `cycle`, `started_at`, `duration_ms`, `status`
+   (pass | fail | skip), `criterion`, optional `evidence_snippet`
+   (truncated). Sensors that did not run this cycle are not
+   touched.
+5. **Retention cap**: `runs:` keeps the most recent N=20 entries.
+   Older entries roll off on append. The cap is enforced by the
+   coordinator on every append, not by a separate cleanup step.
+6. `.vibeflow/patterns/sensors.md` gains a "Cost tiering, sensor
+   persistence, and Validator-owned scheduling" subsection
+   covering: per-sensor file layout, class-based default, two-phase
+   per-cycle execution, lag-by-one Validator scheduling, run-
+   history persistence with retention, merge-ready full sweep, and
+   the actionable-feedback rationale (with explicit reconciliation
+   against shift-feedback-left).
+7. `tests/sensor-tiering.test.sh` extended with end-to-end smoke:
+   a 3-cycle fixture run with one cheap-passing and one expensive-
+   passing sensor — assert (a) cycle 1 runs Phase A only;
+   (b) cycle 2 runs Phase A + B (Validator authorized); (c) cycle 3
+   runs Phase A only (Validator does not authorize, e.g. diff
+   doesn't touch expensive surface); (d) `runs:` history correctly
+   appended for executed sensors only, with retention cap working
+   when seeded near the limit; (e) merge-ready check runs the full
+   suite regardless of `schedule_next`.
+8. **Craftsmanship**: skill changes preserve parallel-spawn
+   architecture (no new in-cycle synchronization between Validator
+   and coordinator); pattern doc edit follows the existing section
+   structure (What / Where / The Pattern / Rules / Examples /
+   Anti-patterns); no manifesto invariant weakened or removed; the
+   actionable-feedback rationale traces to source PRD by inline
+   reference.
+
+## Scope
+
+- **Edit** `skills/implement/SKILL.md`:
+  - Per-cycle protocol gains an explicit two-phase block:
+    - Phase A: `hooks/verify-acceptance.sh --tier cheap --criterion
+      <last-target>`; persist to
+      `$(wm_snapshots_dir)/cycle-<N>.yaml`.
+    - Phase B: read cycle N-1's `schedule_next` from
+      `progress.md` (or `contracts.md`); if `tier:expensive` is
+      authorized OR specific expensive sensor IDs applicable to
+      the targeted criterion are listed, invoke
+      `hooks/verify-acceptance.sh --tier expensive --criterion
+      <last-target>` and merge results into the same per-cycle
+      YAML.
+  - **Cycle-1 explicit default**: hard-coded "Phase A only" branch
+    when no prior cycle exists. Don't infer from missing
+    `schedule_next` — make the boundary explicit.
+  - **History-append step**: after both phases finish (or after
+    Phase A alone, in cycle 1), iterate executed sensor IDs;
+    parse each `.yoke/sensors/<id>.md`; append a `runs:` entry;
+    enforce N=20 cap; atomic write back.
+  - **Merge-ready convergence**: `hooks/verify-acceptance.sh
+    --tier all` (or omit `--tier` for the same effect); convergence
+    requires all sensors green. Document explicitly that
+    `schedule_next` is ignored at this step.
+- **Edit** `.vibeflow/patterns/sensors.md`:
+  - Add a new subsection after the parallel-execution section
+    (around line 119, where the inferential-sensor failure policy
+    ends): "### Cost tiering, sensor persistence, and Validator-
+    owned scheduling".
+  - Cover:
+    - Per-sensor file layout (`.yoke/sensors/<id>.md`) with
+      frontmatter + caveats body + `runs:` history.
+    - Class-based tier default (computational → cheap; inferential
+      → expensive).
+    - Two-phase per-cycle execution (Phase A / Phase B / merge-
+      ready).
+    - Lag-by-one Validator scheduling via `schedule_next`.
+    - Run-history persistence with N=20 retention cap.
+    - Actionable-feedback rationale, with explicit reconciliation
+      vs. shift-feedback-left (cheap stays in-loop; expensive is
+      gated only because pre-convergence failures aren't
+      actionable).
+  - Add anti-pattern entry: "Running all expensive sensors every
+    cycle when the feature is mid-assembly — failures are
+    incompleteness signals, not bug signals; the Generator cannot
+    act on them."
+  - Reference `.vibeflow/prds/sensor-cost-tiering.md` for
+    traceability.
+- **Edit** `tests/sensor-tiering.test.sh` (extended from Parts 1–4):
+  - End-to-end smoke fixture with 2 sensors (`cheap-comp`,
+    `expensive-comp`) and a 3-cycle scripted run.
+  - Cycle 1: Phase A runs cheap only; Validator fixture verdict
+    authorizes `tier:expensive` for cycle 2 in `schedule_next`;
+    coordinator appends 1 entry to `cheap-comp`'s `runs:`.
+  - Cycle 2: Phase A + B both run; coordinator appends entries to
+    both sensors' `runs:`.
+  - Cycle 3: Validator fixture verdict does not authorize
+    expensive; assert Phase B did not run; coordinator appends 1
+    entry to `cheap-comp` only.
+  - Retention test: pre-seed a sensor file with `runs:` already
+    at 20 entries; run one more cycle; assert the oldest entry
+    rolled off and the new entry was appended.
+  - Merge-ready: invoke the merge-ready code path with a
+    `schedule_next` that authorizes nothing; assert all sensors
+    still ran (full suite).
+
+## Anti-scope
+
+- **No new architecture.** Parallel-spawn (Generator + Validator +
+  Orchestrator concurrent per cycle) is preserved. No new
+  synchronization primitive between Validator and coordinator
+  inside one cycle.
+- **No tier authoring or parsing changes.** Parts 1–3 own those.
+- **No `schedule_next` schema changes.** Part 4 owns the shape;
+  Part 5 only consumes it.
+- **No tier-aware budget accounting.** Cycle budget stays uniform
+  — Phase B runs within the existing per-cycle wall-clock budget.
+- **No retry semantics for expensive sensors.**
+- **No CI / Sprint-8 wiring.**
+- **No flake auto-quarantine.** `runs:` history enables it as a
+  future addition; this part only persists data.
+- **No `runs:` field migration** for pre-existing sensor files
+  with a different shape. (Such files don't exist; sensors are
+  introduced fresh in Part 1.)
+- **No removal of any existing manifesto invariant.** Shift-
+  feedback-left is **refined**, not rescinded.
+
+## Technical Decisions
+
+- **Phase B reads `schedule_next` from the persisted snapshot, not
+  from a live Validator query.** Rationale: Validator may have
+  already finished its turn for cycle N when Phase B for cycle
+  N+1 starts; the snapshot is the durable record. Matches the
+  lag-by-one model.
+- **Merge-ready uses `--tier all` explicitly.** Rationale:
+  convergence semantics must be obvious to anyone reading the
+  skill source.
+- **Cycle-1 default hard-coded, not derived from missing
+  `schedule_next`.** Rationale: makes the boundary explicit;
+  failing to read N-1 (because N-1 doesn't exist) shouldn't be
+  silently equivalent to "no expensive authorized" — it should
+  be an explicit branch.
+- **History append is part of the cycle, not a separate
+  finalization step.** Rationale: keeping it in the cycle means
+  failures during append fail the cycle clearly; a separate
+  finalization step risks orphaning data.
+- **Retention cap N=20, enforced on append.** Rationale: bounded
+  per-file size; predictable disk usage; recent-history dominance
+  is what the Validator needs (older history is rarely informative
+  for scheduling decisions). N=20 is a starting point; revisit
+  after observing real-world `.yoke/sensors/` over multi-month
+  use.
+- **Atomic write back to sensor files.** Rationale: same as
+  Part 2's upsert — no partial-write risk if the coordinator is
+  interrupted mid-append.
+- **Pattern-doc placement after the existing parallel-execution
+  section.** Rationale: contiguous reading order; new behavior
+  layers on top of existing model.
+
+## Applicable Patterns
+
+- `.vibeflow/patterns/sensors.md` — primary; this part edits it.
+- `.vibeflow/patterns/ralph-loop.md` — cycle protocol invariants
+  (deterministic node, hard bounds, parallel spawn) preserved.
+- `.vibeflow/patterns/roles.md` — Validator scheduling is a
+  refinement; coordinator (deterministic node) consumes the output
+  and writes history.
+- `.vibeflow/patterns/acceptance-contract.md` — binding semantics
+  preserved by merge-ready full sweep.
+- `.vibeflow/patterns/memory-model.md` — coordinator writes to
+  working memory (`.yoke/sensors/`); no canonical-memory access.
+- `.vibeflow/conventions.md` — shift-feedback-left rationale
+  reconciled in the new pattern subsection (not violated).
+
+## Risks
+
+- **R1 — `skills/implement/SKILL.md` cycle protocol may inline a
+  fixed `verify-acceptance.sh` call site that's hard to split into
+  Phases A/B.** Mitigation: read the file in Phase 1; refactor
+  minimally to introduce two distinct invocations. Narrow blast
+  radius.
+- **R2 — Cycle 1's "Phase A only" branch delays first expensive-
+  sensor failure by one cycle.** Acceptance: this is the design
+  (lag-by-one). Merge-ready full sweep is the safety net; document
+  explicitly in the pattern doc.
+- **R3 — `schedule_next` schema may evolve in future work.**
+  Mitigation: read only the keys this part needs (`tiers:`,
+  `sensors:`); ignore unknown keys; document forward-compatibility
+  inline in the skill.
+- **R4 — Pattern-doc edit overlaps textually with existing
+  parallel-execution coverage.** Mitigation: new subsection
+  references (does not duplicate) the existing coverage; new
+  content stays focused on tiering + persistence + scheduling.
+- **R5 — Sensor-file append performance on large `runs:` lists.**
+  With cap N=20, append is O(20) per cycle per sensor — trivial.
+  Mitigation: just enforce the cap; no other concern.
+- **R6 — End-to-end fixture run might be slow.** Mitigation: use
+  trivially-passing sensors (`echo ok`) for both cheap and
+  expensive in the test fixture; the test verifies *gating
+  behavior + persistence*, not *sensor payload*.
+- **R7 — Coordinator writes to sensor files concurrent with a
+  human-invoked upsert.** Both write atomically (Part 2's upsert,
+  this part's append), so the worst case is a clobbered intermediate
+  state — not file corruption. Documented assumption: humans run
+  upsert between cycles, not concurrently.
+
+## Dependencies
+
+- `.vibeflow/specs/sensor-cost-tiering-part-1.md` — sensor file
+  schema with `runs:` field, `wm_sensors_dir`.
+- `.vibeflow/specs/sensor-cost-tiering-part-2.md` — upsert ensures
+  files exist; coordinator's append assumes the field-level merge
+  rule.
+- `.vibeflow/specs/sensor-cost-tiering-part-3.md` — `--tier` flag
+  on `verify-acceptance.sh` (Phase A and Phase B both call it).
+- `.vibeflow/specs/sensor-cost-tiering-part-4.md` — Validator's
+  `schedule_next` emission and persistence (consumed here).

--- a/agents/validator.md
+++ b/agents/validator.md
@@ -17,11 +17,22 @@ Take each Generator cycle's diff (the code changes the Generator
 applied) and judge it against `.yoke/acceptance-contracts/<slug>.md`. Run
 every declared computational sensor via
 `hooks/verify-acceptance.sh`. Emit a **structured JSON verdict** per
-criterion. Append consensus interpretations to `.yoke/contracts/<slug>.md`.
+criterion plus a **per-cycle `schedule_next:` block** that authorizes
+the next cycle's expensive sensors. Append consensus interpretations
+to `.yoke/contracts/<slug>.md`.
 
 You optimize for **rigor**. Where the Generator asks "is this done
 end-to-end", you ask "is this provably correct against the Contract".
 Together you converge.
+
+> **Sensor-cost-tiering Part 4.** You read each referenced
+> sensor's per-file home at `.yoke/sensors/<id>.md` (caveats body,
+> `runs:` history, calibration notes) when emitting `schedule_next` —
+> the file is the durable record of what each sensor has done in
+> recent cycles. The coordinator gates next-cycle expensive-tier
+> execution on your decision (lag-by-one, same model used for
+> inferential judges). Source PRD:
+> `.vibeflow/prds/sensor-cost-tiering.md`.
 
 ## Persona
 
@@ -68,6 +79,16 @@ specific sensor outcome.
   recording the lag/missing reason — never guess. The judges that
   produced these verdicts are spawned by `/yoke:implement` in the
   per-cycle background batch; you never spawn them yourself.
+- **Read per-sensor files** at `.yoke/sensors/<id>.md` for every
+  sensor mapped to the cycle's targeted criterion(s). The
+  frontmatter (`tier`, `class`, `applies_to`) and the `runs:` history
+  inform `schedule_next` — recurring failures across cycles, recent
+  flakes, calibration notes, and known caveats are first-class
+  signals. Scope this read to sensors that apply to the targeted
+  criterion(s); do not load every sensor file every cycle. When
+  caveats explicitly mention conditions that affect the current
+  diff (e.g. "flakes when the test DB is cold"), surface them in
+  the `reason` field of `schedule_next`.
 - **Emit structured JSON verdicts.** Each verdict per criterion has:
 
   ```json
@@ -85,6 +106,44 @@ specific sensor outcome.
   **reject the verdict and re-prompt yourself** with a structured
   output requirement. Unstructured output is a sensor bug per
   `patterns/sensors.md`.
+- **Emit `schedule_next:` per cycle** alongside the verdicts, naming
+  the sensors / tiers the coordinator should run **next** cycle. The
+  shape is fixed:
+
+  ```yaml
+  schedule_next:
+    sensors: [<sensor-id>...]    # explicit ids (optional)
+    tiers:   [cheap | expensive] # tier shorthand (optional)
+    reason:  "<must cite at least one signal source>"
+  ```
+
+  At least one of `sensors:` or `tiers:` MUST be non-empty. The
+  `reason:` field is mandatory and MUST cite at least one signal
+  source by name — a sensor id (e.g. `playwright-checkout`), a
+  criterion id (e.g. `Scenario 1`, `FR-3`), a Tech-Spec section
+  reference, or a `runs:` history entry from a per-sensor file.
+  Free-form text is allowed beyond that requirement, but a `reason`
+  with no citation fails the schema (treat as a self-bug, re-emit).
+
+  **Default rule** (apply unless a specific signal overrides):
+  - Always include `tier:cheap` in `tiers:`.
+  - Include `tier:expensive` in `tiers:` when **cheap-tier was green
+    for the targeted criterion(s) on the previous cycle**, OR the
+    diff touches files in any expensive sensor's `applies_to`
+    surface, OR this is the final merge-ready check. Otherwise omit
+    `expensive`.
+  - When a sensor's `runs:` history shows two consecutive flakes,
+    name the sensor in `reason:` and prefer NOT to authorize it
+    until the diff plausibly addresses the flake's location.
+
+  **Cycle-1 heuristic.** No prior `schedule_next` exists; the
+  coordinator runs **cheap only** by default. Your first verdict
+  may authorize `tier:expensive` starting cycle 2 using **type-of-
+  work signals**: the Tech-Spec task descriptions (e.g. "this task
+  rewires the checkout flow covered by Playwright"), the cycle's
+  diff (which `applies_to` surfaces does it touch?), and any
+  expensive sensor's caveats. When in doubt at cycle 1, omit
+  `tier:expensive` — the merge-ready full sweep is the safety net.
 - **Append to `.yoke/contracts/<slug>.md`** when you and the Generator
   reach consensus on a sub-objective. Use the YAML schema in
   `templates/contracts.md`. Cite the Acceptance Contract criterion.
@@ -134,19 +193,24 @@ every `.yoke/tasks/<slug>-s*-t*.md`,
 `.yoke/acceptance-contracts/<slug>.md`, `.yoke/runtime/progress.md`,
 `.yoke/contracts/<slug>.md`,
 `.yoke/runtime/.snapshots/cycle-<N>.yaml` (computational sensor
-output), and
+output),
 `.yoke/runtime/.judge-verdicts/cycle-<N-1>/*.json` (inferential
 sensor verdicts written by judges spawned by `/yoke:implement` in
-the previous cycle's background batch). Read host-project code
+the previous cycle's background batch), and
+`.yoke/sensors/<id>.md` (per-sensor frontmatter + caveats body +
+`runs:` history; project-scoped working-memory artifact created and
+refreshed by `/yoke:ack-sensors --mode upsert` — see
+`.vibeflow/prds/sensor-cost-tiering.md`). Read host-project code
 (read-only). Write `.yoke/contracts/<slug>.md` (jointly with the
 Generator). Read canonical memory only by invoking `/yoke:ask` via
 the Skill tool.
 
 ## Allowed tools
 
-- `Read` — upstream artifacts, host project code, and the per-cycle
+- `Read` — upstream artifacts, host project code, the per-cycle
   sensor snapshot at `$(wm_snapshots_dir)/cycle-<N>.yaml` (written by
-  the coordinator's single per-cycle `verify-acceptance.sh` run).
+  the coordinator's single per-cycle `verify-acceptance.sh` run),
+  and per-sensor files at `.yoke/sensors/<id>.md`.
 - `Write`, `Edit` — `.yoke/contracts/<slug>.md` only (jointly with the
   Generator).
 - `Grep`, `Glob` — across the host project workspace.
@@ -173,3 +237,21 @@ the Skill tool.
   categories, stop conditions.
 - `.vibeflow/patterns/sensors.md` — structured-output requirement,
   inferential vs. computational, calibration metadata.
+
+## Rationale: shift-left only when actionable
+
+The `schedule_next` mechanism encodes a refinement, not a relaxation,
+of the framework's "shift feedback left" convention
+(`conventions.md:18-22`, `patterns/sensors.md:136`). Cheap sensors
+still run every cycle — the convention is upheld where feedback is
+**actionable**. Expensive sensors (e2e, heavyweight inferential
+judges) are gated **only** because pre-convergence failures are not
+actionable feedback: a failing Playwright run three cycles before
+the page mounts is incompleteness, not a bug; the Generator cannot
+act on it. Per-sensor `runs:` history makes this judgment auditable
+post-hoc — every authorization or deferral cites a concrete signal.
+
+Source PRD: `.vibeflow/prds/sensor-cost-tiering.md`. The merge-ready
+full sweep (Part 5 of that PRD) is the binding-semantics safety net:
+no run is declared done until every sensor — cheap and expensive —
+passes against the binding Acceptance Contract.

--- a/hooks/verify-acceptance.sh
+++ b/hooks/verify-acceptance.sh
@@ -9,6 +9,20 @@
 #                             either a "Scenario N" heading or an "FR-N"
 #                             functional-requirement bullet in the contract.
 #                             Default (no flag): full-suite run.
+#   --tier <cheap|expensive|all>
+#                             Filter executed sensors by cost tier (sensor-
+#                             cost-tiering Part 3). Tier is resolved per
+#                             sensor by reading `.yoke/sensors/<id>.md`
+#                             frontmatter (with class-based default —
+#                             computational → cheap, inferential →
+#                             expensive). Orthogonal to `--criterion`;
+#                             both filters combine by intersection. Only
+#                             meaningful for new-format contracts (`## Sensors
+#                             registry`); old-format contracts have no tier
+#                             metadata and reject `--tier cheap|expensive`.
+#                             Default (no flag) preserves current full-suite
+#                             behavior; `--tier all` is explicit and
+#                             equivalent.
 #   --concurrency <N>         Override sensor parallelism. <N> must be a
 #                             positive integer. Default resolves from
 #                             .yoke/config.yaml's runtime.sensor_concurrency,
@@ -23,25 +37,27 @@
 #                        (i.e., .yoke/acceptance-contracts/<slug>.md, where <slug>
 #                        comes from .yoke/.current).
 #
-# v0.3.0 supports only "shell command" sensor types (e.g. `npm test`,
-# `pytest`). Richer sensor types (structural fixtures, inferential
-# semantic judges with rubrics) ship in later sprints.
+# Sensor source-of-truth (sensor-cost-tiering Part 1+):
 #
-# Sensors are extracted from the "## Sensors > ### Computational" section
-# of the Acceptance Contract; the Validator (Sprint 3) writes them in this
-# shape:
+#   * **New format** — contract uses `## Sensors registry` block + `Sensors:
+#     [<id>]` references. Each sensor's command/class/tier lives in
+#     `.yoke/sensors/<id>.md`. Read by this hook when the contract has the
+#     registry section.
+#   * **Old format** — contract uses inline `## Sensors > ### Computational`
+#     block:
 #
-#   ## Sensors
+#       ## Sensors
 #
-#   ### Computational
-#   - linter: `npm run lint`
-#   - type-check: `mypy --strict`
-#   - structural: `pytest tests/contracts/`
-#   - unit: `pytest tests/unit/`
+#       ### Computational
+#       - linter: `npm run lint`
+#       - type-check: `mypy --strict`
 #
-# Each bullet's first backticked segment is the command Yoke will run.
+#     Read by this hook when the registry section is absent. No tier
+#     metadata; `--tier cheap|expensive` is rejected against old-format
+#     contracts with a structured violation pointing at `/yoke:ack-sensors
+#     --mode upsert <contract>`.
 #
-# Per-criterion mapping (used by --criterion):
+# Per-criterion mapping (used by --criterion, both formats):
 #   - Scenario blocks carry `Sensors: [name1, name2, ...]`.
 #   - FR bullets carry `Sensor: name.` (single sensor).
 #
@@ -59,7 +75,10 @@
 #   0 — verification ran (regardless of individual sensor outcomes)
 #   2 — usage error
 #   3 — Acceptance Contract not found
-#   4 — Acceptance Contract has no Sensors > Computational section
+#   4 — Acceptance Contract has no sensor section (neither old nor new
+#       format), or `--tier cheap|expensive` was passed against an
+#       old-format contract, or a referenced `.yoke/sensors/<id>.md` is
+#       missing or malformed under tier filtering.
 
 set -euo pipefail
 
@@ -72,6 +91,7 @@ source "${hook_dir}/../lib/working-memory/paths.sh"
 
 contract=""
 filter_criterion=""
+filter_tier="all"
 explicit_concurrency=""
 fragments_dir=""
 
@@ -83,6 +103,24 @@ while [ $# -gt 0 ]; do
         echo "Error: --criterion requires a value." >&2
         exit 2
       fi
+      shift 2
+      ;;
+    --tier)
+      filter_tier="${2:-}"
+      case "$filter_tier" in
+        cheap|expensive|all) ;;
+        "")
+          echo "Error: --tier requires a value." >&2
+          exit 2
+          ;;
+        *)
+          # Structured violation per sensors.md back-pressure.
+          echo "Error: unknown --tier value '${filter_tier}'." >&2
+          echo "  expected: cheap | expensive | all" >&2
+          echo "  correction: re-run with --tier cheap, --tier expensive, --tier all, or omit the flag." >&2
+          exit 2
+          ;;
+      esac
       shift 2
       ;;
     --concurrency)
@@ -199,7 +237,17 @@ if [ -f "$ack_sensors" ]; then
   fi
 fi
 
-# --- sensor block extraction ------------------------------------------------
+# --- contract format detection ----------------------------------------------
+# New format (sensor-cost-tiering Part 1+) puts sensor metadata in
+# `.yoke/sensors/<id>.md` files and references them from the contract via a
+# `## Sensors registry` block + `Sensors: [<id>]` lines in scenarios.
+# Old format keeps inline bullets under `## Sensors > ### Computational`.
+# Both formats are supported here; new format is preferred when present.
+contract_format=""
+if grep -qE '^## Sensors registry[[:space:]]*$' "$contract"; then
+  contract_format="new"
+fi
+
 sensors_block=$(awk '
   /^## Sensors[[:space:]]*$/ { in_sensors = 1; next }
   in_sensors && /^## / && !/^## Sensors/ { in_sensors = 0 }
@@ -208,8 +256,23 @@ sensors_block=$(awk '
   in_sensors && in_comp { print }
 ' "$contract")
 
-if [ -z "$sensors_block" ]; then
-  echo "Error: Acceptance Contract has no '## Sensors > ### Computational' section." >&2
+if [ -z "$contract_format" ] && [ -n "$sensors_block" ]; then
+  contract_format="old"
+fi
+
+if [ -z "$contract_format" ]; then
+  echo "Error: Acceptance Contract has no sensor section." >&2
+  echo "  expected: '## Sensors registry' (new format) or '## Sensors > ### Computational' (old format)" >&2
+  echo "  correction: add a registry block or run \`/yoke:ack-sensors --mode upsert ${contract}\`." >&2
+  exit 4
+fi
+
+# Tier filtering requires the new format (sensor files have tier metadata).
+if [ "$filter_tier" != "all" ] && [ "$contract_format" = "old" ]; then
+  echo "Error: --tier ${filter_tier} requires the new contract format with '## Sensors registry'." >&2
+  echo "  expected: contract with '## Sensors registry' and per-sensor files in .yoke/sensors/" >&2
+  echo "  actual: contract uses old-format inline '## Sensors > ### Computational' block" >&2
+  echo "  correction: migrate the contract to the new format and run \`/yoke:ack-sensors --mode upsert ${contract}\`." >&2
   exit 4
 fi
 
@@ -304,15 +367,92 @@ EOF
 export -f run_one_sensor
 
 # --- build sensor pair list (name|command) and apply --criterion filter ----
+# Parallel map: sensor_tier[<name>] = cheap|expensive|"" (empty for old
+# format / unresolved). Used by the --tier filter below.
+declare -A sensor_tier=()
+
 sensor_pairs=()
-while IFS= read -r line; do
-  [ -z "$line" ] && continue
-  if [[ "$line" =~ ^[[:space:]]*-[[:space:]]+([^:]+):[[:space:]]*\`([^\`]+)\` ]]; then
-    sensor_name=$(echo "${BASH_REMATCH[1]}" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')
-    command_str="${BASH_REMATCH[2]}"
-    sensor_pairs+=("${sensor_name}|${command_str}")
-  fi
-done <<< "$sensors_block"
+if [ "$contract_format" = "old" ]; then
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    if [[ "$line" =~ ^[[:space:]]*-[[:space:]]+([^:]+):[[:space:]]*\`([^\`]+)\` ]]; then
+      sensor_name=$(echo "${BASH_REMATCH[1]}" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')
+      command_str="${BASH_REMATCH[2]}"
+      sensor_pairs+=("${sensor_name}|${command_str}")
+    fi
+  done <<< "$sensors_block"
+else
+  # New format: extract registered ids from `## Sensors registry` YAML
+  # block and load command + class + tier from each `.yoke/sensors/<id>.md`.
+  registry_ids=$(awk '
+    /^## Sensors registry/ { in_section = 1; next }
+    in_section && /^## / { in_section = 0 }
+    in_section && /^```yaml[[:space:]]*$/ { in_block = 1; next }
+    in_section && /^```[[:space:]]*$/ && in_block { in_block = 0 }
+    in_block && /^[[:space:]]*-[[:space:]]+id:/ {
+      v = $0
+      sub(/^[[:space:]]*-[[:space:]]+id:[[:space:]]*/, "", v)
+      sub(/[[:space:]]+$/, "", v)
+      print v
+    }
+  ' "$contract")
+
+  while IFS= read -r id; do
+    [ -z "$id" ] && continue
+    sensor_file=".yoke/sensors/${id}.md"
+    if [ ! -f "$sensor_file" ]; then
+      # Skip silently when --tier is `all` (or omitted) and we are
+      # processing a registered sensor whose file is missing — readiness
+      # mode is the right place to surface that. But surface a hard
+      # failure when the user explicitly asked for tier filtering, since
+      # tier resolution requires the file.
+      if [ "$filter_tier" != "all" ]; then
+        echo "Error: sensor file missing for registered id '${id}'." >&2
+        echo "  expected: ${sensor_file}" >&2
+        echo "  actual: file not found" >&2
+        echo "  correction: run \`/yoke:ack-sensors --mode upsert ${contract}\`." >&2
+        exit 4
+      fi
+      continue
+    fi
+
+    fm=$(awk '
+      BEGIN { count = 0 }
+      /^---[[:space:]]*$/ { count++; if (count == 2) exit; next }
+      count == 1 { print }
+    ' "$sensor_file")
+
+    sensor_command=$(printf '%s\n' "$fm" \
+      | awk -F': ' '/^command:/ { sub(/^command:[[:space:]]*/, "", $0); print $0; exit }')
+    sensor_class=$(printf '%s\n' "$fm" \
+      | awk -F': ' '/^class:/ { sub(/^class:[[:space:]]*/, "", $0); print $0; exit }')
+    sensor_tier_val=$(printf '%s\n' "$fm" \
+      | awk -F': ' '/^tier:/ { sub(/^tier:[[:space:]]*/, "", $0); print $0; exit }')
+
+    if [ -z "$sensor_command" ] || [ -z "$sensor_class" ]; then
+      if [ "$filter_tier" != "all" ]; then
+        echo "Error: sensor file '${sensor_file}' is malformed." >&2
+        echo "  expected: command and class fields populated in frontmatter" >&2
+        echo "  actual: command='${sensor_command}', class='${sensor_class}'" >&2
+        echo "  correction: edit ${sensor_file} or re-run \`/yoke:ack-sensors --mode upsert ${contract}\`." >&2
+        exit 4
+      fi
+      continue
+    fi
+
+    # Class-based default when tier is absent.
+    if [ -z "$sensor_tier_val" ]; then
+      if [ "$sensor_class" = "inferential" ]; then
+        sensor_tier_val="expensive"
+      else
+        sensor_tier_val="cheap"
+      fi
+    fi
+
+    sensor_pairs+=("${id}|${sensor_command}")
+    sensor_tier["$id"]="$sensor_tier_val"
+  done <<< "$registry_ids"
+fi
 
 if [ -n "$filter_criterion" ]; then
   allowed=$(sensors_for_criterion "$filter_criterion" || true)
@@ -329,6 +469,23 @@ if [ -n "$filter_criterion" ]; then
       done
     done <<< "$allowed"
   fi
+  if [ "${#filtered_pairs[@]}" -gt 0 ]; then
+    sensor_pairs=("${filtered_pairs[@]}")
+  else
+    sensor_pairs=()
+  fi
+fi
+
+# --- apply --tier filter (new format only; old format errors out earlier) --
+if [ "$filter_tier" != "all" ] && [ "${#sensor_pairs[@]}" -gt 0 ]; then
+  filtered_pairs=()
+  for pair in "${sensor_pairs[@]}"; do
+    name="${pair%%|*}"
+    pair_tier="${sensor_tier[$name]:-}"
+    if [ "$pair_tier" = "$filter_tier" ]; then
+      filtered_pairs+=("$pair")
+    fi
+  done
   if [ "${#filtered_pairs[@]}" -gt 0 ]; then
     sensor_pairs=("${filtered_pairs[@]}")
   else

--- a/lib/sensors/ack-sensors.sh
+++ b/lib/sensors/ack-sensors.sh
@@ -6,26 +6,39 @@
 #       project. v0.4.0 surfaces only `CLAUDE.md`-derived sensors;
 #       additional discoverers (package.json, Makefile, pyproject.toml)
 #       ship in Part 4.
-#   readiness <acceptance-contract-path> — verify every sensor declared
-#       under `## Sensors > ### Computational` in the contract is
-#       reachable on $PATH.
+#   readiness <acceptance-contract-path> — verify every sensor referenced
+#       by the contract has a well-formed `.yoke/sensors/<id>.md` file
+#       (rewritten in sensor-cost-tiering Part 2; previously verified
+#       binary-on-PATH against the inline `## Sensors` block).
+#   upsert <acceptance-contract-path> — create / update
+#       `.yoke/sensors/<id>.md` files from the contract's
+#       `## Sensors registry` block and `Sensors: [...]` references.
+#       Field-level merge: only `applies_to` is refreshed from the
+#       contract; author edits to caveats, calibration notes, explicit
+#       `tier:` overrides, and `runs:` history are preserved verbatim.
+#       Idempotent — running it twice with no contract changes produces
+#       no file modifications.
+#
+#       Source PRD: .vibeflow/prds/sensor-cost-tiering.md
 #
 # Usage:
-#   bash lib/sensors/ack-sensors.sh [--mode catalog | readiness] [<contract>]
+#   bash lib/sensors/ack-sensors.sh [--mode catalog | readiness | upsert] [<contract>]
 #
 # Output:
 #   stdout — structured YAML (see SKILL.md for the schema per mode)
 #   stderr — diagnostics
 #
 # Exit codes:
-#   0 — catalog or readiness ran successfully
+#   0 — operation succeeded
 #   2 — usage error
-#   3 — Acceptance Contract not found (readiness only)
-#   4 — at least one sensor's binary is missing (readiness only)
+#   3 — Acceptance Contract not found (readiness / upsert only)
+#   4 — at least one sensor file is missing or malformed (readiness),
+#       or registry / reference validation failed (upsert)
 #
 # Determinism: catalog output is sorted by (category, source, command)
 # under LC_ALL=C, so repeated invocations on the same project are
-# byte-identical.
+# byte-identical. Upsert is idempotent — files are rewritten only when
+# their merged content differs from the on-disk content.
 
 set -euo pipefail
 
@@ -183,28 +196,230 @@ catalog_mode() {
 }
 
 # ---------------------------------------------------------------------------
-# Readiness mode
+# Shared helpers (readiness + upsert)
 # ---------------------------------------------------------------------------
-readiness_mode() {
+
+# Required-arg check used by both readiness and upsert.
+require_contract_arg() {
+  local mode_label="$1"
   if [ -z "$contract" ]; then
-    echo "Error: --mode readiness requires an <acceptance-contract-path> argument." >&2
+    echo "Error: --mode ${mode_label} requires an <acceptance-contract-path> argument." >&2
     exit 2
   fi
   if [ ! -f "$contract" ]; then
     echo "Error: Acceptance Contract not found at '${contract}'." >&2
     exit 3
   fi
+}
 
-  local sensors_block
-  sensors_block="$(awk '
-    /^## Sensors[[:space:]]*$/ { in_sensors = 1; next }
-    in_sensors && /^## / && !/^## Sensors/ { in_sensors = 0 }
-    in_sensors && /^### Computational[[:space:]]*$/ { in_comp = 1; next }
-    in_sensors && in_comp && /^### / { in_comp = 0 }
-    in_sensors && in_comp { print }
-  ' "$contract")"
+# Extract the YAML block under `## Sensors registry` (between ```yaml
+# and ```). One block per contract; emits empty string when absent.
+extract_registry_yaml() {
+  awk '
+    /^## Sensors registry/ { in_section = 1; next }
+    in_section && /^## / { in_section = 0 }
+    in_section && /^```yaml[[:space:]]*$/ { in_block = 1; next }
+    in_section && /^```[[:space:]]*$/ && in_block { in_block = 0 }
+    in_block { print }
+  ' "$contract"
+}
 
-  if [ -z "$sensors_block" ]; then
+# Parse the registry YAML block into TSV: <id>\t<command>\t<class>.
+# Emits one row per registered sensor; rows where any field is missing
+# are emitted with empty fields so the caller can validate.
+parse_registry_tsv() {
+  awk '
+    function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+    function flush() {
+      if (id != "") { printf "%s\t%s\t%s\n", id, cmd, cls }
+      id = ""; cmd = ""; cls = ""
+    }
+    BEGIN { id = ""; cmd = ""; cls = "" }
+    /^[[:space:]]*-[[:space:]]+id:/ {
+      flush()
+      v = $0; sub(/^[[:space:]]*-[[:space:]]+id:[[:space:]]*/, "", v); id = trim(v)
+      next
+    }
+    /^[[:space:]]+command:/ {
+      v = $0; sub(/^[[:space:]]+command:[[:space:]]*/, "", v); cmd = trim(v)
+      next
+    }
+    /^[[:space:]]+class:/ {
+      v = $0; sub(/^[[:space:]]+class:[[:space:]]*/, "", v); cls = trim(v)
+      next
+    }
+    END { flush() }
+  '
+}
+
+# Parse contract scenarios for (sensor-id, task-id) pairs.
+# Walks each `Task: <task-id>` line and the *next* `Sensors: [...]`
+# line that follows it. Emits TSV: <sensor-id>\t<task-id>.
+parse_scenario_sensor_pairs() {
+  awk '
+    function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+    /^Task:[[:space:]]*/ {
+      task = $0; sub(/^Task:[[:space:]]*/, "", task); task = trim(task)
+      next
+    }
+    /^Sensors:[[:space:]]*\[/ {
+      line = $0
+      sub(/^Sensors:[[:space:]]*\[/, "", line)
+      sub(/\][[:space:]]*$/, "", line)
+      n = split(line, ids, ",")
+      for (i = 1; i <= n; i++) {
+        s = trim(ids[i])
+        if (s != "" && task != "") {
+          printf "%s\t%s\n", s, task
+        }
+      }
+      next
+    }
+  ' "$contract"
+}
+
+# Parse a sensor file's frontmatter (between the first two `---`).
+# Echoes the frontmatter content. Returns non-zero if the file lacks
+# the delimiters.
+extract_sensor_frontmatter() {
+  local file="$1"
+  awk '
+    BEGIN { count = 0 }
+    /^---[[:space:]]*$/ { count++; if (count == 2) exit; next }
+    count == 1 { print }
+  ' "$file"
+}
+
+# Verify a sensor file is well-formed: frontmatter delimiters present,
+# required keys present (id, command, class, applies_to, runs).
+# Returns 0 on success, non-zero on any defect (and prints nothing —
+# the caller emits the structured violation).
+sensor_file_well_formed() {
+  local file="$1"
+  [ -f "$file" ] || return 1
+  local fm
+  fm="$(extract_sensor_frontmatter "$file")"
+  [ -n "$fm" ] || return 1
+  local key
+  for key in id command class applies_to runs; do
+    printf '%s\n' "$fm" | grep -qE "^${key}:" || return 1
+  done
+  return 0
+}
+
+# Render a sensor.md from the template, substituting frontmatter values.
+# Args: <id> <command> <class> <tier> <applies_to_csv>
+# Echoes the rendered file content to stdout.
+#
+# applies_to_csv is a comma-separated list of task ids (no spaces);
+# rendered as a YAML flow list `[id1, id2]` for compactness.
+render_sensor_file() {
+  local id="$1"
+  local cmd="$2"
+  local cls="$3"
+  local tier="$4"
+  local applies_csv="$5"
+  local template="${plugin_root}/templates/sensor.md"
+
+  if [ ! -f "$template" ]; then
+    echo "Error: sensor template not found at ${template}" >&2
+    exit 2
+  fi
+
+  local applies_yaml
+  if [ -z "$applies_csv" ]; then
+    applies_yaml="[]"
+  else
+    # Build `[id1, id2, ...]`.
+    applies_yaml="[$(printf '%s' "$applies_csv" | sed 's/,/, /g')]"
+  fi
+
+  # Substitute frontmatter placeholders. The template's HTML-comment
+  # guidance is preserved verbatim — it documents schema for the
+  # author who later opens the per-sensor file.
+  awk -v id="$id" -v cmd="$cmd" -v cls="$cls" -v tier="$tier" -v applies="$applies_yaml" '
+    /^id: <sensor-id>$/                  { print "id: " id; next }
+    /^command: <shell command>$/         { print "command: " cmd; next }
+    /^class: <computational \| inferential>$/ { print "class: " cls; next }
+    /^tier: <cheap \| expensive>$/       { print "tier: " tier; next }
+    /^applies_to: \[\]$/                 { print "applies_to: " applies; next }
+    /^# <human-readable sensor name>$/   { print "# " id; next }
+    { print }
+  ' "$template"
+}
+
+# Update only `applies_to` in an existing sensor file, preserving
+# everything else byte-for-byte. Atomic write via tmp + mv.
+update_applies_to() {
+  local file="$1"
+  local applies_csv="$2"
+
+  local applies_yaml
+  if [ -z "$applies_csv" ]; then
+    applies_yaml="[]"
+  else
+    applies_yaml="[$(printf '%s' "$applies_csv" | sed 's/,/, /g')]"
+  fi
+
+  local tmp="${file}.tmp.$$"
+  awk -v applies="$applies_yaml" '
+    BEGIN { fm = 0 }
+    /^---[[:space:]]*$/ {
+      fm++
+      print
+      next
+    }
+    fm == 1 && /^applies_to:/ {
+      print "applies_to: " applies
+      next
+    }
+    { print }
+  ' "$file" > "$tmp"
+  mv "$tmp" "$file"
+}
+
+# Emit a structured YAML failure block for a single sensor.
+# Args: <id> <expected> <actual> <reason> <correction>
+emit_failure() {
+  printf '  - sensor: "%s"\n' "$1"
+  printf '    expected: "%s"\n' "$2"
+  printf '    actual: "%s"\n' "$3"
+  printf '    reason: "%s"\n' "$4"
+  printf '    correction: "%s"\n' "$5"
+}
+
+# Compute applies_to CSV for a sensor id from scenario pairs.
+# Args: <sensor-id> <pairs-tsv>
+# Echoes a comma-separated, sorted-unique list of task ids, or empty.
+applies_to_for() {
+  local id="$1"
+  local pairs="$2"
+  printf '%s\n' "$pairs" \
+    | awk -v target="$id" -F'\t' '$1 == target { print $2 }' \
+    | LC_ALL=C sort -u \
+    | paste -sd, -
+}
+
+# ---------------------------------------------------------------------------
+# Readiness mode (rewritten in Part 2 — checks per-sensor files now)
+# ---------------------------------------------------------------------------
+readiness_mode() {
+  require_contract_arg "readiness"
+
+  # Collect the union of registered ids and id-references from scenarios.
+  local registry_tsv pairs_tsv
+  registry_tsv="$(extract_registry_yaml | parse_registry_tsv)"
+  pairs_tsv="$(parse_scenario_sensor_pairs)"
+
+  local referenced_ids
+  referenced_ids="$(
+    {
+      printf '%s\n' "$registry_tsv" | awk -F'\t' '$1 != "" { print $1 }'
+      printf '%s\n' "$pairs_tsv"    | awk -F'\t' '$1 != "" { print $1 }'
+    } | LC_ALL=C sort -u
+  )"
+
+  if [ -z "$referenced_ids" ]; then
     printf 'status: ready\nsensors: []\nfailures: []\n'
     return 0
   fi
@@ -212,38 +427,52 @@ readiness_mode() {
   local sensor_yaml=""
   local failure_yaml=""
   local any_missing=0
-  local sensor_name command_str leading_bin
+  local sensors_dir=".yoke/sensors"
+  local id file exists_str parses_str
 
-  while IFS= read -r line; do
-    [ -z "$line" ] && continue
-    if [[ "$line" =~ ^[[:space:]]*-[[:space:]]+([^:]+):[[:space:]]*\`([^\`]+)\` ]]; then
-      sensor_name="$(echo "${BASH_REMATCH[1]}" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
-      command_str="${BASH_REMATCH[2]}"
-    else
+  while IFS= read -r id; do
+    [ -z "$id" ] && continue
+    file="${sensors_dir}/${id}.md"
+
+    if [ ! -f "$file" ]; then
+      any_missing=1
+      exists_str="false"
+      parses_str="false"
+      sensor_yaml+="  - id: \"${id}\""$'\n'
+      sensor_yaml+="    path: \"${file}\""$'\n'
+      sensor_yaml+="    exists: ${exists_str}"$'\n'
+      sensor_yaml+="    parses: ${parses_str}"$'\n'
+      failure_yaml+="$(emit_failure \
+        "$id" \
+        "file at ${file}" \
+        "missing" \
+        "sensor file not found" \
+        "run \`/yoke:ack-sensors --mode upsert ${contract}\`")"$'\n'
       continue
     fi
 
-    leading_bin="$(echo "$command_str" | awk '{print $1}')"
-
-    if command -v "$leading_bin" >/dev/null 2>&1; then
-      sensor_yaml+="  - sensor: \"${sensor_name}\""$'\n'
-      sensor_yaml+="    command: \"${command_str}\""$'\n'
-      sensor_yaml+="    binary: \"${leading_bin}\""$'\n'
-      sensor_yaml+="    reachable: true"$'\n'
+    exists_str="true"
+    if sensor_file_well_formed "$file"; then
+      parses_str="true"
+      sensor_yaml+="  - id: \"${id}\""$'\n'
+      sensor_yaml+="    path: \"${file}\""$'\n'
+      sensor_yaml+="    exists: ${exists_str}"$'\n'
+      sensor_yaml+="    parses: ${parses_str}"$'\n'
     else
       any_missing=1
-      sensor_yaml+="  - sensor: \"${sensor_name}\""$'\n'
-      sensor_yaml+="    command: \"${command_str}\""$'\n'
-      sensor_yaml+="    binary: \"${leading_bin}\""$'\n'
-      sensor_yaml+="    reachable: false"$'\n'
-
-      failure_yaml+="  - sensor: \"${sensor_name}\""$'\n'
-      failure_yaml+="    command: \"${command_str}\""$'\n'
-      failure_yaml+="    expected: \"on-PATH\""$'\n'
-      failure_yaml+="    actual: \"missing\""$'\n'
-      failure_yaml+="    reason: \"binary not found: ${leading_bin}\""$'\n'
+      parses_str="false"
+      sensor_yaml+="  - id: \"${id}\""$'\n'
+      sensor_yaml+="    path: \"${file}\""$'\n'
+      sensor_yaml+="    exists: ${exists_str}"$'\n'
+      sensor_yaml+="    parses: ${parses_str}"$'\n'
+      failure_yaml+="$(emit_failure \
+        "$id" \
+        "well-formed frontmatter (id, command, class, applies_to, runs)" \
+        "missing keys or delimiters" \
+        "sensor file is malformed" \
+        "edit ${file} or re-run \`/yoke:ack-sensors --mode upsert ${contract}\`")"$'\n'
     fi
-  done <<< "$sensors_block"
+  done <<< "$referenced_ids"
 
   if [ "$any_missing" -eq 0 ]; then
     printf 'status: ready\nsensors:\n%sfailures: []\n' "$sensor_yaml"
@@ -254,11 +483,133 @@ readiness_mode() {
   exit 4
 }
 
+# ---------------------------------------------------------------------------
+# Upsert mode — create / update .yoke/sensors/<id>.md from contract
+# ---------------------------------------------------------------------------
+upsert_mode() {
+  require_contract_arg "upsert"
+
+  local registry_tsv pairs_tsv
+  registry_tsv="$(extract_registry_yaml | parse_registry_tsv)"
+  pairs_tsv="$(parse_scenario_sensor_pairs)"
+
+  # Validate: every scenario reference must have a registry entry.
+  local registered_ids referenced_ids unregistered
+  registered_ids="$(printf '%s\n' "$registry_tsv" | awk -F'\t' '$1 != "" { print $1 }' | LC_ALL=C sort -u)"
+  referenced_ids="$(printf '%s\n' "$pairs_tsv"    | awk -F'\t' '$1 != "" { print $1 }' | LC_ALL=C sort -u)"
+  unregistered="$(LC_ALL=C comm -23 \
+    <(printf '%s\n' "$referenced_ids") \
+    <(printf '%s\n' "$registered_ids"))"
+
+  if [ -n "$unregistered" ]; then
+    printf 'status: error\nupserted: []\nfailures:\n' >&2
+    while IFS= read -r id; do
+      [ -z "$id" ] && continue
+      emit_failure \
+        "$id" \
+        "registry entry under \`## Sensors registry\` in ${contract}" \
+        "missing" \
+        "sensor referenced in a scenario but not declared in the registry" \
+        "add \`- id: ${id}\n    command: <cmd>\n    class: <computational|inferential>\` under \`## Sensors registry\`" >&2
+    done <<< "$unregistered"
+    exit 4
+  fi
+
+  # Validate registry entries themselves.
+  local malformed=0
+  local malformed_yaml=""
+  while IFS=$'\t' read -r id cmd cls; do
+    [ -z "$id" ] && continue
+    if [ -z "$cmd" ] || [ -z "$cls" ]; then
+      malformed=1
+      malformed_yaml+="$(emit_failure \
+        "$id" \
+        "command and class fields populated" \
+        "command='${cmd}', class='${cls}'" \
+        "registry entry has empty command or class" \
+        "fill the missing field in \`## Sensors registry\` of ${contract}")"$'\n'
+      continue
+    fi
+    case "$cls" in
+      computational|inferential) ;;
+      *)
+        malformed=1
+        malformed_yaml+="$(emit_failure \
+          "$id" \
+          "class: computational | inferential" \
+          "class: ${cls}" \
+          "registry entry has unknown class" \
+          "set class to computational or inferential in \`## Sensors registry\` of ${contract}")"$'\n'
+        ;;
+    esac
+  done <<< "$registry_tsv"
+
+  if [ "$malformed" -ne 0 ]; then
+    printf 'status: error\nupserted: []\nfailures:\n%s' "$malformed_yaml" >&2
+    exit 4
+  fi
+
+  # Materialize / update each registered sensor.
+  mkdir -p ".yoke/sensors"
+  local upserted_yaml=""
+  local id cmd cls applies_csv default_tier file action
+
+  while IFS=$'\t' read -r id cmd cls; do
+    [ -z "$id" ] && continue
+    applies_csv="$(applies_to_for "$id" "$pairs_tsv")"
+    file=".yoke/sensors/${id}.md"
+
+    if [ "$cls" = "inferential" ]; then
+      default_tier="expensive"
+    else
+      default_tier="cheap"
+    fi
+
+    if [ ! -f "$file" ]; then
+      # Create from template.
+      local tmp="${file}.tmp.$$"
+      render_sensor_file "$id" "$cmd" "$cls" "$default_tier" "$applies_csv" > "$tmp"
+      mv "$tmp" "$file"
+      action="created"
+    else
+      # Field-level merge: only refresh applies_to. Preserve everything
+      # else (command, class, tier, body, runs) byte-for-byte. If the
+      # current applies_to already matches the desired one, do nothing
+      # (idempotency: don't bump mtime).
+      local current_applies desired_yaml
+      current_applies="$(extract_sensor_frontmatter "$file" \
+        | awk -F': ' '/^applies_to:/ { sub(/^applies_to:[[:space:]]*/, "", $0); print $0; exit }')"
+      if [ -z "$applies_csv" ]; then
+        desired_yaml="[]"
+      else
+        desired_yaml="[$(printf '%s' "$applies_csv" | sed 's/,/, /g')]"
+      fi
+      if [ "$current_applies" = "$desired_yaml" ]; then
+        action="unchanged"
+      else
+        update_applies_to "$file" "$applies_csv"
+        action="updated"
+      fi
+    fi
+
+    upserted_yaml+="  - id: \"${id}\""$'\n'
+    upserted_yaml+="    path: \"${file}\""$'\n'
+    upserted_yaml+="    action: ${action}"$'\n'
+  done <<< "$registry_tsv"
+
+  if [ -z "$upserted_yaml" ]; then
+    printf 'status: ok\nupserted: []\nfailures: []\n'
+  else
+    printf 'status: ok\nupserted:\n%sfailures: []\n' "$upserted_yaml"
+  fi
+}
+
 case "$mode" in
   catalog)   catalog_mode ;;
   readiness) readiness_mode ;;
+  upsert)    upsert_mode ;;
   *)
-    echo "Error: unknown --mode value '${mode}'. Use 'catalog' or 'readiness'." >&2
+    echo "Error: unknown --mode value '${mode}'. Use 'catalog', 'readiness', or 'upsert'." >&2
     exit 2
     ;;
 esac

--- a/lib/sensors/append-runs.sh
+++ b/lib/sensors/append-runs.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+# append-runs.sh — append a per-cycle run entry to each executed sensor's
+# `.yoke/sensors/<id>.md` `runs:` history, applying the N=20 retention cap.
+#
+# Source PRD: .vibeflow/prds/sensor-cost-tiering.md
+#
+# Usage:
+#   bash lib/sensors/append-runs.sh <snapshot-yaml> <cycle> <criterion>
+#
+# The snapshot is `verify-acceptance.sh`'s output (results: list of sensors).
+# For each sensor in the snapshot:
+#   * Locate `.yoke/sensors/<sensor>.md`. Skip silently if not registered
+#     (sensor exists in the snapshot but has no per-sensor file).
+#   * Append one entry to its `runs:` block:
+#       - {cycle: <N>, started_at: <iso8601>, status: <pass|fail|skip>,
+#          criterion: "<id>", duration_ms: <int>, evidence_snippet: "<...>"}
+#   * Cap the `runs:` list at the most recent CAP=20 entries; oldest roll
+#     off on overflow.
+#   * Atomic write via tmp + mv.
+#
+# Constraint: `runs:` MUST be the last frontmatter key in the per-sensor
+# file. Everything between `runs:` and the closing `---` is treated as
+# `runs:` content; any other frontmatter key after `runs:` will be
+# clobbered. The Part-1 template puts `runs:` last by design.
+#
+# Exit codes:
+#   0  success
+#   2  usage error
+#   3  snapshot not found
+
+set -euo pipefail
+
+CAP=20
+
+usage() {
+  echo "Usage: $0 <snapshot.yaml> <cycle> <criterion>" >&2
+  exit 2
+}
+
+[ $# -eq 3 ] || usage
+snapshot="$1"
+cycle="$2"
+criterion="$3"
+
+[ -f "$snapshot" ] || {
+  echo "Error: snapshot not found: $snapshot" >&2
+  exit 3
+}
+
+[[ "$cycle" =~ ^[0-9]+$ ]] || {
+  echo "Error: cycle must be a non-negative integer (got '${cycle}')." >&2
+  exit 2
+}
+
+started_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+sensors_dir=".yoke/sensors"
+
+# YAML escape for double-quoted scalars: backslashes and double quotes.
+yaml_esc() {
+  local s="$1"
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  s=${s//$'\n'/ }
+  s=${s//$'\r'/}
+  printf '%s' "$s"
+}
+
+# Append one new runs entry to <sensor-file>, applying CAP.
+# Args:
+#   $1 sensor-file
+#   $2 new-entry-line  (single line starting with "  - {")
+append_one() {
+  local file="$1"
+  local entry="$2"
+  local tmp="${file}.tmp.$$"
+
+  # Three-zone split:
+  #   prefix    — everything before the `runs:` line in frontmatter
+  #   in_runs   — collected `  - {...}` lines (old entries)
+  #   suffix    — closing `---` and the body, verbatim
+  #
+  # `runs:` is required to be the last frontmatter key. The closing
+  # `---` ends the in-runs zone.
+  local prefix="" old_entries="" suffix=""
+  local state="prefix"
+
+  # Use a heredoc-friendly loop. IFS empty preserves leading spaces.
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$state" in
+      prefix)
+        if [[ "$line" =~ ^runs: ]]; then
+          state="in_runs"
+        else
+          prefix+="$line"$'\n'
+        fi
+        ;;
+      in_runs)
+        if [[ "$line" =~ ^---[[:space:]]*$ ]]; then
+          suffix+="$line"$'\n'
+          state="suffix"
+        elif [[ "$line" =~ ^[[:space:]]*-[[:space:]]+\{ ]]; then
+          old_entries+="$line"$'\n'
+        fi
+        # ignore blank lines and stray content inside the runs zone
+        ;;
+      suffix)
+        suffix+="$line"$'\n'
+        ;;
+    esac
+  done < "$file"
+
+  if [ "$state" = "prefix" ]; then
+    # No `runs:` found — sensor file is malformed for this purpose.
+    echo "Error: ${file} has no \`runs:\` key in frontmatter." >&2
+    return 1
+  fi
+
+  # Combine old entries with the new one and cap at CAP.
+  local all_entries="${old_entries}${entry}"$'\n'
+  local capped
+  capped="$(printf '%s' "$all_entries" \
+              | grep -E '^[[:space:]]*-[[:space:]]+\{' \
+              | tail -n "$CAP")"
+
+  {
+    printf '%s' "$prefix"
+    printf 'runs:\n'
+    printf '%s\n' "$capped"
+    printf '%s' "$suffix"
+  } > "$tmp"
+
+  mv "$tmp" "$file"
+}
+
+# Iterate over per-sensor results in the snapshot. The snapshot YAML
+# format (from verify-acceptance.sh):
+#
+#   results:
+#     - sensor: "<name>"
+#       command: "<cmd>"
+#       status: pass|fail|skip
+#       exit_code: <int>
+#       output_excerpt: "<...>"
+#       reason: "<...>"
+#
+# Emit TSV lines: <name>\t<status>\t<output_excerpt>
+sensor_records="$(awk '
+  function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+  /^[[:space:]]*-[[:space:]]+sensor:/ {
+    if (cur_name != "") {
+      printf "%s\t%s\t%s\n", cur_name, cur_status, cur_excerpt
+    }
+    line = $0
+    sub(/^[[:space:]]*-[[:space:]]+sensor:[[:space:]]*"?/, "", line)
+    sub(/"?[[:space:]]*$/, "", line)
+    cur_name = trim(line)
+    cur_status = ""
+    cur_excerpt = ""
+    next
+  }
+  /^[[:space:]]+status:/ {
+    line = $0
+    sub(/^[[:space:]]+status:[[:space:]]*/, "", line)
+    cur_status = trim(line)
+    next
+  }
+  /^[[:space:]]+output_excerpt:/ {
+    line = $0
+    sub(/^[[:space:]]+output_excerpt:[[:space:]]*"?/, "", line)
+    sub(/"?[[:space:]]*$/, "", line)
+    cur_excerpt = trim(line)
+    next
+  }
+  END {
+    if (cur_name != "") {
+      printf "%s\t%s\t%s\n", cur_name, cur_status, cur_excerpt
+    }
+  }
+' "$snapshot")"
+
+if [ -z "$sensor_records" ]; then
+  # Empty snapshot — nothing to append.
+  exit 0
+fi
+
+# Truncate evidence to ~200 chars in YAML form, after escaping quotes.
+truncate_evidence() {
+  local s="$1"
+  s="$(yaml_esc "$s")"
+  # Use head -c on raw bytes; UTF-8 multi-byte chars may be split, but
+  # this is a snippet, not a verbatim store. Add an ellipsis when truncated.
+  local cut
+  cut="$(printf '%s' "$s" | head -c 200)"
+  if [ "${#s}" -gt "${#cut}" ]; then
+    cut="${cut}…"
+  fi
+  printf '%s' "$cut"
+}
+
+while IFS=$'\t' read -r name status excerpt; do
+  [ -z "$name" ] && continue
+  sensor_file="${sensors_dir}/${name}.md"
+  [ -f "$sensor_file" ] || continue
+
+  evidence="$(truncate_evidence "$excerpt")"
+  criterion_esc="$(yaml_esc "$criterion")"
+
+  if [ -n "$evidence" ]; then
+    entry="  - {cycle: ${cycle}, started_at: \"${started_at}\", status: ${status}, criterion: \"${criterion_esc}\", evidence_snippet: \"${evidence}\"}"
+  else
+    entry="  - {cycle: ${cycle}, started_at: \"${started_at}\", status: ${status}, criterion: \"${criterion_esc}\"}"
+  fi
+
+  append_one "$sensor_file" "$entry"
+done <<< "$sensor_records"

--- a/lib/working-memory/paths.sh
+++ b/lib/working-memory/paths.sh
@@ -14,6 +14,7 @@
 #   ├── tasks/<slug>-s<NN>-t<MM>.md                # versioned archive  (tech-spec-task-split per-task body)
 #   ├── acceptance-contracts/<slug>.md             # versioned archive
 #   ├── contracts/<slug>.md                        # versioned archive
+#   ├── sensors/<sensor-id>.md                     # versioned archive  (project-scoped; not slug-keyed)
 #   └── runtime/                                   # gitignored
 #       ├── progress.md
 #       ├── .cycle-counter
@@ -48,6 +49,7 @@ readonly _WM_PATHS_LOADED=1
 readonly WM_ROOT=".yoke"
 readonly WM_CURRENT_FILE="${WM_ROOT}/.current"
 readonly WM_RUNTIME_DIR="${WM_ROOT}/runtime"
+readonly WM_SENSORS_DIR="${WM_ROOT}/sensors"
 readonly WM_SLUG_REGEX='^[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9][a-z0-9-]{0,49}$'
 readonly WM_TASK_NUM_REGEX='^[1-9][0-9]{0,2}$'
 readonly WM_ARCHIVE_CATEGORIES=(prds specs tasks acceptance-contracts contracts)
@@ -179,6 +181,37 @@ wm_progress_path()         { printf '%s/progress.md' "$WM_RUNTIME_DIR"; }
 wm_cycle_counter_path()    { printf '%s/.cycle-counter' "$WM_RUNTIME_DIR"; }
 wm_snapshots_dir()         { printf '%s/.snapshots' "$WM_RUNTIME_DIR"; }
 wm_trigger4_packet_path()  { printf '%s/.trigger4-packet.yaml' "$WM_RUNTIME_DIR"; }
+
+# --- sensor paths -----------------------------------------------------------
+#
+# Sensors are first-class persistent artifacts in working memory, scoped to
+# the host project (not per-task). Each sensor lives in
+# .yoke/sensors/<sensor-id>.md with frontmatter + caveats body + runs history.
+#
+# Created/refreshed by `/yoke:ack-sensors --mode upsert`; read by
+# `hooks/verify-acceptance.sh` and `agents/validator.md`; appended to by
+# `skills/implement/SKILL.md` after each cycle.
+#
+# Source PRD: .vibeflow/prds/sensor-cost-tiering.md
+wm_sensors_dir() { printf '%s' "$WM_SENSORS_DIR"; }
+
+# wm_sensor_path "<sensor-id>"
+#   echoes .yoke/sensors/<sensor-id>.md for the given sensor id.
+#   Sensor ids must match [a-z0-9][a-z0-9_.-]{0,63} — kebab-or-snake plus
+#   '.' and trailing '-_.': lower-case alnum-start, ≤64 chars total.
+#   Returns non-zero with a `wm:`-prefixed message on invalid id.
+wm_sensor_path() {
+    local id="${1:-}"
+    if [[ -z "$id" ]]; then
+        echo "wm: wm_sensor_path requires <sensor-id>" >&2
+        return 1
+    fi
+    if [[ ! "$id" =~ ^[a-z0-9][a-z0-9_.-]{0,63}$ ]]; then
+        echo "wm: invalid sensor id: '$id' (expected [a-z0-9][a-z0-9_.-]{0,63})" >&2
+        return 1
+    fi
+    printf '%s/%s.md' "$WM_SENSORS_DIR" "$id"
+}
 
 # wm_judge_verdict_dir "<slug>" "<cycle>"
 #   echoes .yoke/runtime/.judge-verdicts/cycle-<N>/ for the given cycle.

--- a/skills/ack-sensors/SKILL.md
+++ b/skills/ack-sensors/SKILL.md
@@ -1,27 +1,39 @@
 ---
 name: ack-sensors
 description: >
-  Acknowledges every sensor available for the host project (catalog mode)
-  or verifies that every sensor declared in an Acceptance Contract is
-  reachable on the local machine (readiness mode). Deterministic node —
-  no agentic spawning. Output is structured YAML on stdout; diagnostics
-  go to stderr. Sorted output is byte-identical across consecutive
-  invocations on the same project.
-argument-hint: "[--mode catalog | readiness] [<acceptance-contract-path>]"
+  Acknowledges every sensor available for the host project (catalog mode),
+  verifies that every sensor referenced by an Acceptance Contract has a
+  well-formed `.yoke/sensors/<id>.md` file (readiness mode), or creates /
+  updates those sensor files from the contract's `## Sensors registry`
+  block (upsert mode). Deterministic node — no agentic spawning. Output
+  is structured YAML on stdout; diagnostics go to stderr. Sorted output
+  is byte-identical across consecutive invocations on the same project.
+argument-hint: "[--mode catalog | readiness | upsert] [<acceptance-contract-path>]"
 allowed-tools: Bash, Read
 ---
 
-# /yoke:ack-sensors — sensor catalog + readiness check
+# /yoke:ack-sensors — sensor catalog + readiness + upsert
 
-Single source of truth for sensor discovery (catalog) and pre-runtime
-reachability (readiness). Used by humans during Trigger 3 and by the
-Validator subagent at the start of every Phase-4 cycle.
+Single source of truth for sensor discovery (catalog), pre-runtime
+sensor-file readiness (readiness), and per-sensor file
+materialization from the contract (upsert). Used by humans during
+Trigger 3, by the Validator subagent at the start of every Phase-4
+cycle, and by the human between cycles when a contract gains a new
+sensor reference.
+
+Per-sensor files live in `.yoke/sensors/<id>.md` (working memory,
+project-scoped, **not** slug-keyed). They are the source of truth for
+the sensor's command, class, tier (with class-based default), criterion
+mapping, accumulated caveats, and run history. The Acceptance Contract
+references sensors **by id only**.
+
+Source PRD: `.vibeflow/prds/sensor-cost-tiering.md`.
 
 ## How to run this skill
 
 This skill is a thin wrapper: it forwards every argument to the
 deterministic helper `lib/sensors/ack-sensors.sh`, which contains all
-the parsing, sorting, and reachability logic.
+the parsing, sorting, materialization, and validation logic.
 
 Run the helper from the plugin root, forwarding `$@`:
 
@@ -43,7 +55,8 @@ The helper supports one optional `--mode` flag. Default is `catalog`.
 | Flag | What it does | When to call it |
 | :--- | :--- | :--- |
 | `--mode catalog` *(default)* | Enumerate every sensor that *could* run for the host project | Before drafting an Acceptance Contract; on demand from a human |
-| `--mode readiness <contract>` | Verify every sensor declared under `## Sensors > ### Computational` in the given Acceptance Contract is reachable | Before Phase 4; first thing the Validator does each cycle |
+| `--mode readiness <contract>` | Verify every sensor referenced by the contract has a well-formed `.yoke/sensors/<id>.md` file | Before Phase 4; first thing the Validator does each cycle |
+| `--mode upsert <contract>` | Create or update `.yoke/sensors/<id>.md` files from the contract's `## Sensors registry` block; field-level merge preserves author edits | After editing the contract; before the next `/yoke:implement` |
 
 ### Catalog output schema
 
@@ -67,59 +80,126 @@ CLAUDE.md, no parseable bullets, etc.).
 ```yaml
 status: ready | not-ready
 sensors:
-  - sensor: "<name from contract>"
-    command: "<command from contract>"
-    binary: "<leading token>"
-    reachable: true | false
+  - id: "<sensor-id>"
+    path: ".yoke/sensors/<id>.md"
+    exists: true | false
+    parses: true | false
 failures:
-  - sensor: "<name>"
-    command: "<command>"
-    expected: "on-PATH"
-    actual: "missing"
-    reason: "binary not found: <leading token>"
+  - sensor: "<id>"
+    expected: "<what should be there>"
+    actual: "<what is there>"
+    reason: "<short failure description>"
+    correction: "<suggested next command>"
 ```
 
 `failures:` is empty when `status: ready`. Every failure carries
-`sensor`, `command`, `expected`, `actual`, `reason` — the
+`sensor`, `expected`, `actual`, `reason`, `correction` — the
 structured-output rule from `patterns/sensors.md`.
+
+Readiness checks **file existence + frontmatter shape**: the per-sensor
+file must exist at `.yoke/sensors/<id>.md` and contain the required
+frontmatter keys (`id`, `command`, `class`, `applies_to`, `runs`).
+The standard correction when a check fails is to run
+`/yoke:ack-sensors --mode upsert <contract>` to materialize / refresh
+the missing file.
+
+### Upsert mode
+
+Reads the contract's `## Sensors registry` YAML block and the
+`Sensors: [...]` references in BDD scenarios, then for each registered
+sensor id:
+
+- **Create path** (file absent at `.yoke/sensors/<id>.md`): renders
+  the per-sensor file from `templates/sensor.md`, populating `id`,
+  `command`, `class`, `applies_to` (the union of task ids referencing
+  this sensor in the contract's scenarios), and `tier` (class-based
+  default — `computational` → `cheap`, `inferential` → `expensive`).
+  Body sections (`## Caveats`, `## Calibration notes`) are seeded
+  empty for the author to fill in.
+- **Update path** (file present): **field-level merge**. Only
+  `applies_to` is refreshed from the contract. Author edits to
+  `command`, `class`, explicit `tier:` overrides, the body (caveats,
+  calibration notes), and `runs:` history are preserved verbatim.
+  Atomic write via temp file + `mv`.
+- **Idempotent**: when the desired `applies_to` matches the on-disk
+  value, no file is rewritten — `mtime` stays put. Running upsert
+  twice on a stable contract is a no-op.
+
+Validation (fail-fast, structured violations on stderr):
+
+- Every `Sensors: [<id>]` reference in a scenario must appear in the
+  `## Sensors registry`. Unregistered references → exit 4.
+- Every registry entry must have non-empty `command` and `class`. The
+  `class` must be `computational` or `inferential`. Malformed entries
+  → exit 4.
+- Sensor `id` must satisfy `[a-z0-9][a-z0-9_.-]{0,63}` (path-traversal
+  guard); enforced by `wm_sensor_path` in `lib/working-memory/paths.sh`.
+
+#### Upsert output schema
+
+```yaml
+status: ok | error
+upserted:
+  - id: "<sensor-id>"
+    path: ".yoke/sensors/<id>.md"
+    action: created | updated | unchanged
+failures: []
+```
+
+The `failures:` block is non-empty (and emitted on stderr) only when
+the contract's registry / references fail validation; in that case
+`status: error` and exit code is `4`.
 
 ### Exit codes
 
 | Code | Meaning |
 | :---: | :--- |
-| `0` | Catalog or readiness ran successfully (regardless of whether sensors were found / reachable in catalog mode) |
-| `2` | Usage error (bad flag, missing required argument in readiness mode) |
-| `3` | Acceptance Contract file not found (readiness mode only) |
-| `4` | At least one declared sensor's binary is missing (readiness mode only) |
+| `0` | Operation succeeded (catalog, readiness ready, upsert ok) |
+| `2` | Usage error (bad flag, missing required argument) |
+| `3` | Acceptance Contract file not found (readiness / upsert only) |
+| `4` | Readiness: at least one sensor file is missing or malformed. Upsert: registry / reference validation failed. |
 
 Codes match the family used by `lib/sensors/discover-from-claude-md.sh`
 and `hooks/verify-acceptance.sh`.
 
 ## Pattern compliance
 
-- **`patterns/sensors.md`** — every readiness failure includes
-  `sensor`, `command`, `expected`, `actual`, `reason`. No prose-only
-  failures. Catalog output preserves the structured `category /
-  command / source` shape.
+- **`patterns/sensors.md`** — every readiness / upsert failure
+  includes `sensor`, `expected`, `actual`, `reason`, `correction`.
+  No prose-only failures. Catalog output preserves the structured
+  `category / command / source` shape. Per-sensor files are now the
+  source of truth for command + class + tier; the contract carries
+  only ids + a registry block.
 - **`patterns/plugin-structure.md`** — skill lives at
   `skills/ack-sensors/SKILL.md`; logic delegates to
   `lib/sensors/ack-sensors.sh`, which calls the existing
-  `lib/sensors/discover-from-claude-md.sh`.
+  `lib/sensors/discover-from-claude-md.sh` (catalog) and writes to
+  the project's `.yoke/sensors/` (upsert).
 - **Conventions: "Blueprints wrapping agentic nodes"** — this skill
   is purely deterministic. `allowed-tools: Bash, Read` only — no
-  `Task`, no `Agent`.
+  `Task`, no `Agent`. Upsert is idempotent, atomic, and
+  non-destructive (never deletes a sensor file even when the
+  contract drops a reference — orphan handling is drift-sense's
+  job).
 
 ## Anti-scope reminders
 
 - This skill **does not** parse `package.json`, `Makefile`, or
-  `pyproject.toml`. Those discoverers ship in Part 4.
+  `pyproject.toml` for catalog mode beyond what
+  `discover-from-*.sh` already does.
 - This skill **does not** spawn sensors. The Validator orchestrates
-  spawning (Part 2).
+  spawning.
 - This skill **does not** read or write canonical memory.
+- Upsert **does not** delete sensor files when the contract drops
+  a reference — leftovers are drift-sense's responsibility.
+- Upsert **does not** prompt interactively; missing registry
+  metadata fails fast with a structured violation telling the user
+  exactly which field to fill.
 
 ## Lineage
 
 The CLAUDE.md parser (`lib/sensors/discover-from-claude-md.sh`)
 predates this skill (introduced in Sprint 3). This skill exposes it
-under a single user-facing surface and adds the readiness-mode
-reachability check.
+under a single user-facing surface, adds the readiness-mode
+file-existence check, and adds the upsert mode that materializes
+per-sensor files from the contract registry.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -199,25 +199,64 @@ For each cycle (numbered starting at 1):
    hard-bound check, stop check) against partial state — every step
    below in this cycle assumes all `3 + N` Task calls have returned.
 
-2. **Sensor execution (deterministic, exactly once per cycle).** Run
-   `hooks/verify-acceptance.sh` to capture cycle N's post-Generator
-   sensor state. Pass `--criterion <id>` where `<id>` is the
-   Generator's last targeted criterion (read from the most recent
-   `citing_criterion:` entry in `wm_progress_path`); pass
+2. **Sensor execution — Phase A (cheap, deterministic).** Run
+   `hooks/verify-acceptance.sh --tier cheap` to capture cycle N's
+   post-Generator sensor state for the **cheap tier**. Pass
+   `--criterion <id>` where `<id>` is the Generator's last targeted
+   criterion (read from the most recent `citing_criterion:` entry in
+   `wm_progress_path`); pass
    `--fragments-dir "$(wm_runtime_dir)/.pending-fragments"`; redirect
    stdout to `$(wm_runtime_dir)/.pending-snapshot.yaml`. Sensors run
    in parallel via `xargs -P "$(yoke_sensor_concurrency)"` (default 4,
    configurable via `runtime.sensor_concurrency` in
    `.yoke/config.yaml`). When no `citing_criterion` is recorded
-   (cycle 0 / fallback) omit `--criterion` and run the full suite.
-   This is the sole sensor execution per cycle — `hooks/post-iteration.sh`
-   promotes the scratch artifacts to `cycle-<N>.yaml` /
-   `cycle-<N>.fragments/` and never re-runs sensors when the scratch
-   is present. The Validator (`agents/validator.md`) reads the
-   resulting snapshot — it never invokes `verify-acceptance.sh`
-   itself.
+   (cycle 0 / fallback) omit `--criterion` and run the full cheap
+   tier. The Validator (`agents/validator.md`) reads the resulting
+   snapshot — it never invokes `verify-acceptance.sh` itself.
 
-3. **Contradiction check (deterministic).** Run
+3. **Sensor execution — Phase B (expensive, gated, deterministic).**
+   Decide whether to run the expensive tier this cycle by reading
+   cycle `<N-1>`'s `schedule_next` from `wm_progress_path` (Validator-
+   owned scheduling, sensor-cost-tiering Part 4 — see
+   `agents/validator.md`'s "schedule_next emission" contract).
+   - **Cycle 1**: skip Phase B. No prior `schedule_next` exists; the
+     coordinator runs cheap-only by design. Phase B becomes possible
+     from cycle 2 onward via the Validator's authorization.
+   - **Cycle ≥ 2**: parse the `schedule_next:` block from the most
+     recent `## Cycle <N-1>` entry in `wm_progress_path`. If
+     `tiers:` includes `expensive`, OR `sensors:` lists explicit
+     ids whose `applies_to` covers the current criterion, run
+     `hooks/verify-acceptance.sh --tier expensive --criterion <id>
+     --fragments-dir "$(wm_runtime_dir)/.pending-fragments"` and
+     **append** its results to the same
+     `$(wm_runtime_dir)/.pending-snapshot.yaml` (the snapshot is the
+     union of Phase A + Phase B). Otherwise, skip Phase B.
+   This dual phase is the **two-phase per-cycle execution** of
+   sensor-cost-tiering — cheap sensors fire every cycle (shift-left
+   on actionable feedback), expensive sensors fire only when
+   pre-convergence failure would yield actionable signal. Source PRD:
+   `.vibeflow/prds/sensor-cost-tiering.md`. Both phases respect the
+   `runtime.inferential_sensor_concurrency` cap and the deferred-
+   sensors queue when tier filtering authorizes inferential judges.
+
+4. **Run-history append (deterministic).** After Phase A (always)
+   and Phase B (when authorized), invoke
+   `bash lib/sensors/append-runs.sh "$(wm_runtime_dir)/.pending-snapshot.yaml" <N> <criterion>`
+   to append one entry to each executed sensor's
+   `.yoke/sensors/<id>.md` `runs:` history. The helper applies a
+   retention cap of N=20 (oldest entries roll off on overflow) and
+   writes atomically. Sensors that did not run this cycle (Phase B
+   was skipped, or the sensor was filtered out by `--criterion`)
+   are not touched. Sensors with no per-sensor file (not registered
+   under `## Sensors registry`) are skipped silently — readiness
+   mode is the right place to surface that. The persisted history
+   is the durable record the Validator reads next cycle when
+   emitting `schedule_next`. `hooks/post-iteration.sh` then promotes
+   the scratch snapshot to `$(wm_snapshots_dir)/cycle-<N>.yaml` —
+   the snapshot file is the union of Phase A + Phase B and is never
+   re-run when the scratch is already present.
+
+5. **Contradiction check (deterministic).** Run
    `lib/ralph-loop/orchestrate.sh check-contradiction`. If a sprint
    contract textually contradicts an Acceptance Contract criterion
    (heuristic: contains a relax/remove/skip/disable/bypass/ignore
@@ -225,39 +264,44 @@ For each cycle (numbered starting at 1):
    and the loop pauses with a clear message: "Sprint contract
    contradicts Acceptance Contract. Pausing for human arbitration."
 
-4. **Persist (deterministic).** Run `hooks/post-iteration.sh`. The
+6. **Persist (deterministic).** Run `hooks/post-iteration.sh`. The
    hook:
    - Increments the cycle counter at `wm_cycle_counter_path`
      (`.yoke/runtime/.cycle-counter`).
    - Snapshots `verify-acceptance.sh` output to
      `$(wm_snapshots_dir)/cycle-<N>.yaml`.
 
-5. **Hard-bound check (deterministic).** Run
+7. **Hard-bound check (deterministic).** Run
    `hooks/check-hard-bounds.sh`. If cycles, timeout, or token
    budget is exceeded, the hook invokes
    `lib/ralph-loop/escalate.sh --reason hard-bound` and exits 10.
    The skill treats this as a pause-with-arbitration-packet.
 
-6. **Stop check (full-suite serial sweep).** Before declaring
-   MERGE-READY, run `hooks/verify-acceptance.sh --concurrency 1` (no
-   `--criterion`) one final time, redirecting stdout to a scratch
-   path under `$(wm_runtime_dir)/.merge-ready-snapshot.yaml`. Scoped
-   / parallel mode never decides convergence; the serial full-suite
-   sweep is the authoritative check. If every criterion in the
+8. **Stop check (full-suite serial sweep, all tiers).** Before
+   declaring MERGE-READY, run `hooks/verify-acceptance.sh
+   --concurrency 1 --tier all` (no `--criterion`) one final time,
+   redirecting stdout to a scratch path under
+   `$(wm_runtime_dir)/.merge-ready-snapshot.yaml`. The merge-ready
+   sweep ignores `schedule_next` entirely — every sensor (cheap
+   AND expensive) MUST pass before convergence, regardless of what
+   the Validator authorized in the last per-cycle decision. Scoped /
+   parallel / tier-filtered modes never decide convergence; the
+   serial full-suite sweep across all tiers is the authoritative
+   check (sensor-cost-tiering Part 5). If every criterion in the
    Acceptance Contract has `status: pass` in this snapshot AND no
    `divergence` verdict from the Validator, return MERGE-READY and
-   advance to the canonization handoff (step 3). Otherwise, continue
-   to step 7.
+   advance to the canonization handoff (§3). Otherwise, continue
+   to step 9.
 
-7. **Cycle status snapshot (deterministic, exactly once per cycle).**
+9. **Cycle status snapshot (deterministic, exactly once per cycle).**
    Run `bash lib/ralph-loop/status-snapshot.sh "$(wm_runtime_dir)"`
    and emit its stdout to the user verbatim. Fires once per cycle,
    only when the loop continues to the next cycle — i.e. **after**
-   step 4 (`post-iteration.sh`) and step 5 (`check-hard-bounds.sh`)
-   have completed and step 6 chose to continue. Do **not** emit on
+   step 6 (`post-iteration.sh`) and step 7 (`check-hard-bounds.sh`)
+   have completed and step 8 chose to continue. Do **not** emit on
    MERGE-READY (the canonize handoff prints the exit summary) or on
    escalation paths (`escalate.sh` already surfaces full state via
-   the Trigger-4 packet). Do **not** emit between step 1 and step 6
+   the Trigger-4 packet). Do **not** emit between step 1 and step 8
    — the per-notification / mid-cycle window must remain silent.
    On non-zero helper exit, log a single line `(status snapshot
    unavailable: <stderr summary>)` and continue — the snapshot is a
@@ -380,7 +424,7 @@ see `.vibeflow/patterns/human-triggers.md`.
   written to `.yoke/runtime/.judge-verdicts/cycle-<N-1>/` by judges
   spawned in the previous cycle's batch.
 - Do NOT emit user-visible status mid-cycle — between step 1
-  (per-cycle batch dispatch) and step 7 (cycle status snapshot) the
+  (per-cycle batch dispatch) and step 9 (cycle status snapshot) the
   skill must stay silent. The status block is a single, fixed-format
   emission per cycle; per-notification or per-step output dilutes
   back-pressure (`conventions.md`: "success is silent, failures are

--- a/templates/acceptance-contract.md
+++ b/templates/acceptance-contract.md
@@ -25,13 +25,17 @@ can decide pass/fail. The Then clauses are drafted from the task
 file's *Validation* section (full description) with the
 *Acceptance criterion* as the binary observable check.
 
+`Sensors:` entries reference sensor ids declared in the **Sensors
+registry** below; the per-sensor command, class and tier live in
+`.yoke/sensors/<sensor-id>.md`, never inline here.
+
 ### Scenario 1 — <name, mirroring task <slug>-s01-t01>
 Task: <slug>-s01-t01
 Given <context>
 When <action>
 Then <observable outcome — drafted from the task file's Validation section>
 Fixture: <path | none>
-Sensors: [<sensor name from the Sensors section below>]
+Sensors: [<sensor-id>]
 
 ### Scenario 2 — <name, mirroring task <slug>-s01-t02>
 Task: <slug>-s01-t02
@@ -39,14 +43,14 @@ Given <context>
 When <action>
 Then <observable outcome>
 Fixture: <path | none>
-Sensors: [<sensor name>]
+Sensors: [<sensor-id>]
 
 ## Functional requirements
 
 Measurable, observable. Each FR maps to a concrete sensor or fixture.
 
-- [ ] **FR-1** — <requirement>. Sensor: <name>.
-- [ ] **FR-2** — <requirement>. Sensor: <name>.
+- [ ] **FR-1** — <requirement>. Sensor: <sensor-id>.
+- [ ] **FR-2** — <requirement>. Sensor: <sensor-id>.
 
 ## Applicable policies
 
@@ -55,27 +59,47 @@ and canonical-memory path.
 
 - **<policy id>** (<source>) — canonical: `<path>`. Applies to: <scope>.
 
-## Sensors
+## Sensors registry
 
-### Computational
+> **Sensors are first-class persistent artifacts** in
+> `.yoke/sensors/<sensor-id>.md`, defined using `templates/sensor.md`.
+> This section lists every sensor id used by this contract, with the
+> metadata needed to materialize the per-sensor file.
+> `/yoke:ack-sensors --mode upsert` reads this registry and
+> creates / updates `.yoke/sensors/<sensor-id>.md` files from
+> `templates/sensor.md`; author edits to existing sensor files (caveats,
+> calibration notes, explicit `tier:` overrides, `runs:` history) are
+> preserved on update.
+>
+> **Tier default is class-based**: `computational` → `cheap`;
+> `inferential` → `expensive`. To override, set `tier:` explicitly in
+> `.yoke/sensors/<sensor-id>.md`. Heavy computational sensors (Playwright,
+> browser automation) MUST set `tier: expensive` — the class-based default
+> is a starting point, not a substitute for author judgment.
+>
+> Source PRD: `.vibeflow/prds/sensor-cost-tiering.md`.
 
-Discovered from the host project's `CLAUDE.md` (sections `## Testing`,
-`## Linting`, `## Build`) plus any added by the Validator during
-drafting. **Each bullet's first backticked segment is the runnable
-command.** `hooks/verify-acceptance.sh` parses these.
+```yaml
+sensors:
+  - id: <sensor-id>
+    command: <shell command>
+    class: <computational | inferential>
+  - id: <sensor-id-2>
+    command: <shell command>
+    class: <computational | inferential>
+```
 
-- linter: `<command>`
-- type-check: `<command>`
-- structural: `<command>`
-- unit: `<command>`
+### Inferential sensors — calibration metadata
 
-### Inferential
-
-Sprint-3 placeholder. Inferential sensors with full calibration metadata
-ship in Sprint 5+. When added, each entry carries:
+Inferential sensors carry calibration metadata in their per-sensor file's
+body (`## Calibration notes` section). When registering an inferential
+sensor here, ensure the per-sensor file also captures:
 
 - `prompt`: `<path>`
 - `model_calibrated_against`: `<model id>`
 - `calibrated_at`: `<iso8601>`
 - `known_false_positives`: `<rate or count>`
 - `known_false_negatives`: `<rate or count>`
+
+`hooks/verify-acceptance.sh` parses the registry and the per-sensor files
+to execute the contract.

--- a/templates/contracts.md
+++ b/templates/contracts.md
@@ -17,5 +17,18 @@
 - references:
     - "acceptance-contract.md#<criterion id>"
 - cycle: <N>
+- schedule_next:
+    sensors: ["<sensor-id>"]                    # optional; explicit ids
+    tiers: ["cheap"]                            # at least one of sensors / tiers must be non-empty
+    reason: "<must cite at least one signal source — sensor id, criterion id, Tech-Spec section, or runs: history entry>"
 
 <!-- Subsequent contracts append below this line, one `## Contract <id>` block per consensus reached. -->
+
+> Schema notes:
+>
+> - `schedule_next` mirrors the Validator's per-cycle decision verbatim
+>   (added in v0.8.0 by sensor-cost-tiering Part 4). When consensus is
+>   reached on a sub-objective, the scheduling decision active at that
+>   cycle is captured here for audit. At least one of `sensors:` or
+>   `tiers:` MUST be non-empty; `reason:` MUST cite at least one signal
+>   source. Source PRD: `.vibeflow/prds/sensor-cost-tiering.md`.

--- a/templates/progress.md
+++ b/templates/progress.md
@@ -40,6 +40,10 @@
         coupling_signal: "<tech-spec-overlap | sensor-evidence-overlap | both>"
     change_set:
       "<path>": "<one-line intent>"
+- schedule_next:
+    sensors: ["<sensor-id>"]                    # optional; explicit ids
+    tiers: ["cheap"]                            # at least one of sensors / tiers must be non-empty
+    reason: "<must cite at least one signal source — sensor id, criterion id, Tech-Spec section, or runs: history entry>"
 - notes: "<free text — keep tight>"
 
 <!-- Subsequent cycles append below this line, one `## Cycle <N>` block per cycle. -->
@@ -67,3 +71,12 @@
 > - `citing_criteria` is an alternative to `citing_criterion`, used when
 >   a cycle batches multiple coupled criteria. Exactly one of the two
 >   fields MUST be populated per cycle.
+> - `schedule_next` is the Validator's per-cycle scheduling decision —
+>   added in v0.8.0 by sensor-cost-tiering Part 4. Persisted verbatim
+>   from the Validator's verdict, it tells the coordinator which
+>   sensors / tiers to run in cycle `<N+1>` (lag-by-one). At least one
+>   of `sensors:` or `tiers:` MUST be non-empty; `reason:` MUST cite
+>   at least one signal source by name (sensor id, criterion id,
+>   Tech-Spec section, or `runs:` history entry from a per-sensor
+>   file). Empty / missing `schedule_next` is a malformed verdict.
+>   Source PRD: `.vibeflow/prds/sensor-cost-tiering.md`.

--- a/templates/sensor.md
+++ b/templates/sensor.md
@@ -1,0 +1,53 @@
+<!--
+templates/sensor.md — per-sensor working-memory artifact template.
+
+The host project's `.yoke/sensors/<sensor-id>.md` is the source of truth
+for a single sensor's command, class, tier, criterion mapping, accumulated
+caveats and run history. Acceptance Contracts reference sensors by `id`;
+they no longer inline the command, class or tier.
+
+Created and refreshed by `/yoke:ack-sensors --mode upsert` (Part 2 of
+sensor-cost-tiering — see .vibeflow/prds/sensor-cost-tiering.md). Read
+by `hooks/verify-acceptance.sh` (Part 3) and by `agents/validator.md`
+(Part 4). Run-history entries are appended by `skills/implement/SKILL.md`
+(Part 5).
+
+Tier default is class-based: computational sensors default to `cheap`;
+inferential sensors default to `expensive`. The author may override either
+way via the `tier:` field below — explicit value always wins.
+
+Heavy computational sensors (Playwright, browser automation) MUST set
+`tier: expensive` explicitly — the class-based default is a starting
+point, not a substitute for author judgment.
+-->
+---
+id: <sensor-id>
+command: <shell command>
+class: <computational | inferential>
+tier: <cheap | expensive>
+applies_to: []
+runs: []
+---
+
+# <human-readable sensor name>
+
+## Caveats
+
+<!--
+Known flakes, environmental dependencies, calibration notes, and other
+context the Validator should weigh when scheduling this sensor. Free-form
+markdown.
+
+Examples:
+- "Times out under 30 s when test DB is cold; warm with `make seed-test-db`."
+- "Skips on macOS — uses GNU-only `find -printf`."
+- "Calibrated against claude-opus-4-7 on 2026-04-22; recheck on model upgrade."
+-->
+
+## Calibration notes
+
+<!--
+Inferential sensors only. Document the prompt, rubric, and known
+false-positive / false-negative rates. Computational sensors leave this
+section empty.
+-->

--- a/tests/ack-sensors-catalog.test.sh
+++ b/tests/ack-sensors-catalog.test.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
 # tests/ack-sensors-catalog.test.sh
 #
-# Part 1 smoke test for /yoke:ack-sensors (catalog + readiness).
-# Validates DoD #1–#6 from .vibeflow/specs/ack-sensors-skill-part-1.md:
+# Smoke test for /yoke:ack-sensors — catalog mode + mode-dispatch
+# error paths + SKILL.md compliance.
+#
+# Originally validated DoD #1–#6 of
+# `.vibeflow/specs/ack-sensors-skill-part-1.md`. Readiness coverage
+# (DoD #2) was rewritten in `sensor-cost-tiering` Part 2 — the
+# binary-on-PATH check was replaced by per-sensor-file existence /
+# frontmatter checks against `.yoke/sensors/<id>.md`. Comprehensive
+# readiness + upsert assertions for the new behavior live in
+# `tests/sensor-tiering.test.sh`. This file now covers:
 #   - deterministic sorted catalog YAML
-#   - readiness exit codes (0 / 4) and structured failure block
 #   - empty-discovery envelope
+#   - mode-dispatch error paths (missing contract, missing arg,
+#     unknown --mode value)
 #   - SKILL.md frontmatter + structured-output compliance
 
 set -euo pipefail
@@ -93,72 +102,11 @@ echo "$out_empty" | grep -q '^sensors: \[\]' && pass "missing CLAUDE.md → sens
 echo "$out_empty" | grep -q '^notes:' && pass "missing CLAUDE.md → notes: present" || err "missing CLAUDE.md did not include notes:"
 
 # ---------------------------------------------------------------------------
-# DoD #2 — readiness mode: ready exit and not-ready exit + structured failure
+# Readiness coverage moved to tests/sensor-tiering.test.sh (sensor-cost-
+# tiering Part 2) — readiness now checks `.yoke/sensors/<id>.md`
+# files instead of binary-on-PATH. The mode-dispatch error paths
+# below still apply and are exercised here.
 # ---------------------------------------------------------------------------
-ready_contract="${tmp}/ready-contract.md"
-cat > "$ready_contract" <<'EOF'
-# Acceptance Contract — fixture (all sensors reachable)
-
-## Sensors
-
-### Computational
-- shell-true: `true`
-- shell-echo: `echo hello`
-
-EOF
-
-set +e
-out_ready="$(bash "$HELPER" --mode readiness "$ready_contract" 2>/dev/null)"
-ready_code=$?
-set -e
-
-if [ "$ready_code" -eq 0 ]; then
-  pass "readiness with reachable binaries → exit 0"
-else
-  err "readiness with reachable binaries → exit ${ready_code} (expected 0)"
-fi
-
-echo "$out_ready" | grep -q '^status: ready' && pass "ready contract → status: ready" || err "ready contract did not produce status: ready"
-echo "$out_ready" | grep -q 'reachable: true' && pass "ready contract → reachable: true" || err "ready contract did not report reachable: true"
-echo "$out_ready" | grep -q '^failures: \[\]' && pass "ready contract → failures: []" || err "ready contract did not produce empty failures"
-
-# Now a contract with one missing binary
-broken_contract="${tmp}/broken-contract.md"
-cat > "$broken_contract" <<'EOF'
-# Acceptance Contract — fixture (one missing binary)
-
-## Sensors
-
-### Computational
-- shell-true: `true`
-- bogus-bin: `definitely-not-a-real-binary-zzz arg1 arg2`
-
-EOF
-
-set +e
-out_broken="$(bash "$HELPER" --mode readiness "$broken_contract" 2>/dev/null)"
-broken_code=$?
-set -e
-
-if [ "$broken_code" -eq 4 ]; then
-  pass "readiness with missing binary → exit 4"
-else
-  err "readiness with missing binary → exit ${broken_code} (expected 4)"
-fi
-
-echo "$out_broken" | grep -q '^status: not-ready' && pass "broken contract → status: not-ready" || err "broken contract did not produce status: not-ready"
-
-# DoD #5 — structured failure block: every required field present
-for field in 'sensor:' 'command:' 'expected: "on-PATH"' 'actual: "missing"' 'reason: "binary not found:'; do
-  if echo "$out_broken" | grep -q "$field"; then
-    pass "failure block contains: ${field}"
-  else
-    err "failure block missing required field: ${field}"
-  fi
-done
-
-# Failure block must reference the bogus sensor by name
-echo "$out_broken" | grep -q 'sensor: "bogus-bin"' && pass "failure block names the missing sensor" || err "failure block missing sensor name"
 
 # Missing contract path → exit 3
 set +e

--- a/tests/sensor-tiering.test.sh
+++ b/tests/sensor-tiering.test.sh
@@ -1,0 +1,1155 @@
+#!/usr/bin/env bash
+# tests/sensor-tiering.test.sh
+#
+# Sensor-cost-tiering invariants (Part 1 of 5).
+#
+# Part 1 — foundation: per-sensor template + project-scoped
+# `wm_sensors_dir`/`wm_sensor_path` helpers + Acceptance Contract
+# references sensors by id (no inline command / tier / class).
+#
+# Subsequent parts extend this file:
+#   Part 2 — `/yoke:ack-sensors --mode upsert` (create / update / preserve)
+#   Part 3 — `hooks/verify-acceptance.sh --tier` filter
+#   Part 4 — Validator `schedule_next` emission + persistence
+#   Part 5 — Coordinator two-phase per-cycle + runs-history persistence
+#
+# Source PRD: .vibeflow/prds/sensor-cost-tiering.md
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib/harness.sh"
+
+cd "$PLUGIN_ROOT"
+
+# ---------------------------------------------------------------------
+# (a) templates/sensor.md exists and carries the required frontmatter
+# ---------------------------------------------------------------------
+SENSOR_TPL="$PLUGIN_ROOT/templates/sensor.md"
+
+if [ -f "$SENSOR_TPL" ]; then
+  pass "(a) templates/sensor.md exists"
+else
+  err "(a) templates/sensor.md is missing"
+fi
+
+# Extract the YAML frontmatter (between the first two `---` lines).
+sensor_fm=$(awk '
+  /^---$/ { count++; next }
+  count == 1 { print }
+' "$SENSOR_TPL" 2>/dev/null || true)
+
+required_fm_keys=(id command class tier applies_to runs)
+missing_fm=()
+for key in "${required_fm_keys[@]}"; do
+  if ! printf '%s\n' "$sensor_fm" | grep -qE "^${key}:"; then
+    missing_fm+=("$key")
+  fi
+done
+
+if [ "${#missing_fm[@]}" -eq 0 ]; then
+  pass "(a) templates/sensor.md frontmatter has all required keys: ${required_fm_keys[*]}"
+else
+  err "(a) templates/sensor.md frontmatter missing keys: ${missing_fm[*]}"
+fi
+
+# Required body sections.
+if grep -qE '^## Caveats$' "$SENSOR_TPL"; then
+  pass "(a) templates/sensor.md has '## Caveats' section"
+else
+  err "(a) templates/sensor.md is missing '## Caveats' section"
+fi
+
+if grep -qE '^## Calibration notes$' "$SENSOR_TPL"; then
+  pass "(a) templates/sensor.md has '## Calibration notes' section"
+else
+  err "(a) templates/sensor.md is missing '## Calibration notes' section"
+fi
+
+# ---------------------------------------------------------------------
+# (b) wm_sensors_dir + wm_sensor_path resolve correctly
+# ---------------------------------------------------------------------
+# shellcheck source=/dev/null
+source "$PLUGIN_ROOT/lib/working-memory/paths.sh"
+
+actual_sensors_dir="$(wm_sensors_dir)"
+if [ "$actual_sensors_dir" = ".yoke/sensors" ]; then
+  pass "(b) wm_sensors_dir returns .yoke/sensors"
+else
+  err "(b) wm_sensors_dir returned '$actual_sensors_dir' (expected .yoke/sensors)"
+fi
+
+actual_sensor_path="$(wm_sensor_path "playwright-checkout" 2>/dev/null || true)"
+if [ "$actual_sensor_path" = ".yoke/sensors/playwright-checkout.md" ]; then
+  pass "(b) wm_sensor_path 'playwright-checkout' returns .yoke/sensors/playwright-checkout.md"
+else
+  err "(b) wm_sensor_path returned '$actual_sensor_path' (expected .yoke/sensors/playwright-checkout.md)"
+fi
+
+# Invalid id: empty
+if wm_sensor_path "" 2>/dev/null; then
+  err "(b) wm_sensor_path accepted empty id (should fail)"
+else
+  pass "(b) wm_sensor_path rejects empty id"
+fi
+
+# Invalid id: starts with a hyphen
+if wm_sensor_path "-bad-start" 2>/dev/null; then
+  err "(b) wm_sensor_path accepted id starting with hyphen (should fail)"
+else
+  pass "(b) wm_sensor_path rejects id starting with hyphen"
+fi
+
+# Invalid id: contains a slash (path traversal guard)
+if wm_sensor_path "evil/../escape" 2>/dev/null; then
+  err "(b) wm_sensor_path accepted id with slash (should fail)"
+else
+  pass "(b) wm_sensor_path rejects id with slash"
+fi
+
+# Valid id with allowed punctuation: dots, dashes, underscores
+if path_with_dots="$(wm_sensor_path "playwright.checkout_v1-2" 2>/dev/null)"; then
+  if [ "$path_with_dots" = ".yoke/sensors/playwright.checkout_v1-2.md" ]; then
+    pass "(b) wm_sensor_path accepts dots, underscores, hyphens"
+  else
+    err "(b) wm_sensor_path returned '$path_with_dots' for valid id"
+  fi
+else
+  err "(b) wm_sensor_path rejected valid id 'playwright.checkout_v1-2'"
+fi
+
+# ---------------------------------------------------------------------
+# (c) templates/acceptance-contract.md references sensors by id only
+# ---------------------------------------------------------------------
+CONTRACT_TPL="$PLUGIN_ROOT/templates/acceptance-contract.md"
+
+if [ -f "$CONTRACT_TPL" ]; then
+  pass "(c) templates/acceptance-contract.md exists"
+else
+  err "(c) templates/acceptance-contract.md is missing"
+fi
+
+# Sensors registry section is present.
+if grep -qE '^## Sensors registry$' "$CONTRACT_TPL"; then
+  pass "(c) acceptance-contract.md has '## Sensors registry' section"
+else
+  err "(c) acceptance-contract.md is missing '## Sensors registry' section"
+fi
+
+# Registry block declares sensors with id + command + class.
+registry_block=$(awk '
+  /^```yaml$/ { in_block = 1; next }
+  /^```$/ && in_block { in_block = 0 }
+  in_block { print }
+' "$CONTRACT_TPL" 2>/dev/null || true)
+
+for key in "id:" "command:" "class:"; do
+  if printf '%s\n' "$registry_block" | grep -qF "$key"; then
+    pass "(c) Sensors registry block declares '$key'"
+  else
+    err "(c) Sensors registry block missing '$key'"
+  fi
+done
+
+# Anti-inline check: scenarios reference sensors by id only — no
+# `linter:` / `unit:` / `type-check:` / `structural:` per-bullet inline
+# command declarations like the pre-Part-1 layout used.
+inline_hits=$(grep -nE '^- (linter|type-check|structural|unit): `' "$CONTRACT_TPL" || true)
+if [ -z "$inline_hits" ]; then
+  pass "(c) acceptance-contract.md has no inline sensor-command bullets"
+else
+  err "(c) acceptance-contract.md still has inline sensor-command bullets:"
+  printf '%s\n' "$inline_hits" | sed 's/^/    /' >&2
+fi
+
+# Anti-inline check: scenarios should not declare `tier:` directly.
+contract_tier_hits=$(grep -nE '^[[:space:]]*tier:' "$CONTRACT_TPL" || true)
+if [ -z "$contract_tier_hits" ]; then
+  pass "(c) acceptance-contract.md has no inline 'tier:' declarations"
+else
+  err "(c) acceptance-contract.md has inline 'tier:' declarations:"
+  printf '%s\n' "$contract_tier_hits" | sed 's/^/    /' >&2
+fi
+
+# Scenario `Sensors:` entries should reference ids (placeholder is
+# `<sensor-id>` in the template, but the bracket form must remain).
+if grep -qE '^Sensors: \[' "$CONTRACT_TPL"; then
+  pass "(c) acceptance-contract.md retains 'Sensors: [<id>...]' shape"
+else
+  err "(c) acceptance-contract.md is missing 'Sensors: [<id>...]' references"
+fi
+
+# ---------------------------------------------------------------------
+# (d) /yoke:ack-sensors --mode upsert: create / update / idempotency
+# ---------------------------------------------------------------------
+ACK_SENSORS="$PLUGIN_ROOT/lib/sensors/ack-sensors.sh"
+
+# Build a fixture contract referencing 4 sensors:
+#   linter-ruff   (computational, default cheap)
+#   unit-pytest   (computational, default cheap)
+#   judge-voice   (inferential,   default expensive)
+#   playwright-e2e (computational; author will override to expensive)
+TMP_PART2=$(mktemp -d)
+trap 'rm -rf "$TMP_PART2"' EXIT
+
+cat > "$TMP_PART2/contract.md" <<'CONTRACT'
+# Acceptance Contract — fixture-task
+
+> Status: ratified
+
+## Use cases (BDD scenarios)
+
+### Scenario 1 — fixture s01-t01
+Task: 2026-04-27-fixture-s01-t01
+Given x
+When y
+Then z
+Fixture: none
+Sensors: [linter-ruff, unit-pytest]
+
+### Scenario 2 — fixture s01-t02
+Task: 2026-04-27-fixture-s01-t02
+Given x
+When y
+Then z
+Fixture: none
+Sensors: [unit-pytest, playwright-e2e]
+
+### Scenario 3 — fixture s01-t03
+Task: 2026-04-27-fixture-s01-t03
+Given x
+When y
+Then z
+Fixture: none
+Sensors: [judge-voice]
+
+## Sensors registry
+
+```yaml
+sensors:
+  - id: linter-ruff
+    command: ruff check
+    class: computational
+  - id: unit-pytest
+    command: pytest -q
+    class: computational
+  - id: judge-voice
+    command: bash agents/semantic-judge/voice.sh
+    class: inferential
+  - id: playwright-e2e
+    command: npx playwright test
+    class: computational
+```
+CONTRACT
+
+# Create case: empty .yoke/sensors/, run upsert, files materialize.
+(
+  cd "$TMP_PART2"
+  bash "$ACK_SENSORS" --mode upsert "$TMP_PART2/contract.md" >/dev/null
+)
+
+for id in linter-ruff unit-pytest judge-voice playwright-e2e; do
+  if [ -f "$TMP_PART2/.yoke/sensors/${id}.md" ]; then
+    pass "(d) upsert created .yoke/sensors/${id}.md"
+  else
+    err "(d) upsert did not create .yoke/sensors/${id}.md"
+  fi
+done
+
+# Class-based default tier check.
+ruff_tier=$(awk -F': ' '/^tier:/ { print $2; exit }' "$TMP_PART2/.yoke/sensors/linter-ruff.md" 2>/dev/null || true)
+if [ "$ruff_tier" = "cheap" ]; then
+  pass "(d) computational sensor 'linter-ruff' defaulted to tier: cheap"
+else
+  err "(d) computational sensor 'linter-ruff' expected tier=cheap, got '${ruff_tier}'"
+fi
+
+judge_tier=$(awk -F': ' '/^tier:/ { print $2; exit }' "$TMP_PART2/.yoke/sensors/judge-voice.md" 2>/dev/null || true)
+if [ "$judge_tier" = "expensive" ]; then
+  pass "(d) inferential sensor 'judge-voice' defaulted to tier: expensive"
+else
+  err "(d) inferential sensor 'judge-voice' expected tier=expensive, got '${judge_tier}'"
+fi
+
+# applies_to is populated from scenario references.
+ruff_applies=$(awk -F': ' '/^applies_to:/ { sub(/^applies_to:[[:space:]]*/, "", $0); print $0; exit }' "$TMP_PART2/.yoke/sensors/linter-ruff.md" 2>/dev/null || true)
+if [[ "$ruff_applies" == *"2026-04-27-fixture-s01-t01"* ]]; then
+  pass "(d) linter-ruff applies_to includes referencing task id"
+else
+  err "(d) linter-ruff applies_to is missing referencing task id (got '${ruff_applies}')"
+fi
+
+# Update case: hand-edit a sensor file (override tier, add caveat),
+# re-run upsert with a contract that gives it new applies_to,
+# and confirm: applies_to refreshed; tier override + caveat preserved.
+PW="$TMP_PART2/.yoke/sensors/playwright-e2e.md"
+# Override tier inside the frontmatter
+awk '
+  BEGIN { fm = 0 }
+  /^---[[:space:]]*$/ { fm++; print; next }
+  fm == 1 && /^tier:/ { print "tier: expensive"; next }
+  { print }
+' "$PW" > "$PW.new" && mv "$PW.new" "$PW"
+
+# Add author caveat in body.
+printf '\n## Caveats\n- Times out under 30 s when test DB is cold.\n' >> "$PW"
+
+# Modify the contract to expand playwright-e2e's applies_to.
+cat > "$TMP_PART2/contract.md" <<'CONTRACT'
+# Acceptance Contract — fixture-task
+
+> Status: ratified
+
+## Use cases (BDD scenarios)
+
+### Scenario 1 — fixture s01-t01
+Task: 2026-04-27-fixture-s01-t01
+Given x
+When y
+Then z
+Fixture: none
+Sensors: [linter-ruff, unit-pytest, playwright-e2e]
+
+### Scenario 2 — fixture s01-t02
+Task: 2026-04-27-fixture-s01-t02
+Given x
+When y
+Then z
+Fixture: none
+Sensors: [unit-pytest, playwright-e2e]
+
+### Scenario 3 — fixture s01-t03
+Task: 2026-04-27-fixture-s01-t03
+Given x
+When y
+Then z
+Fixture: none
+Sensors: [judge-voice]
+
+## Sensors registry
+
+```yaml
+sensors:
+  - id: linter-ruff
+    command: ruff check
+    class: computational
+  - id: unit-pytest
+    command: pytest -q
+    class: computational
+  - id: judge-voice
+    command: bash agents/semantic-judge/voice.sh
+    class: inferential
+  - id: playwright-e2e
+    command: npx playwright test
+    class: computational
+```
+CONTRACT
+
+(
+  cd "$TMP_PART2"
+  bash "$ACK_SENSORS" --mode upsert "$TMP_PART2/contract.md" >/dev/null
+)
+
+# applies_to expanded to include the new task id.
+pw_applies=$(awk -F': ' '/^applies_to:/ { sub(/^applies_to:[[:space:]]*/, "", $0); print $0; exit }' "$PW" 2>/dev/null || true)
+if [[ "$pw_applies" == *"2026-04-27-fixture-s01-t01"* && "$pw_applies" == *"2026-04-27-fixture-s01-t02"* ]]; then
+  pass "(d) upsert refreshed playwright-e2e applies_to with both task ids"
+else
+  err "(d) upsert did not expand playwright-e2e applies_to (got '${pw_applies}')"
+fi
+
+# Tier override preserved.
+pw_tier=$(awk -F': ' '/^tier:/ { print $2; exit }' "$PW" 2>/dev/null || true)
+if [ "$pw_tier" = "expensive" ]; then
+  pass "(d) upsert preserved author tier override (expensive) on update"
+else
+  err "(d) upsert clobbered author tier override (got '${pw_tier}')"
+fi
+
+# Author caveat preserved verbatim.
+if grep -qF "Times out under 30 s when test DB is cold." "$PW"; then
+  pass "(d) upsert preserved author caveat in body"
+else
+  err "(d) upsert clobbered author caveat"
+fi
+
+# Idempotency: running upsert again with no contract changes is a no-op.
+pre_hash=$(LC_ALL=C find "$TMP_PART2/.yoke/sensors" -type f -name '*.md' \
+            -exec sha256sum {} \; 2>/dev/null | LC_ALL=C sort)
+(
+  cd "$TMP_PART2"
+  bash "$ACK_SENSORS" --mode upsert "$TMP_PART2/contract.md" >/dev/null
+)
+post_hash=$(LC_ALL=C find "$TMP_PART2/.yoke/sensors" -type f -name '*.md' \
+             -exec sha256sum {} \; 2>/dev/null | LC_ALL=C sort)
+
+if [ "$pre_hash" = "$post_hash" ]; then
+  pass "(d) upsert is idempotent (no file changes on second run)"
+else
+  err "(d) upsert is NOT idempotent — file content changed on second run"
+fi
+
+# ---------------------------------------------------------------------
+# (e) /yoke:ack-sensors --mode readiness: file-existence + parse checks
+# ---------------------------------------------------------------------
+
+# Happy path: all sensor files exist + parse → status: ready, exit 0.
+if (cd "$TMP_PART2" && bash "$ACK_SENSORS" --mode readiness "$TMP_PART2/contract.md" >/dev/null 2>&1); then
+  pass "(e) readiness reports ready when all sensor files exist + parse"
+else
+  err "(e) readiness reported not-ready unexpectedly"
+fi
+
+# Failure path: delete one sensor file → readiness must fail with
+# structured violation pointing at the missing file.
+rm "$TMP_PART2/.yoke/sensors/judge-voice.md"
+ready_out="$(cd "$TMP_PART2" && bash "$ACK_SENSORS" --mode readiness "$TMP_PART2/contract.md" 2>&1 || true)"
+ready_exit=$(cd "$TMP_PART2" && bash "$ACK_SENSORS" --mode readiness "$TMP_PART2/contract.md" >/dev/null 2>&1; echo $?)
+
+if [ "$ready_exit" -eq 4 ]; then
+  pass "(e) readiness exits 4 when a sensor file is missing"
+else
+  err "(e) readiness expected exit 4 on missing sensor, got '${ready_exit}'"
+fi
+
+if printf '%s' "$ready_out" | grep -qE 'status:[[:space:]]+not-ready'; then
+  pass "(e) readiness reports status: not-ready on missing sensor"
+else
+  err "(e) readiness did not surface status: not-ready"
+fi
+
+if printf '%s' "$ready_out" | grep -qF 'sensor: "judge-voice"'; then
+  pass "(e) readiness names the missing sensor in failures"
+else
+  err "(e) readiness did not name the missing sensor"
+fi
+
+if printf '%s' "$ready_out" | grep -qF '/yoke:ack-sensors --mode upsert'; then
+  pass "(e) readiness suggests \`/yoke:ack-sensors --mode upsert\` correction"
+else
+  err "(e) readiness did not include the upsert correction instruction"
+fi
+
+# ---------------------------------------------------------------------
+# (f) Upsert validation: unregistered reference → structured failure
+# ---------------------------------------------------------------------
+TMP_PART2_BAD=$(mktemp -d)
+cat > "$TMP_PART2_BAD/contract.md" <<'CONTRACT'
+# Acceptance Contract — bad fixture
+
+> Status: ratified
+
+## Use cases (BDD scenarios)
+
+### Scenario 1 — bad
+Task: 2026-04-27-bad-s01-t01
+Given x
+When y
+Then z
+Fixture: none
+Sensors: [phantom-sensor]
+
+## Sensors registry
+
+```yaml
+sensors:
+  - id: linter-ruff
+    command: ruff check
+    class: computational
+```
+CONTRACT
+
+bad_out="$(cd "$TMP_PART2_BAD" && bash "$ACK_SENSORS" --mode upsert "$TMP_PART2_BAD/contract.md" 2>&1 || true)"
+bad_exit=$(cd "$TMP_PART2_BAD" && bash "$ACK_SENSORS" --mode upsert "$TMP_PART2_BAD/contract.md" >/dev/null 2>&1; echo $?)
+
+if [ "$bad_exit" -eq 4 ]; then
+  pass "(f) upsert exits 4 on unregistered sensor reference"
+else
+  err "(f) upsert expected exit 4 on unregistered reference, got '${bad_exit}'"
+fi
+
+if printf '%s' "$bad_out" | grep -qF 'phantom-sensor'; then
+  pass "(f) upsert names the unregistered sensor id in failures"
+else
+  err "(f) upsert did not name the unregistered sensor"
+fi
+
+rm -rf "$TMP_PART2_BAD"
+
+# ---------------------------------------------------------------------
+# (g) hooks/verify-acceptance.sh --tier filter (Part 3)
+# ---------------------------------------------------------------------
+HOOK="$PLUGIN_ROOT/hooks/verify-acceptance.sh"
+
+# Re-run upsert to restore judge-voice.md (deleted earlier in (e)).
+(
+  cd "$TMP_PART2"
+  bash "$ACK_SENSORS" --mode upsert "$TMP_PART2/contract.md" >/dev/null
+)
+
+# Sanity: all 4 sensor files exist before the hook tests.
+for id in linter-ruff unit-pytest judge-voice playwright-e2e; do
+  if [ -f "$TMP_PART2/.yoke/sensors/${id}.md" ]; then
+    pass "(g) sensor file present pre-hook: ${id}"
+  else
+    err "(g) missing sensor file pre-hook: ${id}"
+  fi
+done
+
+# Default behavior preserved: no --tier flag → all sensors invoked.
+hook_default="$(cd "$TMP_PART2" && bash "$HOOK" "$TMP_PART2/contract.md" 2>/dev/null || true)"
+default_count=$(printf '%s\n' "$hook_default" | grep -c '^  - sensor:' || true)
+if [ "$default_count" -eq 4 ]; then
+  pass "(g) default (no --tier) ran all 4 sensors"
+else
+  err "(g) default expected 4 sensor entries, got ${default_count}"
+fi
+
+# --tier all is explicit and equivalent to omitting the flag.
+hook_all="$(cd "$TMP_PART2" && bash "$HOOK" --tier all "$TMP_PART2/contract.md" 2>/dev/null || true)"
+all_count=$(printf '%s\n' "$hook_all" | grep -c '^  - sensor:' || true)
+if [ "$all_count" -eq 4 ]; then
+  pass "(g) --tier all ran all 4 sensors"
+else
+  err "(g) --tier all expected 4 sensor entries, got ${all_count}"
+fi
+
+# --tier cheap: 2 cheap sensors (linter-ruff, unit-pytest) — playwright-e2e
+# was overridden to expensive in (d); judge-voice is inferential→expensive.
+hook_cheap="$(cd "$TMP_PART2" && bash "$HOOK" --tier cheap "$TMP_PART2/contract.md" 2>/dev/null || true)"
+if printf '%s' "$hook_cheap" | grep -qF 'sensor: "linter-ruff"' \
+   && printf '%s' "$hook_cheap" | grep -qF 'sensor: "unit-pytest"'; then
+  pass "(g) --tier cheap includes computational-cheap sensors"
+else
+  err "(g) --tier cheap missing expected cheap sensors"
+fi
+
+if printf '%s' "$hook_cheap" | grep -qF 'sensor: "judge-voice"'; then
+  err "(g) --tier cheap leaked inferential sensor judge-voice"
+else
+  pass "(g) --tier cheap excludes inferential sensor judge-voice"
+fi
+
+if printf '%s' "$hook_cheap" | grep -qF 'sensor: "playwright-e2e"'; then
+  err "(g) --tier cheap leaked overridden-expensive sensor playwright-e2e"
+else
+  pass "(g) --tier cheap excludes overridden-expensive playwright-e2e"
+fi
+
+# --tier expensive: judge-voice (inferential default) + playwright-e2e
+# (overridden) — 2 expensive sensors.
+hook_expensive="$(cd "$TMP_PART2" && bash "$HOOK" --tier expensive "$TMP_PART2/contract.md" 2>/dev/null || true)"
+if printf '%s' "$hook_expensive" | grep -qF 'sensor: "judge-voice"' \
+   && printf '%s' "$hook_expensive" | grep -qF 'sensor: "playwright-e2e"'; then
+  pass "(g) --tier expensive includes inferential + overridden-expensive sensors"
+else
+  err "(g) --tier expensive missing expected expensive sensors"
+fi
+
+if printf '%s' "$hook_expensive" | grep -qF 'sensor: "linter-ruff"'; then
+  err "(g) --tier expensive leaked cheap sensor linter-ruff"
+else
+  pass "(g) --tier expensive excludes cheap sensor linter-ruff"
+fi
+
+# Intersection with --criterion: only sensors that apply to the criterion
+# AND match the tier. Scenario 1 maps to linter-ruff + unit-pytest +
+# playwright-e2e (after Part-2's contract update). With --tier cheap we
+# expect just linter-ruff + unit-pytest.
+hook_combined="$(cd "$TMP_PART2" && bash "$HOOK" --tier cheap --criterion 'Scenario 1' "$TMP_PART2/contract.md" 2>/dev/null || true)"
+combined_count=$(printf '%s\n' "$hook_combined" | grep -c '^  - sensor:' || true)
+if [ "$combined_count" -eq 2 ]; then
+  pass "(g) --tier cheap + --criterion Scenario 1 intersected to 2 sensors"
+else
+  err "(g) intersection expected 2 sensors, got ${combined_count}"
+fi
+if printf '%s' "$hook_combined" | grep -qF 'sensor: "linter-ruff"' \
+   && printf '%s' "$hook_combined" | grep -qF 'sensor: "unit-pytest"'; then
+  pass "(g) intersection includes the right sensors"
+else
+  err "(g) intersection missing expected sensors"
+fi
+
+# Empty intersection: --tier expensive + criterion that maps only cheap
+# sensors → 0 sensors, exit 0. We use Scenario 1 above which contains
+# playwright-e2e (expensive) — so try Scenario 1 with --tier expensive
+# and assert only playwright-e2e shows up. Then build a new criterion
+# that maps only cheap.
+
+# Use a synthetic case: --criterion 'Scenario 3' (judge-voice only) with
+# --tier cheap → 0 sensors.
+hook_empty="$(cd "$TMP_PART2" && bash "$HOOK" --tier cheap --criterion 'Scenario 3' "$TMP_PART2/contract.md" 2>/dev/null || true)"
+empty_count=$(printf '%s\n' "$hook_empty" | grep -c '^  - sensor:' || true)
+if [ "$empty_count" -eq 0 ]; then
+  pass "(g) empty intersection produces 0 sensor entries"
+else
+  err "(g) empty intersection expected 0 sensors, got ${empty_count}"
+fi
+empty_exit=$(cd "$TMP_PART2" && bash "$HOOK" --tier cheap --criterion 'Scenario 3' "$TMP_PART2/contract.md" >/dev/null 2>&1; echo $?)
+if [ "$empty_exit" -eq 0 ]; then
+  pass "(g) empty intersection exits 0"
+else
+  err "(g) empty intersection expected exit 0, got ${empty_exit}"
+fi
+
+# Unknown --tier value → exit 2 with structured violation.
+unknown_out="$(cd "$TMP_PART2" && bash "$HOOK" --tier slow "$TMP_PART2/contract.md" 2>&1 || true)"
+unknown_exit=$(cd "$TMP_PART2" && bash "$HOOK" --tier slow "$TMP_PART2/contract.md" >/dev/null 2>&1; echo $?)
+if [ "$unknown_exit" -eq 2 ]; then
+  pass "(g) unknown --tier value exits 2"
+else
+  err "(g) unknown --tier expected exit 2, got ${unknown_exit}"
+fi
+if printf '%s' "$unknown_out" | grep -qF 'expected: cheap | expensive | all'; then
+  pass "(g) unknown --tier emits structured violation with allowed set"
+else
+  err "(g) unknown --tier missing structured violation"
+fi
+
+# Missing sensor file under tier filter → exit 4 with structured violation.
+rm "$TMP_PART2/.yoke/sensors/judge-voice.md"
+miss_out="$(cd "$TMP_PART2" && bash "$HOOK" --tier expensive "$TMP_PART2/contract.md" 2>&1 || true)"
+miss_exit=$(cd "$TMP_PART2" && bash "$HOOK" --tier expensive "$TMP_PART2/contract.md" >/dev/null 2>&1; echo $?)
+if [ "$miss_exit" -eq 4 ]; then
+  pass "(g) missing sensor file under --tier exits 4"
+else
+  err "(g) missing sensor file expected exit 4, got ${miss_exit}"
+fi
+if printf '%s' "$miss_out" | grep -qF 'judge-voice'; then
+  pass "(g) missing-sensor violation names the offending id"
+else
+  err "(g) missing-sensor violation did not name offending id"
+fi
+if printf '%s' "$miss_out" | grep -qF '/yoke:ack-sensors --mode upsert'; then
+  pass "(g) missing-sensor violation suggests upsert correction"
+else
+  err "(g) missing-sensor violation missing correction instruction"
+fi
+
+# Restore judge-voice.md so subsequent hook calls (if any) work.
+(cd "$TMP_PART2" && bash "$ACK_SENSORS" --mode upsert "$TMP_PART2/contract.md" >/dev/null)
+
+# ---------------------------------------------------------------------
+# (h) old-format contracts: --tier cheap|expensive rejected; default OK
+# ---------------------------------------------------------------------
+TMP_OLD=$(mktemp -d)
+cat > "$TMP_OLD/contract.md" <<'CONTRACT'
+# Acceptance Contract — old format
+
+## Sensors
+
+### Computational
+- shell-true: `true`
+- shell-echo: `echo hello`
+CONTRACT
+
+# Default mode (no --tier) on old format still works.
+old_default_exit=$(cd "$TMP_OLD" && bash "$HOOK" "$TMP_OLD/contract.md" >/dev/null 2>&1; echo $?)
+if [ "$old_default_exit" -eq 0 ]; then
+  pass "(h) old-format contract works with no --tier (backward compat)"
+else
+  err "(h) old-format default expected exit 0, got ${old_default_exit}"
+fi
+
+# --tier cheap on old format → exit 4 with structured violation.
+old_tier_exit=$(cd "$TMP_OLD" && bash "$HOOK" --tier cheap "$TMP_OLD/contract.md" >/dev/null 2>&1; echo $?)
+old_tier_out="$(cd "$TMP_OLD" && bash "$HOOK" --tier cheap "$TMP_OLD/contract.md" 2>&1 || true)"
+if [ "$old_tier_exit" -eq 4 ]; then
+  pass "(h) old-format with --tier cheap exits 4"
+else
+  err "(h) old-format with --tier cheap expected exit 4, got ${old_tier_exit}"
+fi
+if printf '%s' "$old_tier_out" | grep -qF "Sensors registry"; then
+  pass "(h) old-format tier rejection names the new format"
+else
+  err "(h) old-format tier rejection missing new-format name"
+fi
+if printf '%s' "$old_tier_out" | grep -qF '/yoke:ack-sensors --mode upsert'; then
+  pass "(h) old-format tier rejection suggests upsert correction"
+else
+  err "(h) old-format tier rejection missing correction instruction"
+fi
+
+rm -rf "$TMP_OLD"
+
+# ---------------------------------------------------------------------
+# (i) Validator persona — sensor-file reads + schedule_next contract
+# ---------------------------------------------------------------------
+VALIDATOR_MD="$PLUGIN_ROOT/agents/validator.md"
+
+if [ -f "$VALIDATOR_MD" ]; then
+  pass "(i) agents/validator.md exists"
+else
+  err "(i) agents/validator.md is missing"
+fi
+
+# Validator reads .yoke/sensors/<id>.md (Memory scope or persona body).
+if grep -qE '\.yoke/sensors/<id>\.md' "$VALIDATOR_MD"; then
+  pass "(i) validator persona references .yoke/sensors/<id>.md as a read"
+else
+  err "(i) validator persona does not reference .yoke/sensors/<id>.md"
+fi
+
+# Validator emits schedule_next per cycle with the locked shape.
+if grep -qE '^- \*\*Emit `schedule_next:` per cycle' "$VALIDATOR_MD"; then
+  pass "(i) validator persona requires schedule_next per cycle"
+else
+  err "(i) validator persona does not require schedule_next emission"
+fi
+
+for key in 'sensors:' 'tiers:' 'reason:'; do
+  if grep -qF "$key" "$VALIDATOR_MD"; then
+    pass "(i) validator schedule_next schema declares ${key}"
+  else
+    err "(i) validator schedule_next schema missing ${key}"
+  fi
+done
+
+# Default rule is documented.
+if grep -qE 'Always include `tier:cheap`' "$VALIDATOR_MD"; then
+  pass "(i) validator persona documents 'cheap always' default rule"
+else
+  err "(i) validator persona missing 'cheap always' default rule"
+fi
+
+if grep -qE 'cheap-tier was green' "$VALIDATOR_MD"; then
+  pass "(i) validator persona documents 'expensive when cheap-green' rule"
+else
+  err "(i) validator persona missing 'expensive when cheap-green' rule"
+fi
+
+# Cycle-1 heuristic.
+if grep -qE 'Cycle-1 heuristic' "$VALIDATOR_MD"; then
+  pass "(i) validator persona documents cycle-1 type-aware heuristic"
+else
+  err "(i) validator persona missing cycle-1 heuristic"
+fi
+
+# Actionable-feedback rationale + PRD reference.
+if grep -qE 'shift-left only when actionable' "$VALIDATOR_MD"; then
+  pass "(i) validator persona cites actionable-feedback rationale"
+else
+  err "(i) validator persona missing actionable-feedback rationale"
+fi
+
+if grep -qF 'sensor-cost-tiering.md' "$VALIDATOR_MD"; then
+  pass "(i) validator persona references source PRD"
+else
+  err "(i) validator persona missing source PRD reference"
+fi
+
+# ---------------------------------------------------------------------
+# (j) Templates persist schedule_next (progress.md + contracts.md)
+# ---------------------------------------------------------------------
+PROGRESS_TPL="$PLUGIN_ROOT/templates/progress.md"
+CONTRACTS_TPL="$PLUGIN_ROOT/templates/contracts.md"
+
+for tpl_pair in "progress.md:$PROGRESS_TPL" "contracts.md:$CONTRACTS_TPL"; do
+  name="${tpl_pair%%:*}"
+  path="${tpl_pair#*:}"
+  if [ -f "$path" ]; then
+    pass "(j) templates/${name} exists"
+  else
+    err "(j) templates/${name} is missing"
+    continue
+  fi
+  if grep -qE '^[[:space:]]*-?[[:space:]]*schedule_next:' "$path"; then
+    pass "(j) templates/${name} declares schedule_next:"
+  else
+    err "(j) templates/${name} missing schedule_next:"
+  fi
+  for key in 'sensors:' 'tiers:' 'reason:'; do
+    if awk '
+      /^[[:space:]]*-?[[:space:]]*schedule_next:/ { in_block = 1; next }
+      in_block && /^[[:space:]]+-/ && !/^[[:space:]]+- timestamp:/ { in_block = 0 }
+      in_block && /^[[:space:]]+(sensors|tiers|reason):/ { print }
+    ' "$path" | grep -qF "$key"; then
+      pass "(j) templates/${name} schedule_next block declares ${key}"
+    else
+      err "(j) templates/${name} schedule_next block missing ${key}"
+    fi
+  done
+done
+
+# ---------------------------------------------------------------------
+# (k) Fixture verdict — schema check (valid + invalid cases)
+# ---------------------------------------------------------------------
+# A small inline schema validator for Validator verdicts. Required
+# keys: schedule_next.sensors OR schedule_next.tiers (at least one
+# non-empty) and schedule_next.reason (non-empty string).
+
+verdict_well_formed() {
+  local blob="$1"
+
+  # Must have a schedule_next: section.
+  printf '%s\n' "$blob" | grep -qE '^[[:space:]]*schedule_next:' || return 1
+
+  # Extract the schedule_next sub-block (lines indented under it).
+  local body
+  body=$(printf '%s\n' "$blob" | awk '
+    /^[[:space:]]*schedule_next:/ { in_block = 1; indent = -1; next }
+    in_block {
+      if (indent == -1) {
+        match($0, /^[[:space:]]*/)
+        indent = RLENGTH
+        if (indent == 0) { exit }
+      }
+      # End block when indent shrinks below the block''s own indent
+      match($0, /^[[:space:]]*/)
+      if (RLENGTH < indent && $0 !~ /^[[:space:]]*$/) { exit }
+      print
+    }
+  ')
+
+  # `reason:` must be present and non-empty.
+  local reason
+  reason=$(printf '%s\n' "$body" | awk -F': ' '
+    /^[[:space:]]+reason:/ {
+      sub(/^[[:space:]]+reason:[[:space:]]*"?/, "", $0)
+      sub(/"?[[:space:]]*$/, "", $0)
+      print
+      exit
+    }
+  ')
+  [ -n "$reason" ] || return 1
+
+  # Either sensors: or tiers: must be present and non-empty (i.e. not [] or empty).
+  local sensors tiers
+  sensors=$(printf '%s\n' "$body" | awk '
+    /^[[:space:]]+sensors:/ {
+      sub(/^[[:space:]]+sensors:[[:space:]]*/, "", $0)
+      print
+      exit
+    }
+  ')
+  tiers=$(printf '%s\n' "$body" | awk '
+    /^[[:space:]]+tiers:/ {
+      sub(/^[[:space:]]+tiers:[[:space:]]*/, "", $0)
+      print
+      exit
+    }
+  ')
+
+  local has_sensors=0
+  local has_tiers=0
+  if [ -n "$sensors" ] && [ "$sensors" != "[]" ]; then has_sensors=1; fi
+  if [ -n "$tiers" ] && [ "$tiers" != "[]" ]; then has_tiers=1; fi
+
+  if [ "$has_sensors" -eq 0 ] && [ "$has_tiers" -eq 0 ]; then
+    return 1
+  fi
+
+  return 0
+}
+
+# Good fixture: tiers + reason citing a sensor id.
+good_verdict='schedule_next:
+  sensors: []
+  tiers: ["cheap", "expensive"]
+  reason: "linter-ruff and unit-pytest were green this cycle for Scenario 1; diff touches src/checkout.tsx covered by playwright-checkout"'
+
+if verdict_well_formed "$good_verdict"; then
+  pass "(k) well-formed verdict (tiers + reason) passes schema check"
+else
+  err "(k) well-formed verdict failed schema check"
+fi
+
+# Good fixture using sensors only (no tiers shorthand).
+good_sensors_verdict='schedule_next:
+  sensors: ["playwright-checkout"]
+  tiers: []
+  reason: "Scenario 1 diff touches checkout flow"'
+
+if verdict_well_formed "$good_sensors_verdict"; then
+  pass "(k) well-formed verdict (sensors only) passes schema check"
+else
+  err "(k) well-formed verdict (sensors only) failed schema check"
+fi
+
+# Bad fixture: missing schedule_next entirely.
+no_block_verdict='criterion: "Scenario 1"
+status: pass
+sensor: linter-ruff'
+if verdict_well_formed "$no_block_verdict"; then
+  err "(k) verdict missing schedule_next was accepted (should fail)"
+else
+  pass "(k) verdict missing schedule_next is rejected"
+fi
+
+# Bad fixture: empty reason.
+empty_reason_verdict='schedule_next:
+  sensors: []
+  tiers: ["cheap"]
+  reason: ""'
+if verdict_well_formed "$empty_reason_verdict"; then
+  err "(k) verdict with empty reason was accepted (should fail)"
+else
+  pass "(k) verdict with empty reason is rejected"
+fi
+
+# Bad fixture: both sensors and tiers empty.
+both_empty_verdict='schedule_next:
+  sensors: []
+  tiers: []
+  reason: "doing nothing"'
+if verdict_well_formed "$both_empty_verdict"; then
+  err "(k) verdict with both sensors and tiers empty was accepted (should fail)"
+else
+  pass "(k) verdict with both sensors and tiers empty is rejected"
+fi
+
+# ---------------------------------------------------------------------
+# (l) Pattern doc + SKILL.md describe Part 5 behavior
+# ---------------------------------------------------------------------
+SENSORS_PATTERN="$PLUGIN_ROOT/.vibeflow/patterns/sensors.md"
+IMPLEMENT_SKILL="$PLUGIN_ROOT/skills/implement/SKILL.md"
+
+if grep -qE '^### Cost tiering, sensor persistence, and Validator-owned scheduling' "$SENSORS_PATTERN"; then
+  pass "(l) sensors.md adds 'Cost tiering, ... Validator-owned scheduling' subsection"
+else
+  err "(l) sensors.md missing Part-5 subsection"
+fi
+
+if grep -qE 'shift-left only when actionable|shift-feedback-left|actionable feedback' "$SENSORS_PATTERN"; then
+  pass "(l) sensors.md cites actionable-feedback rationale"
+else
+  err "(l) sensors.md missing actionable-feedback rationale"
+fi
+
+if grep -qF 'Running all expensive sensors every cycle when the feature is mid-assembly' "$SENSORS_PATTERN"; then
+  pass "(l) sensors.md adds anti-pattern entry for unconditional expensive runs"
+else
+  err "(l) sensors.md missing the new anti-pattern entry"
+fi
+
+if grep -qE 'Phase A.*cheap.*deterministic' "$IMPLEMENT_SKILL"; then
+  pass "(l) implement SKILL.md describes Phase A (cheap)"
+else
+  err "(l) implement SKILL.md missing Phase A description"
+fi
+
+if grep -qE 'Phase B.*expensive.*gated' "$IMPLEMENT_SKILL"; then
+  pass "(l) implement SKILL.md describes Phase B (expensive, gated)"
+else
+  err "(l) implement SKILL.md missing Phase B description"
+fi
+
+if grep -qF 'lib/sensors/append-runs.sh' "$IMPLEMENT_SKILL"; then
+  pass "(l) implement SKILL.md invokes lib/sensors/append-runs.sh"
+else
+  err "(l) implement SKILL.md missing append-runs invocation"
+fi
+
+if grep -qE '\-\-tier all' "$IMPLEMENT_SKILL"; then
+  pass "(l) implement SKILL.md merge-ready uses --tier all"
+else
+  err "(l) implement SKILL.md merge-ready missing --tier all"
+fi
+
+if grep -qE 'Cycle 1.*Phase A only|skip Phase B' "$IMPLEMENT_SKILL"; then
+  pass "(l) implement SKILL.md documents cycle-1 Phase-A-only default"
+else
+  err "(l) implement SKILL.md missing cycle-1 default"
+fi
+
+# ---------------------------------------------------------------------
+# (m) lib/sensors/append-runs.sh — unit tests
+# ---------------------------------------------------------------------
+APPEND_RUNS="$PLUGIN_ROOT/lib/sensors/append-runs.sh"
+
+if [ -x "$APPEND_RUNS" ]; then
+  pass "(m) lib/sensors/append-runs.sh exists and is executable"
+else
+  err "(m) lib/sensors/append-runs.sh missing or not executable"
+fi
+
+# Build a fresh fixture in its own tmpdir.
+TMP_PART5=$(mktemp -d)
+mkdir -p "$TMP_PART5/.yoke/sensors"
+cat > "$TMP_PART5/.yoke/sensors/foo.md" <<'EOF'
+---
+id: foo
+command: echo foo
+class: computational
+tier: cheap
+applies_to: [some-task]
+runs: []
+---
+
+# foo
+
+## Caveats
+
+## Calibration notes
+EOF
+
+# Append a single result via a hand-crafted snapshot.
+cat > "$TMP_PART5/snapshot.yaml" <<'EOF'
+results:
+  - sensor: "foo"
+    command: "echo foo"
+    status: pass
+    exit_code: 0
+    output_excerpt: "foo passed cleanly"
+    reason: ""
+EOF
+
+(cd "$TMP_PART5" && bash "$APPEND_RUNS" "$TMP_PART5/snapshot.yaml" 1 "Scenario 1" >/dev/null)
+
+# Verify the runs: block now has one entry.
+if grep -qE '^[[:space:]]*-[[:space:]]+\{cycle: 1' "$TMP_PART5/.yoke/sensors/foo.md"; then
+  pass "(m) append-runs added cycle 1 entry to foo.md"
+else
+  err "(m) append-runs did not add a runs entry to foo.md"
+fi
+
+# Status field captured.
+if grep -qE 'status: pass' "$TMP_PART5/.yoke/sensors/foo.md"; then
+  pass "(m) append-runs entry includes status"
+else
+  err "(m) append-runs entry missing status"
+fi
+
+# Criterion captured.
+if grep -qE 'criterion: "Scenario 1"' "$TMP_PART5/.yoke/sensors/foo.md"; then
+  pass "(m) append-runs entry includes criterion"
+else
+  err "(m) append-runs entry missing criterion"
+fi
+
+# Body preserved.
+if grep -qE '^# foo$' "$TMP_PART5/.yoke/sensors/foo.md"; then
+  pass "(m) append-runs preserved body heading"
+else
+  err "(m) append-runs clobbered body"
+fi
+
+# Append 25 more cycles to test retention cap (N=20, cycles 2..26).
+for n in $(seq 2 26); do
+  cat > "$TMP_PART5/snapshot.yaml" <<EOF
+results:
+  - sensor: "foo"
+    command: "echo foo"
+    status: pass
+    exit_code: 0
+    output_excerpt: ""
+    reason: ""
+EOF
+  (cd "$TMP_PART5" && bash "$APPEND_RUNS" "$TMP_PART5/snapshot.yaml" "$n" "Scenario 1" >/dev/null)
+done
+
+# After 26 appends total, only the last 20 should remain (cycles 7..26).
+remaining_count=$(grep -cE '^[[:space:]]*-[[:space:]]+\{cycle: ' "$TMP_PART5/.yoke/sensors/foo.md")
+if [ "$remaining_count" -eq 20 ]; then
+  pass "(m) retention cap enforced (exactly 20 entries after 26 appends)"
+else
+  err "(m) retention cap broken — expected 20 entries, got ${remaining_count}"
+fi
+
+# Cycle 1 (first) should have rolled off.
+if grep -qE '^[[:space:]]*-[[:space:]]+\{cycle: 1,' "$TMP_PART5/.yoke/sensors/foo.md"; then
+  err "(m) oldest entry (cycle 1) was not rolled off"
+else
+  pass "(m) oldest entry (cycle 1) rolled off as expected"
+fi
+
+# Cycle 26 (newest) should be present.
+if grep -qE '^[[:space:]]*-[[:space:]]+\{cycle: 26,' "$TMP_PART5/.yoke/sensors/foo.md"; then
+  pass "(m) newest entry (cycle 26) present after retention"
+else
+  err "(m) newest entry missing"
+fi
+
+# Cycle 7 (boundary - oldest kept) should be present.
+if grep -qE '^[[:space:]]*-[[:space:]]+\{cycle: 7,' "$TMP_PART5/.yoke/sensors/foo.md"; then
+  pass "(m) boundary entry (cycle 7) present after retention"
+else
+  err "(m) boundary entry (cycle 7) missing"
+fi
+
+# Sensors without a file are skipped silently.
+cat > "$TMP_PART5/snapshot.yaml" <<'EOF'
+results:
+  - sensor: "foo"
+    command: "echo foo"
+    status: pass
+    exit_code: 0
+    output_excerpt: ""
+    reason: ""
+  - sensor: "phantom"
+    command: "echo phantom"
+    status: pass
+    exit_code: 0
+    output_excerpt: ""
+    reason: ""
+EOF
+
+set +e
+(cd "$TMP_PART5" && bash "$APPEND_RUNS" "$TMP_PART5/snapshot.yaml" 99 "Scenario 1" >/dev/null 2>&1)
+phantom_exit=$?
+set -e
+
+if [ "$phantom_exit" -eq 0 ]; then
+  pass "(m) append-runs skips unregistered sensors silently (exit 0)"
+else
+  err "(m) append-runs failed when skipping unregistered sensor (exit ${phantom_exit})"
+fi
+
+if [ ! -f "$TMP_PART5/.yoke/sensors/phantom.md" ]; then
+  pass "(m) append-runs did NOT create file for unregistered sensor"
+else
+  err "(m) append-runs created file for unregistered sensor (should skip)"
+fi
+
+# ---------------------------------------------------------------------
+# (n) End-to-end smoke: cheap-only cycle leaves expensive untouched
+# ---------------------------------------------------------------------
+# Reuse the Part 2/3 fixture (TMP_PART2 has 4 sensors with files).
+
+# Pre-state: capture mtimes of all sensor files.
+declare -A pre_mtime
+for id in linter-ruff unit-pytest judge-voice playwright-e2e; do
+  pre_mtime["$id"]="$(stat -f '%m' "$TMP_PART2/.yoke/sensors/${id}.md" 2>/dev/null \
+                   || stat -c '%Y' "$TMP_PART2/.yoke/sensors/${id}.md" 2>/dev/null)"
+done
+
+# Simulate Phase A only (cheap tier filter from Part 3).
+phase_a_snapshot="$TMP_PART2/phase-a.yaml"
+(cd "$TMP_PART2" && bash "$HOOK" --tier cheap --criterion 'Scenario 1' "$TMP_PART2/contract.md" 2>/dev/null > "$phase_a_snapshot")
+
+# Append runs from the Phase A snapshot.
+(cd "$TMP_PART2" && bash "$APPEND_RUNS" "$phase_a_snapshot" 1 "Scenario 1" >/dev/null)
+
+# Cheap sensors (linter-ruff, unit-pytest) should have a runs entry.
+for id in linter-ruff unit-pytest; do
+  if grep -qE '^[[:space:]]*-[[:space:]]+\{cycle: 1' "$TMP_PART2/.yoke/sensors/${id}.md"; then
+    pass "(n) end-to-end: cheap-tier sensor ${id} has cycle-1 runs entry"
+  else
+    err "(n) end-to-end: cheap-tier sensor ${id} missing cycle-1 entry"
+  fi
+done
+
+# Expensive sensors (judge-voice, playwright-e2e) should NOT have a
+# cycle-1 entry — they didn't run in Phase A. Their `runs:` from prior
+# Part 4 fixture state may already have entries; we only assert no
+# *cycle-1* entry was added for them.
+for id in judge-voice playwright-e2e; do
+  if grep -qE '^[[:space:]]*-[[:space:]]+\{cycle: 1' "$TMP_PART2/.yoke/sensors/${id}.md"; then
+    err "(n) end-to-end: expensive sensor ${id} got cycle-1 entry (Phase B was skipped)"
+  else
+    pass "(n) end-to-end: expensive sensor ${id} unchanged when Phase B skipped"
+  fi
+done
+
+# Now simulate Phase B authorization: run --tier expensive and append.
+phase_b_snapshot="$TMP_PART2/phase-b.yaml"
+(cd "$TMP_PART2" && bash "$HOOK" --tier expensive --criterion 'Scenario 1' "$TMP_PART2/contract.md" 2>/dev/null > "$phase_b_snapshot")
+(cd "$TMP_PART2" && bash "$APPEND_RUNS" "$phase_b_snapshot" 2 "Scenario 1" >/dev/null)
+
+# Now playwright-e2e (Scenario 1 expensive sensor) should have cycle-2.
+if grep -qE '^[[:space:]]*-[[:space:]]+\{cycle: 2' "$TMP_PART2/.yoke/sensors/playwright-e2e.md"; then
+  pass "(n) end-to-end: expensive sensor playwright-e2e has cycle-2 entry after Phase B"
+else
+  err "(n) end-to-end: playwright-e2e missing cycle-2 entry post-Phase-B"
+fi
+
+rm -rf "$TMP_PART5"
+
+harness::summary


### PR DESCRIPTION
## Summary

- Sensors are now **first-class persistent artifacts** at `.yoke/sensors/<id>.md` (working memory, project-scoped). Each carries `command`, `class`, `tier`, `applies_to`, accumulated caveats, and a `runs:` history capped at the last 20 cycles.
- `hooks/verify-acceptance.sh` gains `--tier cheap | expensive | all` (orthogonal to `--criterion`); the Validator emits `schedule_next:` per cycle naming what the coordinator should run next; `/yoke:implement` runs Phase A (cheap, sync) and Phase B (expensive, gated by previous cycle's `schedule_next`); merge-ready always runs the full suite across all tiers.
- Resolves the autonomous-run insight that motivated the work: cheap sensors give in-loop feedback every cycle, expensive ones (Playwright e2e, heavy inferential judges) only when their feedback would be actionable. The `shift-feedback-left` convention is **refined** (cheap stays per-cycle), not rescinded — explicit reconciliation captured in `.vibeflow/patterns/sensors.md`.

## Architecture (5 parts, all PASS audits)

| Part | Layer | Files |
|------|-------|-------|
| 1 | `.yoke/sensors/` layout + sensor template + `wm_sensors_dir`/`wm_sensor_path` + contract-by-ID | 4 |
| 2 | `/yoke:ack-sensors --mode upsert` (idempotent, field-level merge) + readiness rewrite | 4 |
| 3 | `verify-acceptance.sh --tier` filter + dual-format contract support | 2 |
| 4 | Validator reads sensor files + emits `schedule_next:` (lag-by-one) | 4 |
| 5 | Coordinator two-phase execution + `runs:` history persistence (N=20 cap) + pattern doc | 4 |

PRD, specs, and audit reports live under `.vibeflow/`.

## Behavior change for users

- **Acceptance Contract format**: sensors declared by ID via a `## Sensors registry` block; per-sensor `command`/`class`/`tier` no longer inline. Old-format contracts (`## Sensors > ### Computational`) continue to work — `--tier cheap|expensive` rejects them with a corrective instruction pointing at `/yoke:ack-sensors --mode upsert`.
- **Class-based default tier**: computational → `cheap`, inferential → `expensive`. Heavy computational sensors (Playwright, browser automation) must set `tier: expensive` explicitly.
- **Validator**: now emits `schedule_next: { sensors, tiers, reason }` in every cycle verdict; the `reason` field cites at least one signal source. Default rule: include `cheap` always; include `expensive` when prior cheap was green for the targeted criterion, OR diff touches expensive `applies_to` surface, OR merge-ready check.
- **`/yoke:implement`**: cycle protocol gains explicit Phase A (cheap, sync via hook) + Phase B (expensive, gated by cycle N-1's `schedule_next`). Cycle 1 default: Phase A only. Merge-ready convergence: full suite (`--tier all`), regardless of `schedule_next`. Per-cycle results append to sensor files' `runs:` lists.

## Test plan

- [x] `bash tests/sensor-tiering.test.sh` — 110/110 assertions PASS (foundation through end-to-end smoke)
- [x] `bash tests/run-all.sh` — 19/19 test files PASS, zero regressions in pre-existing tests (`acceptance-and-sensors`, `perf-quickwins-part-*`, `ack-sensors-*`, `working-memory`, etc.)
- [x] Idempotency: upsert run twice with no contract changes produces no file modifications (sha256 hash equality)
- [x] Retention cap: 26 appends → exactly 20 entries remain, oldest rolled off, boundary entry preserved
- [x] Backward compat: old-format contracts continue to verify under default flow; `--tier cheap|expensive` against old format rejects with structured violation pointing at upsert

## Out of scope (flagged for follow-up)

- Migration tooling that auto-runs upsert during host-project bootstrap
- Drift-sense pass for orphan sensor files (contract dropped the reference but file remains)
- Quantitative flake auto-quarantine built on `runs:` history
- Canonization of stable sensor knowledge (`/yoke:preserve` of long-lived caveats and calibration notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)