### PR TITLE
fix(implement): retire --tier and schedule_next refs on coordinator + cycle templates

### DIFF
--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -270,45 +270,49 @@ sprint boundaries):
    hard-bound check, stop check) against partial state — every step
    below in this cycle assumes all `3 + N` Task calls have returned.
 
-2. **Sensor execution — Phase A (cheap, deterministic).** Run
-   `hooks/verify-acceptance.sh --tier cheap` to capture cycle N's
-   post-Generator sensor state for the **cheap tier**. Pass
-   `--criterion <id>` where `<id>` is the Generator's last targeted
-   criterion (read from the most recent `citing_criterion:` entry in
-   `wm_progress_path`); pass
-   `--fragments-dir "$(wm_runtime_dir)/.pending-fragments"`; redirect
-   stdout to `$(wm_runtime_dir)/.pending-snapshot.yaml`. Sensors run
-   in parallel via `xargs -P "$(yoke_sensor_concurrency)"` (default 4,
-   configurable via `runtime.sensor_concurrency` in
+2. **Sensor execution — Phase A (cheap-equivalent, deterministic).** Run
+   `hooks/verify-acceptance.sh --max-time-cost 60` to capture cycle N's
+   post-Generator sensor state at the cheap-equivalent cost ceiling
+   (sensors whose `time_cost:` exceeds the cap are skipped; the cap is
+   the coordinator's filter, replacing the retired `--tier cheap`
+   flag per the sensor-harness-realignment refactor — see
+   `agents/validator.md` "Cost-based filtering of which sensors run
+   this cycle is the coordinator's job"). Pass `--criterion <id>`
+   where `<id>` is the Generator's last targeted criterion (read from
+   the most recent `citing_criterion:` entry in `wm_progress_path`);
+   pass `--fragments-dir "$(wm_runtime_dir)/.pending-fragments"`;
+   redirect stdout to `$(wm_runtime_dir)/.pending-snapshot.yaml`.
+   Sensors run in parallel via `xargs -P "$(yoke_sensor_concurrency)"`
+   (default 4, configurable via `runtime.sensor_concurrency` in
    `.yoke/config.yaml`). When no `citing_criterion` is recorded
-   (cycle 0 / fallback) omit `--criterion` and run the full cheap
-   tier. The Validator (`agents/validator.md`) reads the resulting
-   snapshot — it never invokes `verify-acceptance.sh` itself.
+   (cycle 0 / fallback) omit `--criterion` and run every sensor that
+   fits the cap. The Validator (`agents/validator.md`) reads the
+   resulting snapshot — it never invokes `verify-acceptance.sh` itself.
 
-3. **Sensor execution — Phase B (expensive, gated, deterministic).**
-   Decide whether to run the expensive tier this cycle by reading
-   cycle `<N-1>`'s `schedule_next` from `wm_progress_path` (Validator-
-   owned scheduling, sensor-cost-tiering Part 4 — see
-   `agents/validator.md`'s "schedule_next emission" contract).
-   - **Cycle 1**: skip Phase B. No prior `schedule_next` exists; the
-     coordinator runs cheap-only by design. Phase B becomes possible
-     from cycle 2 onward via the Validator's authorization.
-   - **Cycle ≥ 2**: parse the `schedule_next:` block from the most
-     recent `## Cycle <N-1>` entry in `wm_progress_path`. If
-     `tiers:` includes `expensive`, OR `sensors:` lists explicit
-     ids whose `applies_to` covers the current criterion, run
-     `hooks/verify-acceptance.sh --tier expensive --criterion <id>
-     --fragments-dir "$(wm_runtime_dir)/.pending-fragments"` and
-     **append** its results to the same
-     `$(wm_runtime_dir)/.pending-snapshot.yaml` (the snapshot is the
-     union of Phase A + Phase B). Otherwise, skip Phase B.
-   This dual phase is the **two-phase per-cycle execution** of
-   sensor-cost-tiering — cheap sensors fire every cycle (shift-left
-   on actionable feedback), expensive sensors fire only when
-   pre-convergence failure would yield actionable signal. Source PRD:
-   `.yoke/prds/2026-04-27-sensor-cost-tiering.md`. Both phases respect the
+3. **Sensor execution — Phase B (expensive-equivalent, deterministic).**
+   From cycle 2 onward, run a higher-ceiling sweep that lets
+   inferential / longer-running sensors fire without flooding cheap
+   cycles with their cost. The Validator no longer emits a
+   `schedule_next:` block to gate this — that mechanism was retired
+   in the sensor-harness-realignment refactor; cost-based filtering
+   moved to the coordinator. Skip Phase B on cycle 1 (no prior
+   adversarial signal yet to justify the cost). On cycle ≥ 2, run
+   `hooks/verify-acceptance.sh --max-time-cost 600 --criterion <id>
+   --fragments-dir "$(wm_runtime_dir)/.pending-fragments"` and
+   **append** its results to the same
+   `$(wm_runtime_dir)/.pending-snapshot.yaml` (the snapshot is the
+   union of Phase A + Phase B). Sensors that already fit the
+   cheap-equivalent cap from Phase A are de-duplicated by
+   `verify-acceptance.sh` (it skips sensors whose snapshot entry is
+   already present in the merge target). Both phases respect the
    `runtime.inferential_sensor_concurrency` cap and the deferred-
-   sensors queue when tier filtering authorizes inferential judges.
+   sensors queue. The cheap-vs-expensive split is no longer a hard
+   tier classification — it is a soft cost-ceiling shift between the
+   two phases; the same sensor file is eligible for either phase
+   depending on whether its `time_cost:` fits the cap. Source PRD:
+   `.yoke/prds/2026-04-27-sensor-cost-tiering.md` (Part 4's
+   `schedule_next` mechanism was retired by the
+   `2026-04-30-sensor-harness-realignment` PRD).
 
 4. **Run-history append (deterministic).** After Phase A (always)
    and Phase B (when authorized), invoke
@@ -352,11 +356,14 @@ sprint boundaries):
    sweep.** This step decides three outcomes: (a) advance to the
    next sprint, (b) declare MERGE-READY (last sprint just
    converged), or (c) continue this sprint's loop.
-   - First, run `hooks/verify-acceptance.sh --concurrency 1 --tier
-     all --sprint <current_sprint>` (no `--criterion`), filtering
-     sensors / criteria to those declared in the active sprint
-     file's `## Functional acceptance criteria` and `## Sensors`
-     blocks. Redirect stdout to
+   - First, run `hooks/verify-acceptance.sh --concurrency 1
+     --sprint <current_sprint>` (no `--criterion`, no cost cap),
+     filtering sensors / criteria to those declared in the active
+     sprint file's `## Functional acceptance criteria` and
+     `## Sensors` blocks. The convergence sweep runs every
+     in-sprint sensor regardless of cost — the cheap-equivalent /
+     expensive-equivalent ceilings used in steps 2–3 are per-cycle
+     filters, not convergence filters. Redirect stdout to
      `$(wm_runtime_dir)/.sprint-converge-snapshot.yaml`. If every
      active-sprint criterion has `status: pass` AND no `divergence`
      verdict from the Validator, the sprint has converged.
@@ -370,14 +377,13 @@ sprint boundaries):
    - When `current_sprint` would exceed the last sprint id (i.e.
      every sprint has been completed), promote to the **full-run
      merge-ready sweep**: run `hooks/verify-acceptance.sh
-     --concurrency 1 --tier all` (no `--criterion`, no `--sprint`)
+     --concurrency 1` (no `--criterion`, no `--sprint`, no cost cap)
      and redirect stdout to
-     `$(wm_runtime_dir)/.merge-ready-snapshot.yaml`. The merge-ready
-     sweep ignores `schedule_next` entirely — every sensor (cheap
-     AND expensive) across every criterion MUST pass before the run
-     terminates, regardless of any per-sprint authorization. Scoped
-     / parallel / tier-filtered modes never decide convergence; the
-     serial full-suite sweep across all tiers is the authoritative
+     `$(wm_runtime_dir)/.merge-ready-snapshot.yaml`. Every sensor
+     across every criterion MUST pass before the run terminates,
+     regardless of any per-cycle cost-cap filtering. Scoped /
+     parallel / cost-capped modes never decide convergence; the
+     serial full-suite sweep at no cost cap is the authoritative
      final check (sensor-cost-tiering Part 5). If every criterion
      in the Acceptance Contract has `status: pass` in this snapshot
      AND no `divergence` verdict from the Validator, return

--- a/templates/contracts.md
+++ b/templates/contracts.md
@@ -17,18 +17,15 @@
 - references:
     - "acceptance-contract.md#<criterion id>"
 - cycle: <N>
-- schedule_next:
-    sensors: ["<sensor-id>"]                    # optional; explicit ids
-    tiers: ["cheap"]                            # at least one of sensors / tiers must be non-empty
-    reason: "<must cite at least one signal source — sensor id, criterion id, Tech-Spec section, or runs: history entry>"
 
 <!-- Subsequent contracts append below this line, one `## Contract <id>` block per consensus reached. -->
 
-> Schema notes:
->
-> - `schedule_next` mirrors the Validator's per-cycle decision verbatim
->   (added in v0.8.0 by sensor-cost-tiering Part 4). When consensus is
->   reached on a sub-objective, the scheduling decision active at that
->   cycle is captured here for audit. At least one of `sensors:` or
->   `tiers:` MUST be non-empty; `reason:` MUST cite at least one signal
->   source. Source PRD: `.yoke/prds/2026-04-27-sensor-cost-tiering.md`.
+<!--
+The `schedule_next:` field on each contract entry was retired by the
+sensor-harness-realignment refactor (PRD `2026-04-30-sensor-harness-realignment`).
+The Validator no longer emits `schedule_next:`; per-cycle cost-based
+filtering moved to the coordinator (`/yoke:implement`) via
+`--max-time-cost` / `--max-token-cost` on `verify-acceptance.sh`. New
+contracts MUST NOT include the field; legacy entries can stay
+verbatim for audit but are not re-read.
+-->

--- a/templates/progress.md
+++ b/templates/progress.md
@@ -66,10 +66,6 @@ cycle_count: 0
         coupling_signal: "<tech-spec-overlap | sensor-evidence-overlap | both>"
     change_set:
       "<path>": "<one-line intent>"
-- schedule_next:
-    sensors: ["<sensor-id>"]                    # optional; explicit ids
-    tiers: ["cheap"]                            # at least one of sensors / tiers must be non-empty
-    reason: "<must cite at least one signal source — sensor id, criterion id, Tech-Spec section, or runs: history entry>"
 - notes: "<free text — keep tight>"
 
 <!-- Subsequent cycles inside this sprint append as further `### Cycle <C>` H3 entries below. When current_sprint: advances, append a new `## Sprint <NN>` H2 below this section. -->
@@ -103,12 +99,11 @@ cycle_count: 0
 > - `citing_criteria` is an alternative to `citing_criterion`, used when
 >   a cycle batches multiple coupled criteria. Exactly one of the two
 >   fields MUST be populated per cycle.
-> - `schedule_next` is the Validator's per-cycle scheduling decision —
->   added in v0.8.0 by sensor-cost-tiering Part 4. Persisted verbatim
->   from the Validator's verdict, it tells the coordinator which
->   sensors / tiers to run in cycle `<N+1>` (lag-by-one). At least one
->   of `sensors:` or `tiers:` MUST be non-empty; `reason:` MUST cite
->   at least one signal source by name (sensor id, criterion id,
->   Tech-Spec section, or `runs:` history entry from a per-sensor
->   file). Empty / missing `schedule_next` is a malformed verdict.
->   Source PRD: `.yoke/prds/2026-04-27-sensor-cost-tiering.md`.
+> - The legacy `schedule_next:` field on each cycle entry was retired
+>   by the sensor-harness-realignment refactor (PRD
+>   `2026-04-30-sensor-harness-realignment`). The Validator no longer
+>   emits it; per-cycle cost-based filtering moved to the coordinator
+>   (`/yoke:implement`) via `--max-time-cost` / `--max-token-cost`
+>   on `verify-acceptance.sh`. New cycle entries MUST NOT include
+>   `schedule_next:`; legacy entries can stay verbatim for audit but
+>   are not re-read.


### PR DESCRIPTION
## Summary

- Replaces `--tier cheap` / `--tier expensive` / `--tier all` invocations of `hooks/verify-acceptance.sh` in `skills/implement/SKILL.md` with `--max-time-cost <N>` / no-cost-cap equivalents.
- Drops the `schedule_next:` reading branch from step 3 (Phase B authorization) — the Validator no longer emits the field per `agents/validator.md`, and Phase B is now governed by a deterministic cycle-≥-2 rule with a higher cost ceiling.
- Removes the `schedule_next:` field from `templates/contracts.md` and `templates/progress.md` cycle/contract entry schemas; replaces the schema notes with retirement markers pointing at the realignment PRD.

## Why this is a bug

The sensor-harness-realignment PRD (commit `4fe3cdf`) removed `--tier` from `hooks/verify-acceptance.sh` (it now hard-fails with `Error: --tier was removed in the sensor-harness-realignment refactor.`) and retired the Validator's `schedule_next:` emission per `agents/validator.md` ("Cost-based filtering of which sensors run this cycle is the coordinator's job"). The implement skill and the cycle / contract templates stayed on the legacy contract — any reader following the skill literally would hit the `--tier was removed` error on step 2; the Phase B authorization branch parsed a field the Validator had stopped emitting, so cycle ≥ 2 expensive-tier authorization silently never fired.

## Behavior changes

- **Phase A** (step 2): `--tier cheap` → `--max-time-cost 60`. Cheap-equivalent ceiling.
- **Phase B** (step 3): `schedule_next:` reading branch deleted. Cycle 1 still skips Phase B; cycle ≥ 2 runs at `--max-time-cost 600` (expensive-equivalent ceiling). Sensors that fit the cap run regardless of any per-Validator gate.
- **Stop check** (step 8): both the per-sprint convergence sweep and the merge-ready full-suite sweep drop `--tier all` — running `verify-acceptance.sh` with no cost cap is the new convergence contract; the cheap/expensive split is per-cycle, never convergence.
- **Templates**: cycle entries (`templates/progress.md`) and contract entries (`templates/contracts.md`) no longer carry `schedule_next:` in their schema. Legacy entries on disk stay verbatim for audit; new entries omit the field.

## Why this PR can land independently of #23

#23 (retire `append-runs.sh` and step 4) and this PR both edit `skills/implement/SKILL.md` but in non-overlapping line ranges. #23 deletes step 4 + renumbers steps 5..9 → 4..8 + updates intra-doc cross-references; this PR edits the bodies of steps 2, 3, and 8 (numbered against the `main`-branch shape). Whichever lands second rebases against the renumbering; the textual changes don't conflict.

## Test plan

- [ ] `bash tests/sensor-tiering.test.sh` exits 0 (15 checks pass — same as `main`; the legacy `(d)–(n)` parts that depended on `--tier` were already retired in PR #20).
- [ ] `grep -nE -- '--tier (cheap|expensive|all)' skills/implement/SKILL.md` returns only retirement-note matches (the strings appear inside prose explaining *what was retired*, not live invocations).
- [ ] `grep -nE '^\s*(tiers|schedule_next):' templates/contracts.md templates/progress.md` returns nothing — no live schema field carries the retired key.
- [ ] Following step 2 / step 3 / step 8 instructions verbatim against the existing `verify-acceptance.sh` no longer trips the `--tier was removed` error.

## Status

Discovered alongside the v3.0 agent-council dogfood (cycle 1 step 2 of `/yoke:implement` surfaced the `--tier was removed` error verbatim). Second of three small PRs that finish the realignment cleanup; #23 covers the retired `runs:` writer and the third PR (incoming) covers the `ack-sensors.sh` sensor-id validation gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)