### PR TITLE
fix(ack-sensors): reject invalid sensor ids in upsert mode

### DIFF
--- a/lib/sensors/ack-sensors.sh
+++ b/lib/sensors/ack-sensors.sh
@@ -668,11 +668,32 @@ upsert_mode() {
   shopt -u nullglob
   ids="$(printf '%s\n' "$ids" | LC_ALL=C sort -u | grep -v '^$' || true)"
 
+  # Sensor-id regex — matches `wm_sensor_path` in
+  # lib/working-memory/paths.sh. Kebab-or-snake plus '.' / '-' / '_';
+  # lower-case alnum start; ≤64 chars total. The path constructor
+  # honors `--root` so we cannot dispatch through `wm_sensor_path`
+  # directly — duplicating the validation regex here keeps the two
+  # call sites in sync (any tightening must touch both).
+  local sensor_id_regex='^[a-z0-9][a-z0-9_.-]{0,63}$'
+
   local upserted_yaml=""
+  local failures_yaml=""
   local id sf action
+  local invalid_count=0
   if [ -n "$ids" ]; then
     while IFS= read -r id; do
       [ -z "$id" ] && continue
+      if [[ ! "$id" =~ $sensor_id_regex ]]; then
+        # Structured failure per concepts/yoke-pattern-sensors —
+        # sensor / expected / actual / reason / correction.
+        failures_yaml+="  - sensor: \"${id}\""$'\n'
+        failures_yaml+="    expected: \"sensor id matching ${sensor_id_regex}\""$'\n'
+        failures_yaml+="    actual: \"${id}\""$'\n'
+        failures_yaml+="    reason: \"sensor id contains characters outside the kebab-or-snake set (allowed: lower-case alnum start, then [a-z0-9_.-], ≤64 chars total). Whitespace, parentheses, and uppercase are rejected.\""$'\n'
+        failures_yaml+="    correction: \"edit the contract to remove the invalid sensor reference (e.g. drop annotations from \`Sensors: [<id> (annotation)]\` or rename the registry entry); re-run upsert.\""$'\n'
+        invalid_count=$((invalid_count + 1))
+        continue
+      fi
       sf="${sensors_dir}/${id}.md"
       if [ -f "$sf" ]; then
         action="unchanged"
@@ -684,6 +705,22 @@ upsert_mode() {
       upserted_yaml+="    path: \"${sf}\""$'\n'
       upserted_yaml+="    action: ${action}"$'\n'
     done <<< "$ids"
+  fi
+
+  if [ "$invalid_count" -gt 0 ]; then
+    # Surface the same structured failures on stderr so callers piping
+    # stdout into a parser still see the violation list. Exit 4 per
+    # the upsert contract.
+    {
+      printf 'wm: ack-sensors --mode upsert rejected %d invalid sensor id(s):\n' "$invalid_count"
+      printf '%s' "$failures_yaml"
+    } >&2
+    if [ -z "$upserted_yaml" ]; then
+      printf 'status: error\nupserted: []\nfailures:\n%s' "$failures_yaml"
+    else
+      printf 'status: error\nupserted:\n%sfailures:\n%s' "$upserted_yaml" "$failures_yaml"
+    fi
+    exit 4
   fi
 
   if [ -z "$upserted_yaml" ]; then


### PR DESCRIPTION
## Summary

- Adds explicit sensor-id validation to `lib/sensors/ack-sensors.sh::upsert_mode` against the regex `^[a-z0-9][a-z0-9_.-]{0,63}$` (mirroring `wm_sensor_path` in `lib/working-memory/paths.sh`).
- Rejects ids with whitespace, parentheses, uppercase, or leading hyphens; emits structured failure entries (`sensor` / `expected` / `actual` / `reason` / `correction`) per the patterns/sensors contract; exits 4 with the upsert-validation-failed code already documented at the top of the file.
- Valid ids in the same contract continue to materialize on the same pass — partial success is preserved.

## Why this is a bug

`upsert_mode` constructed sensor file paths by string concatenation (`${sensors_dir}/${id}.md`) without validating the id against the documented regex. An Acceptance Contract referencing a sensor as `Sensors: [my-sensor (annotation)]` materialized literally as `.yoke/sensors/my-sensor (annotation).md` — the parenthesized annotation became part of the id and showed up as a filename with whitespace and parens. Same gap admitted UPPERCASE ids, leading-hyphen ids, and any other character that violated `wm_sensor_path`'s contract.

## Smoke test (manual reproduction)

```bash
mkdir -p /tmp/ack-test/.yoke/acceptance-contracts && cd /tmp/ack-test
cat > .yoke/acceptance-contracts/test.md <<'CONTRACT'
### Validation
- **valid-id** — ok
Sensors: [valid-id, valid_id_2, valid.id.3, invalid id with space, bad (annotation), UPPERCASE, -leading-hyphen]
CONTRACT

bash <plugin_root>/lib/sensors/ack-sensors.sh --mode upsert .yoke/acceptance-contracts/test.md
# Before this PR: exit 0; 7 files created including ".yoke/sensors/bad (annotation).md".
# After this PR:  exit 4; 3 files created (valid-id, valid_id_2, valid.id.3); 4 structured failures listed.
```

## Why the regex is duplicated

The sensor-id regex is duplicated inline in `upsert_mode` (with a comment pointing at `wm_sensor_path`) because the upsert path constructor honors `--root <dir>`, which `wm_sensor_path` does not. Dispatching the validation through the helper would require either changing the helper's contract or introducing an alternate constructor; keeping the regex inline with a "must stay in sync" comment is the smaller change.

## Test plan

- [ ] `bash tests/sensor-tiering.test.sh` exits 0 (the existing 15 checks against `templates/sensor.md`, `wm_sensor_path`, and `templates/acceptance-contract.md` still pass).
- [ ] Manual smoke (reproduction above): mixed valid + invalid sensor refs produce `status: error`, exit 4, the 3 valid sensor files materialize, the 4 invalid ids do NOT.
- [ ] Clean contract (only valid ids): `status: ok`, exit 0, files materialize as before.

## Status

Discovered during the v3.0 agent-council dogfood (the AC author wrote `Sensors: [council-arbiter, council-arbiter (inferential)]` to visually distinguish the inferential variant; upsert silently materialized both files including `council-arbiter (inferential).md`). Third of three small PRs that finish the sensor-harness-realignment cleanup; #23 retires the `runs:` writer and #24 retires the `--tier` flag drift in the implement skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)