### PR TITLE
fix(scaffold-sprints): require bash 4+ via env shebang + runtime guard (#33)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
           - tests/smoke/resolve-provider-set-u-safety.test.sh
           - tests/smoke/append-runs-retired.test.sh
           - tests/smoke/placeholder-sensor-preflight.test.sh
+          - tests/smoke/scaffold-sprints-bash4.test.sh
     steps:
       - name: Check out
         uses: actions/checkout@v4

--- a/lib/working-memory/scaffold-sprints.sh
+++ b/lib/working-memory/scaffold-sprints.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # scaffold-sprints.sh
 #
 # Deterministic sprint-file scaffolder for the sprint-as-cycle flow.
@@ -30,6 +30,22 @@
 #       sprint number is outside the 1..99 range
 
 set -euo pipefail
+
+# Bash-4+ guard. The script uses `mapfile` (line 87) which Apple's
+# stock /bin/bash 3.2 does not implement; without `#!/usr/bin/env bash`
+# (above) plus this guard, macOS hosts trip `mapfile: command not
+# found` (exit 127) the first time `/yoke:tech-spec` reaches stage 2.
+# CLAUDE.md :: ## Linting already states "Bash scripts target bash 4+";
+# this surfaces the mismatch with an actionable diagnostic instead of
+# the cryptic mapfile error. Source: issue #33.
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "wm: scaffold-sprints.sh requires bash 4+ (running $BASH_VERSION from ${BASH:-unknown})." >&2
+    echo "wm: on macOS, install Homebrew bash and ensure it precedes /bin/bash on PATH:" >&2
+    echo "wm:   brew install bash" >&2
+    echo "wm:   export PATH=\"/opt/homebrew/bin:\$PATH\"   # Apple Silicon" >&2
+    echo "wm:   export PATH=\"/usr/local/bin:\$PATH\"      # Intel Macs" >&2
+    exit 2
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"

--- a/tests/smoke/scaffold-sprints-bash4.test.sh
+++ b/tests/smoke/scaffold-sprints-bash4.test.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# tests/smoke/scaffold-sprints-bash4.test.sh
+#
+# Sensor: scaffold-sprints-bash4 (computational, cheap).
+#
+# Pins the regression documented in
+# https://github.com/iurykrieger/claude-yoke/issues/33:
+# `lib/working-memory/scaffold-sprints.sh` shipped with shebang
+# `#!/bin/bash` and used `mapfile` (line 87). On macOS hosts /bin/bash
+# is the Apple-shipped 3.2.57 (frozen at GPLv2), which has no
+# `mapfile` / `readarray`. /yoke:tech-spec stage 2 therefore failed
+# with `mapfile: command not found` (exit 127) on every macOS dev
+# machine until a Homebrew bash 5 was forced via explicit invocation.
+# CI on ubuntu-latest always saw bash 4+ and never tripped this.
+#
+# Coverage:
+#   (A) Shebang at line 1 is `#!/usr/bin/env bash` (so PATH resolution
+#       picks up Homebrew's bash on macOS, not Apple's 3.2).
+#   (B) The bash-4 runtime guard is present (`BASH_VERSINFO[0] < 4`)
+#       and exits 2 with an actionable `wm: ... requires bash 4+` line
+#       on stderr — the diagnostic the issue specifically called for.
+#   (C) Forcing the script to run under `/bin/bash` (Apple 3.2 on macOS,
+#       skipped on Linux runners where `/bin/bash` is already 4+) trips
+#       the guard, exits 2, and emits the documented stderr; it does
+#       NOT reach line 87 where `mapfile` would otherwise fire.
+#   (D) Default invocation under bash 4+ still scaffolds correctly —
+#       the guard is a no-op for the supported floor.
+#   (E) Structural pin against future regressions: any script under
+#       `lib/`, `skills/`, or `hooks/` that uses `mapfile` /
+#       `readarray` MUST also use `#!/usr/bin/env bash` AND carry a
+#       `BASH_VERSINFO` guard. This pin catches reintroduction of the
+#       bug class via a different file.
+#
+# References:
+# - Issue: #33
+# - CLAUDE.md :: ## Linting — "Bash scripts target bash 4+".
+
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/harness.sh"
+
+set +e
+
+# Watchdog (concepts/yoke-conventions): never let a hung subshell block CI.
+(sleep 600 && kill -TERM $$ &) >/dev/null 2>&1
+
+cd "$PLUGIN_ROOT"
+
+SCRIPT="$PLUGIN_ROOT/lib/working-memory/scaffold-sprints.sh"
+[ -f "$SCRIPT" ] || { err "script missing at $SCRIPT"; harness::summary; }
+
+# ----------------------------------------------------------------------
+# (A) Shebang.
+# ----------------------------------------------------------------------
+shebang="$(head -1 "$SCRIPT")"
+if [ "$shebang" = "#!/usr/bin/env bash" ]; then
+  pass "(A) shebang resolves bash via /usr/bin/env"
+else
+  err "(A) expected shebang '#!/usr/bin/env bash', got '$shebang'"
+fi
+
+# ----------------------------------------------------------------------
+# (B) Runtime guard present (textual pin — the assertion below in (C)
+# proves it actually fires).
+# ----------------------------------------------------------------------
+if grep -qE 'BASH_VERSINFO\[0\][[:space:]]*<[[:space:]]*4' "$SCRIPT"; then
+  pass "(B) BASH_VERSINFO[0] < 4 guard present"
+else
+  err "(B) BASH_VERSINFO[0] < 4 guard missing — no protection against bash 3.x at runtime"
+fi
+
+if grep -qE '^[[:space:]]*echo "wm: scaffold-sprints\.sh requires bash 4\+' "$SCRIPT"; then
+  pass "(B) actionable 'wm:' diagnostic line present"
+else
+  err "(B) actionable 'wm:' diagnostic missing (issue #33 specifically requested this)"
+fi
+
+# ----------------------------------------------------------------------
+# (C) Forced invocation under stock /bin/bash. On macOS this is
+# Apple's 3.2.57; on Linux runners /bin/bash is already 4+ (so the
+# guard does NOT fire and this assertion is auto-skipped to keep CI
+# green across both platforms — the issue is OS-dependent).
+# ----------------------------------------------------------------------
+if [ -x /bin/bash ]; then
+  bin_bash_major="$(/bin/bash -c 'echo $BASH_VERSINFO' 2>/dev/null || echo 99)"
+  if [ "$bin_bash_major" -lt 4 ]; then
+    forced_stderr="$(mktemp)"
+    /bin/bash "$SCRIPT" /tmp/__yoke_test_nonexistent_spec.md >/dev/null 2>"$forced_stderr"
+    forced_rc=$?
+    forced_stderr_content="$(cat "$forced_stderr")"
+    rm -f "$forced_stderr"
+
+    [ "$forced_rc" -eq 2 ] \
+      && pass "(C) /bin/bash 3.x forces guard, exit 2 (got $forced_rc)" \
+      || err "(C) /bin/bash 3.x forced invocation: expected exit 2, got $forced_rc; stderr=$forced_stderr_content"
+
+    if printf '%s' "$forced_stderr_content" | grep -qF "requires bash 4+"; then
+      pass "(C) stderr surfaces 'requires bash 4+' diagnostic"
+    else
+      err "(C) stderr does not surface 'requires bash 4+' — got: $forced_stderr_content"
+    fi
+
+    if printf '%s' "$forced_stderr_content" | grep -qF "mapfile: command not found"; then
+      err "(C) regression: the cryptic 'mapfile: command not found' message reached the user — guard ran too late"
+    else
+      pass "(C) the cryptic 'mapfile: command not found' message is no longer surfaced"
+    fi
+  else
+    pass "(C) skipped on this host (/bin/bash is already bash $bin_bash_major+; guard not exercised here)"
+  fi
+else
+  pass "(C) skipped: no /bin/bash on this host"
+fi
+
+# ----------------------------------------------------------------------
+# (D) Happy path under env-resolved bash 4+. Builds a minimal valid
+# spec, runs the script, asserts both files were created, and cleans
+# up. Uses the script's normal shebang resolution.
+# ----------------------------------------------------------------------
+TMP="$(mktemp -d)"
+SPEC="$TMP/2026-05-03-scaffold-test-slug.md"
+cat > "$SPEC" <<'SPEC'
+# Spec for scaffold-sprints-bash4 smoke test
+
+### Sprint 1 — Foo
+delivery objective.
+
+### Sprint 2 — Bar
+delivery objective.
+SPEC
+
+# Run the script via env shebang. Capture rc but don't fail the
+# whole harness on cleanup errors (the on-disk artifacts are removed
+# explicitly below).
+happy_stdout="$(mktemp)"
+happy_stderr="$(mktemp)"
+"$SCRIPT" "$SPEC" >"$happy_stdout" 2>"$happy_stderr"
+happy_rc=$?
+
+# Locate scaffolded files (relative to PLUGIN_ROOT/.yoke/sprints).
+created_a="$PLUGIN_ROOT/.yoke/sprints/2026-05-03-scaffold-test-slug-s01.md"
+created_b="$PLUGIN_ROOT/.yoke/sprints/2026-05-03-scaffold-test-slug-s02.md"
+
+[ "$happy_rc" -eq 0 ] \
+  && pass "(D) env-resolved bash 4+ run scaffolds with exit 0" \
+  || err "(D) env-resolved scaffold exited $happy_rc; stderr=$(cat "$happy_stderr")"
+
+if [ -f "$created_a" ] && [ -f "$created_b" ]; then
+  pass "(D) both sprint files created on disk"
+else
+  err "(D) expected sprint files missing — a=$created_a (exists=$([ -f "$created_a" ] && echo 1 || echo 0)), b=$created_b (exists=$([ -f "$created_b" ] && echo 1 || echo 0))"
+fi
+
+# Cleanup happy-path side effects so the test is idempotent.
+rm -f "$created_a" "$created_b" "$happy_stdout" "$happy_stderr"
+rm -rf "$TMP"
+
+# ----------------------------------------------------------------------
+# (E) Structural pin: every script in lib/, skills/, hooks/ that uses
+# `mapfile` or `readarray` MUST use the env-resolved shebang AND carry
+# a BASH_VERSINFO guard. Catches future regressions in OTHER files.
+# ----------------------------------------------------------------------
+e_violations=""
+e_count=0
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  e_count=$((e_count + 1))
+  first_line="$(head -1 "$f")"
+  has_guard=0
+  grep -qE 'BASH_VERSINFO\[0\][[:space:]]*<[[:space:]]*4' "$f" && has_guard=1
+  if [ "$first_line" != "#!/usr/bin/env bash" ] || [ "$has_guard" -eq 0 ]; then
+    e_violations+=$'\n'"  - $f (shebang='$first_line', guarded=$has_guard)"
+  fi
+done < <(grep -rlE '\b(mapfile|readarray)\b' lib/ skills/ hooks/ 2>/dev/null || true)
+
+if [ -z "$e_violations" ]; then
+  pass "(E) every mapfile/readarray user has env-shebang + bash-4 guard ($e_count file(s) audited)"
+else
+  err "(E) bash-4-only-feature users without protection:$e_violations"
+fi
+
+harness::summary


### PR DESCRIPTION
## Summary

- Issue #33: `lib/working-memory/scaffold-sprints.sh` shipped with `#!/bin/bash` and uses `mapfile` on line 87. On macOS hosts `/bin/bash` is Apple's 3.2.57, which has no `mapfile`/`readarray` — every `/yoke:tech-spec` stage 2 invocation died with `mapfile: command not found` (exit 127). CI never caught it because ubuntu-latest's `/bin/bash` is already 4+.
- Two changes to the script: (1) shebang to `#!/usr/bin/env bash` so PATH resolution finds Homebrew bash on macOS, (2) `BASH_VERSINFO[0] < 4` guard immediately after `set -euo pipefail`, exiting 2 with an actionable `wm:`-prefixed diagnostic that names the running bash version and the Homebrew install steps. This protects against explicit `/bin/bash scaffold-sprints.sh …` invocations too.
- The fix surface is narrow: `scaffold-sprints.sh` is the ONLY script under `lib/`, `skills/`, `hooks/`, or `tests/` that uses `mapfile`/`readarray`. The other 25 `#!/bin/bash` scripts in the repo don't trip bash-4-only syntax and stay untouched.
- Adds `tests/smoke/scaffold-sprints-bash4.test.sh` (9 checks) and wires it into the CI matrix. Assertion (E) is the structural pin against future regressions: any script that introduces `mapfile`/`readarray` must also carry the env-shebang + BASH_VERSINFO guard.

## Test plan

- [x] Local: `bash tests/smoke/scaffold-sprints-bash4.test.sh` → `PASS (9 check(s))` on macOS where `/bin/bash` is 3.2.57.
- [x] Reproduced the original bug pre-patch: `/bin/bash scaffold-sprints.sh <spec>` → `mapfile: command not found` exit 127.
- [x] Verified post-patch: `/bin/bash scaffold-sprints.sh <spec>` → `wm: scaffold-sprints.sh requires bash 4+ (running 3.2.57(1)-release from /bin/bash).` exit 2.
- [x] Verified happy path: env-resolved bash 5 scaffolds 2 sprint files cleanly.
- [ ] CI: matrix runner for the new smoke test reports green (Linux only — assertion C auto-skips when `/bin/bash` is 4+).
- [ ] Reviewer regression spot-check on macOS: `git checkout HEAD~1 -- lib/working-memory/scaffold-sprints.sh && bash tests/smoke/scaffold-sprints-bash4.test.sh` should fail on (A), (B), (C).

Closes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)