### PR TITLE
feat(canonize): stage only active-task diff into provider hand-off (#40)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
           - tests/smoke/skill-prompt-helper-references.test.sh
           - tests/smoke/tech-spec-design-doc-shape.test.sh
           - tests/smoke/scaffold-sprints-callable-from-phase-3.test.sh
+          - tests/smoke/canonize-active-task-scope.test.sh
     steps:
       - name: Check out
         uses: actions/checkout@v4

--- a/docs/canonical-memory-provider-contract.md
+++ b/docs/canonical-memory-provider-contract.md
@@ -33,21 +33,20 @@ contract_version: 1
 The provider's canonize skill is invoked exactly as:
 
 ```text
-<provider-canonize-skill> --working-memory <abs-path-to-.yoke>
+<provider-canonize-skill> --working-memory <abs-path-to-stage>
 ```
 
 Invariants:
 
-1. **Path is absolute.** The Yoke facade resolves the absolute path via
-   `cd "$PWD/.yoke" && pwd` before dispatch. Providers MUST NOT
-   re-resolve, follow `..` segments, or accept relative input as a
-   workaround.
+1. **Path is absolute.** The Yoke facade produces the absolute path
+   via `mktemp -d` before dispatch (see "Active-task staging" below).
+   Providers MUST NOT re-resolve, follow `..` segments, or accept
+   relative input as a workaround.
 2. **Path is read-only from the provider's perspective.** Providers
    MUST NOT create, modify, rename, or delete any file under the
-   given `.yoke/` directory. The directory is the framework's
-   working memory; only Yoke skills (the Generator, Validator, and
-   the runtime coordinator) write here. Violating this invariant is
-   a contract breach.
+   given staging directory. The directory contains a per-task slice
+   of the framework's working memory; only Yoke skills write here.
+   Violating this invariant is a contract breach.
 3. **Path is a single directory.** The provider receives one path,
    not a list. Multi-project ingestion is out of scope at
    `contract_version: 1`.
@@ -62,28 +61,80 @@ Invariants:
 The provider MAY copy any portion of the working memory into its own
 private staging area to perform graphification, classification, or
 git operations — that is implementation freedom. The on-disk
-contents of `.yoke/` MUST be byte-identical before and after the
-canonize call.
+contents of the staging directory MUST be byte-identical before and
+after the canonize call.
+
+## Active-task staging (issue #40, contract_version: 1)
+
+The path `<abs-path-to-stage>` is NOT the host's `.yoke/` directly.
+Yoke's `/yoke:canonize` facade invokes
+`lib/working-memory/canonize-stage.sh` to materialize a fresh tmp
+directory (under `${TMPDIR:-/tmp}/yoke-canonize-stage.<RAND>`)
+shaped exactly like `.yoke/` but containing only the active slug's
+artifacts:
+
+```text
+<stage>/
+├── config.yaml                                  # always staged
+├── .gitignore                                   # always staged (when present in host)
+├── prds/<active-slug>.md                        # when present in host
+├── specs/<active-slug>.md                       # when present
+├── sprints/<active-slug>-s<NN>.md               # every match (zero or more)
+├── acceptance-criteria/<active-slug>.md         # when present (post-v4.0.0)
+├── acceptance-contracts/<active-slug>.md        # when present (legacy, pre-v4.0.0)
+├── contracts/<active-slug>.md                   # when present
+└── runtime/                                     # full subtree (per-task, transient)
+```
+
+What the stage does NOT contain:
+
+- Any `prds/<other-slug>.md`, `specs/<other-slug>.md`,
+  `sprints/<other-slug>-s*.md`, or `acceptance-*/<other-slug>.md`
+  for any historical task. Those were canonized in their own
+  `/yoke:canonize` runs and re-feeding them re-runs the provider's
+  graphify and entity-matching against artifacts already in the
+  vault — wasteful and prone to vault pollution if any historical
+  file's frontmatter has drifted.
+- Any `sensors/<sensor-id>.md`. Sensors are project-scoped, not
+  per-task; including them in every canonize run is exactly the
+  bloat issue #40 documented.
+
+Empty archive directories are pruned from the stage so the directory
+tree the provider sees mirrors what a fresh `.yoke/` for the active
+task would look like — no scaffolding artifacts.
+
+The active slug is read from `.yoke/runtime/.current` by the staging
+helper; an explicit `--slug <slug>` flag overrides it (used for
+catch-up canonizations and tests). When `.current` is missing the
+helper exits 3 with a `wm:`-prefixed diagnostic; when `.yoke/`
+itself is missing it exits 2.
+
+Cleanup is the facade's responsibility: `/yoke:canonize` Phase 5
+runs `rm -rf "$stage_dir"` unconditionally (even on non-zero
+provider exit) so failed runs do not leave tmp directories behind.
 
 ## Directory tree
 
-`.yoke/` layout the provider can rely on. Annotations: **REQUIRED**
-files are present whenever Yoke has reached the relevant phase;
-**OPTIONAL** files appear only when the corresponding workflow has
-run. The set is derived from `lib/working-memory/paths.sh` helpers.
+The staged directory layout the provider can rely on. The shape
+mirrors `.yoke/` exactly, but every per-task file is keyed off the
+active slug only (per "Active-task staging" above). Annotations:
+**REQUIRED** files are present whenever Yoke has reached the
+relevant phase; **OPTIONAL** files appear only when the corresponding
+workflow has run. The set is derived from
+`lib/working-memory/paths.sh` helpers.
 
 ```text
-.yoke/
+<stage>/                                       # mktemp -d under TMPDIR
 ├── config.yaml                                # REQUIRED
-├── .gitignore                                 # REQUIRED (versioned)
-├── prds/<slug>.md                             # REQUIRED — one per task
-├── specs/<slug>.md                            # REQUIRED — one per task
-├── sprints/<slug>-s<NN>.md                    # REQUIRED — one or more per slug
-├── acceptance-criteria/<slug>.md              # REQUIRED
-├── contracts/<slug>.md                        # OPTIONAL — present iff sprint
+├── .gitignore                                 # REQUIRED (versioned in host)
+├── prds/<active-slug>.md                      # REQUIRED — one per active task
+├── specs/<active-slug>.md                     # REQUIRED — one per active task
+├── sprints/<active-slug>-s<NN>.md             # REQUIRED — one or more
+├── acceptance-criteria/<active-slug>.md       # REQUIRED — post v4.0.0
+├── acceptance-contracts/<active-slug>.md      # OPTIONAL — pre-v4.0.0 legacy
+├── contracts/<active-slug>.md                 # OPTIONAL — present iff sprint
 │                                              #   contracts emerged at runtime
-├── sensors/<sensor-id>.md                     # OPTIONAL — project-scoped
-└── runtime/                                   # OPTIONAL — gitignored
+└── runtime/                                   # OPTIONAL — gitignored in host
     ├── .current                               # OPTIONAL — active-task pointer
     ├── progress.md                            # OPTIONAL — present iff a ralph
     │                                          #   loop has run; carries the
@@ -93,6 +144,11 @@ run. The set is derived from `lib/working-memory/paths.sh` helpers.
     ├── .snapshots/cycle-N.yaml                # OPTIONAL — sensor snapshots
     └── .judge-verdicts/cycle-N/               # OPTIONAL — per-criterion JSON
 ```
+
+Note: `sensors/<sensor-id>.md` is intentionally absent from the
+staged tree even though it lives at `.yoke/sensors/<sensor-id>.md`
+in the host. Sensors are project-scoped, not per-task — see
+"Active-task staging" above for the rationale.
 
 The slug regex (filename without `.md`) is fixed at:
 

--- a/lib/working-memory/canonize-stage.sh
+++ b/lib/working-memory/canonize-stage.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# canonize-stage.sh
+#
+# Materializes the active task's working-memory diff into a fresh
+# tmp directory shaped exactly like `.yoke/`, then echoes the
+# absolute path of that staging dir on stdout. Designed for
+# /yoke:canonize: instead of handing the provider the full `.yoke/`
+# (which contains historical PRDs, specs, sprint bundles, and
+# acceptance documents from every prior task), the facade stages
+# only the active slug's artifacts.
+#
+# The slug is read from `.yoke/runtime/.current` via wm_active_slug
+# unless `--slug <slug>` is passed (escape hatch for tests and for
+# manual catch-up canonizations of a slug that is not currently
+# active).
+#
+# Files staged (all keyed off the resolved slug):
+#   - config.yaml                       — provider needs canonical_memory.* passthrough
+#   - .gitignore                        — preserved for shape parity
+#   - prds/<slug>.md                    — when present
+#   - specs/<slug>.md                   — when present
+#   - sprints/<slug>-s*.md              — every match (zero or more)
+#   - acceptance-criteria/<slug>.md     — when present (post v4.0.0)
+#   - acceptance-contracts/<slug>.md    — when present (legacy, pre v4.0.0)
+#   - contracts/<slug>.md               — when present (sprint contracts)
+#   - runtime/                          — full subtree, per-task transient state
+#
+# Files explicitly NOT staged:
+#   - prds/<other-slug>.md and the same pattern for every historical
+#     archive category — those are previous tasks, already canonized
+#     in their own runs.
+#   - sensors/<sensor-id>.md — project-scoped, not per-task. Re-feeding
+#     them on every canonize re-runs the provider's entity-matching
+#     pipeline against artifacts that already canonized.
+#
+# Source issue: https://github.com/iurykrieger/claude-yoke/issues/40.
+# Contract reference: docs/canonical-memory-provider-contract.md.
+#
+# Usage:
+#   stage_dir="$(lib/working-memory/canonize-stage.sh)"
+#   # ... dispatch provider with --working-memory "$stage_dir" ...
+#   rm -rf "$stage_dir"   # caller cleans up
+#
+# Exit codes:
+#   0 — staged successfully; absolute stage path on stdout
+#   2 — invalid args, missing host .yoke/, or unsupported bash version
+#   3 — could not resolve active slug (no .yoke/runtime/.current)
+
+set -euo pipefail
+
+# Bash-4+ guard. Mirrors scaffold-sprints.sh per issue #33.
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "wm: canonize-stage.sh requires bash 4+ (running $BASH_VERSION from ${BASH:-unknown})." >&2
+    echo "wm: on macOS, install Homebrew bash and ensure it precedes /bin/bash on PATH:" >&2
+    echo "wm:   brew install bash" >&2
+    echo "wm:   export PATH=\"/opt/homebrew/bin:\$PATH\"   # Apple Silicon" >&2
+    exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=./paths.sh
+source "${SCRIPT_DIR}/paths.sh"
+
+usage() {
+    cat >&2 <<'EOF'
+usage: canonize-stage.sh [--slug <slug>]
+
+  --slug <slug>  Stage this slug instead of reading
+                 .yoke/runtime/.current. Useful for tests and for
+                 catching up a slug that is not currently active.
+
+Echoes the absolute path of a fresh staging directory on stdout.
+Caller is responsible for `rm -rf` after the provider returns.
+EOF
+}
+
+slug=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --slug)
+            slug="${2:-}"
+            shift 2 || { usage; exit 2; }
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "wm: canonize-stage.sh: unknown argument: $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+if [[ ! -d "$PWD/.yoke" ]]; then
+    echo "wm: .yoke/ not found in \$PWD ($PWD)" >&2
+    exit 2
+fi
+
+if [[ -z "$slug" ]]; then
+    slug="$(wm_active_slug)" || exit 3
+else
+    wm_validate_slug "$slug" || exit 2
+fi
+
+stage="$(mktemp -d "${TMPDIR:-/tmp}/yoke-canonize-stage.XXXXXX")"
+
+mkdir -p \
+    "$stage/prds" \
+    "$stage/specs" \
+    "$stage/sprints" \
+    "$stage/acceptance-criteria" \
+    "$stage/acceptance-contracts" \
+    "$stage/contracts"
+
+# config.yaml + .gitignore — required for shape parity. The provider
+# reads canonical_memory.* passthrough keys from config.yaml.
+[[ -f .yoke/config.yaml ]] && cp -p .yoke/config.yaml "$stage/config.yaml"
+[[ -f .yoke/.gitignore ]] && cp -p .yoke/.gitignore "$stage/.gitignore"
+
+# Per-slug archive files (each is conditional — partial archives are
+# valid; e.g. spec-phase only has prds/specs/sprints, no contracts).
+[[ -f ".yoke/prds/${slug}.md" ]] \
+    && cp -p ".yoke/prds/${slug}.md" "$stage/prds/${slug}.md"
+[[ -f ".yoke/specs/${slug}.md" ]] \
+    && cp -p ".yoke/specs/${slug}.md" "$stage/specs/${slug}.md"
+[[ -f ".yoke/acceptance-criteria/${slug}.md" ]] \
+    && cp -p ".yoke/acceptance-criteria/${slug}.md" "$stage/acceptance-criteria/${slug}.md"
+[[ -f ".yoke/acceptance-contracts/${slug}.md" ]] \
+    && cp -p ".yoke/acceptance-contracts/${slug}.md" "$stage/acceptance-contracts/${slug}.md"
+[[ -f ".yoke/contracts/${slug}.md" ]] \
+    && cp -p ".yoke/contracts/${slug}.md" "$stage/contracts/${slug}.md"
+
+# Every sprint file for the active slug.
+shopt -s nullglob
+for f in ".yoke/sprints/${slug}"-s*.md; do
+    cp -p "$f" "$stage/sprints/$(basename "$f")"
+done
+shopt -u nullglob
+
+# runtime/ is per-task, transient, gitignored. Copy the full subtree
+# so the provider sees the same context the framework saw at canonize
+# time (progress.md is especially useful for canonize-line lineage).
+if [[ -d .yoke/runtime ]]; then
+    mkdir -p "$stage/runtime"
+    cp -Rp .yoke/runtime/. "$stage/runtime/"
+fi
+
+# Drop empty archive directories so the staged tree mirrors what the
+# provider would see in a fresh `.yoke/`. Empty `acceptance-contracts/`
+# (post v4.0.0) and empty `contracts/` (pre-runtime) are common.
+for d in "$stage/prds" "$stage/specs" "$stage/sprints" \
+         "$stage/acceptance-criteria" "$stage/acceptance-contracts" \
+         "$stage/contracts"; do
+    if [[ -d "$d" ]] && [[ -z "$(ls -A "$d" 2>/dev/null)" ]]; then
+        rmdir "$d"
+    fi
+done
+
+printf '%s' "$stage"

--- a/skills/canonize/SKILL.md
+++ b/skills/canonize/SKILL.md
@@ -1,20 +1,19 @@
 ---
 name: canonize
 description: >
-  Provider-agnostic facade for the canonical-memory write hand-off. When
-  /yoke:implement terminates and the working memory under .yoke/
-  carries the freshest signal the framework will ever have, this skill
-  is the single verb that hands the active task's diff to the configured
-  canonical-memory provider. Resolves the provider via
-  lib/canonical-memory/resolve-provider.sh, stages only the active task's
-  archive files into a fresh tmp directory shaped like .yoke/ (historical
-  PRDs / specs / sprints / acceptance documents from prior tasks are NOT
-  re-fed), dispatches to the provider's pinned canonize skill (e.g.
-  /bedrock:teach for the bedrock provider per providers.yaml), removes
-  the stage on exit, and appends a single canonize: line to
-  .yoke/runtime/progress.md. Never bundles, summarizes, or pre-processes
-  inside the staged tree; never classifies maturity (provider judgment);
-  never silently swallows the provider's exit code.
+  Provider-agnostic facade that hands the active task's working memory
+  to the configured canonical-memory provider. Resolves the provider
+  via lib/canonical-memory/resolve-provider.sh, stages the active
+  slug's archive files (prds/, specs/, sprints/, acceptance-criteria/,
+  contracts/, runtime/, plus config.yaml) into a fresh tmp directory
+  shaped like .yoke/, dispatches the provider's pinned canonize skill
+  with --working-memory <stage-path>, removes the stage on exit, and
+  appends a single canonize: line to .yoke/runtime/progress.md. The
+  scope is per-task: only the active slug's files are staged; sensors
+  and other tasks' archives stay outside the hand-off. Pure dispatcher
+  semantics — never bundles, summarizes, classifies, or pre-processes
+  the staged tree (the provider owns those decisions); never swallows
+  the provider's exit code.
   Use when: "canonize", "yoke canonize", "/yoke:canonize", "save working
   memory to canonical memory", or whenever /yoke:implement terminates.
 argument-hint: ""
@@ -31,10 +30,11 @@ code.
 
 This facade is the single write entry point for every Yoke caller —
 the canonize-only Orchestrator subagent at full-run termination, plus
-manual re-canonize invocations. The legacy `/yoke:preserve` skill was
-retired with the v2.0.0 facade extraction; the substrate-specific
-canonize logic now lives inside the active provider plugin (e.g.
-`/bedrock:teach` for the bedrock provider per `providers.yaml`).
+manual re-canonize invocations. Substrate-specific canonize logic
+lives inside the active provider plugin (e.g. `/bedrock:teach` for
+the bedrock provider per `providers.yaml`); this facade owns
+provider resolution, active-task staging, dispatch, and exit-code
+propagation.
 
 ## Plugin paths
 
@@ -82,19 +82,19 @@ wm: /yoke:canonize takes no arguments at v2.0.0
 
 ## Phase 1 — Stage the active task's diff
 
-This facade does NOT hand the provider the full `.yoke/` directory.
-Historical PRDs, specs, sprints, and acceptance documents from prior
-tasks have already been canonized in their own runs; re-feeding them
-every cycle wastes provider tokens, re-runs entity-matching against
-a vault that already has those entries, and risks polluting the
-vault if any historical file's frontmatter has drifted since its
-original canonization.
+The hand-off is **per-task**: only the active slug's archive files
+plus `config.yaml`, `.gitignore`, and the `runtime/` subtree reach
+the provider. Each task's archive is canonized once, in its own
+`/yoke:canonize` run; subsequent runs would otherwise burn tokens
+re-running graphify and entity-matching against vault entries that
+already exist, and could push frontmatter drift into the vault as
+if it were a fresh write.
 
 Invoke the active-task staging helper. It reads
-`.yoke/runtime/.current` for the slug, copies only the slug's
-archive files plus `config.yaml`/`.gitignore`/`runtime/` into a
-fresh tmp directory shaped exactly like `.yoke/`, and echoes the
-absolute path on stdout:
+`.yoke/runtime/.current` for the slug, copies the slug's archive
+files plus `config.yaml`/`.gitignore`/`runtime/` into a fresh tmp
+directory shaped exactly like `.yoke/`, and echoes the absolute
+path on stdout:
 
 ```bash
 stage_dir="$(<plugin_dir>/lib/working-memory/canonize-stage.sh)"
@@ -227,11 +227,11 @@ reads the exit code as authoritative.
   narrows by active-task scope.
 - Pre-bundling the staged tree into a tarball or single document.
   The provider expects a directory tree shaped like `.yoke/`.
-- Staging the full `.yoke/` (every historical PRD/spec/sprint/AC
-  from prior tasks) to "let the provider decide". The provider's
-  judgment is about WHAT to canonize among the active-task slice —
-  not about filtering historical noise the facade should never have
-  fed in the first place.
+- Staging the host's full `.yoke/` (every prior-task PRD/spec/sprint/
+  AC) to "let the provider decide". The provider's judgment is
+  about WHAT to canonize among the active-task slice; archive
+  filtering is the facade's responsibility and is bounded by the
+  active slug.
 - Branching the dispatch logic on `$YOKE_PROVIDER_NAME`. The whole
   point of the facade is that providers are interchangeable.
 - Logging the provider's full stdout to `runtime/progress.md`. Only

--- a/skills/canonize/SKILL.md
+++ b/skills/canonize/SKILL.md
@@ -6,15 +6,15 @@ description: >
   carries the freshest signal the framework will ever have, this skill
   is the single verb that hands the active task's diff to the configured
   canonical-memory provider. Resolves the provider via
-  lib/canonical-memory/resolve-provider.sh, stages the active task's
-  archive files into a fresh tmp directory (per issue #40 — historical
-  PRDs / specs / sprints / acceptance documents are NOT re-fed),
-  dispatches to the provider's pinned canonize skill (e.g. /bedrock:teach
-  for the bedrock provider per providers.yaml), removes the stage on
-  exit, and appends a single canonize: line to .yoke/runtime/progress.md.
-  Never bundles, summarizes, or pre-processes inside the staged tree;
-  never classifies maturity (provider judgment); never silently swallows
-  the provider's exit code.
+  lib/canonical-memory/resolve-provider.sh, stages only the active task's
+  archive files into a fresh tmp directory shaped like .yoke/ (historical
+  PRDs / specs / sprints / acceptance documents from prior tasks are NOT
+  re-fed), dispatches to the provider's pinned canonize skill (e.g.
+  /bedrock:teach for the bedrock provider per providers.yaml), removes
+  the stage on exit, and appends a single canonize: line to
+  .yoke/runtime/progress.md. Never bundles, summarizes, or pre-processes
+  inside the staged tree; never classifies maturity (provider judgment);
+  never silently swallows the provider's exit code.
   Use when: "canonize", "yoke canonize", "/yoke:canonize", "save working
   memory to canonical memory", or whenever /yoke:implement terminates.
 argument-hint: ""
@@ -82,14 +82,13 @@ wm: /yoke:canonize takes no arguments at v2.0.0
 
 ## Phase 1 — Stage the active task's diff
 
-Per issue #40, this facade does NOT hand the provider the full
-`.yoke/` directory anymore. Historical PRDs, specs, sprints, and
-acceptance documents from prior tasks have already been canonized in
-their own runs; re-feeding them every cycle wastes provider tokens
-and re-runs entity-matching against a vault that already has those
-entries (concrete impact during the v4.0.0 cutover: 138 files in
-`.yoke/`, only 8 fresh — re-canonization risked vault pollution and
-turned a 5-minute hand-off into a 30+-minute one).
+This facade does NOT hand the provider the full `.yoke/` directory.
+Historical PRDs, specs, sprints, and acceptance documents from prior
+tasks have already been canonized in their own runs; re-feeding them
+every cycle wastes provider tokens, re-runs entity-matching against
+a vault that already has those entries, and risks polluting the
+vault if any historical file's frontmatter has drifted since its
+original canonization.
 
 Invoke the active-task staging helper. It reads
 `.yoke/runtime/.current` for the slug, copies only the slug's
@@ -111,8 +110,9 @@ Helper exit codes — surface verbatim, do NOT retry:
 
 `$stage_dir` is the only path passed to the provider. Sensors live
 in `.yoke/sensors/<id>.md` (project-scoped, not per-task) and are
-explicitly NOT staged — re-feeding them on every canonize is
-exactly what the issue rejected.
+explicitly NOT staged — re-feeding them on every canonize re-runs
+the provider's entity-matching against artifacts that already
+canonized.
 
 Per the working-memory provider contract, the directory is read-only
 from the provider's perspective; the facade still owns the cleanup.
@@ -210,12 +210,12 @@ reads the exit code as authoritative.
 
 | # | Rule |
 |---|---|
-| 1 | NEVER classify maturity, summarize, or otherwise pre-process inside the staged tree. The provider owns canonization decisions; the facade only narrows the input set to the active task (issue #40). |
+| 1 | NEVER classify maturity, summarize, or otherwise pre-process inside the staged tree. The provider owns canonization decisions; the facade only narrows the input set to the active task. |
 | 2 | NEVER pass a relative path. The staging helper outputs an absolute path via `mktemp -d`. |
 | 3 | NEVER pass the host's `.yoke/` directly. Always pass the staged copy from Phase 1. |
 | 4 | NEVER swallow the provider's exit code. Propagate it verbatim. |
 | 5 | NEVER write inside the host's `.yoke/` except for the single `canonize:` line appended to `runtime/progress.md` in Phase 4. |
-| 6 | NEVER stage `.yoke/sensors/<id>.md` files. They are project-scoped, not per-task; re-feeding them is exactly the bloat issue #40 rejected. |
+| 6 | NEVER stage `.yoke/sensors/<id>.md` files. They are project-scoped, not per-task; re-feeding them on every canonize re-runs the provider's entity-matching against artifacts that already canonized. |
 | 7 | NEVER invoke the provider's canonize skill (e.g. `/bedrock:teach`) directly. Always dispatch through `$YOKE_PROVIDER_CANONIZE_SKILL`. |
 | 8 | NEVER skip the Phase 5 stage cleanup. Even on non-zero `$provider_rc`, `rm -rf "$stage_dir"` runs unconditionally. |
 
@@ -228,8 +228,10 @@ reads the exit code as authoritative.
 - Pre-bundling the staged tree into a tarball or single document.
   The provider expects a directory tree shaped like `.yoke/`.
 - Staging the full `.yoke/` (every historical PRD/spec/sprint/AC
-  from prior tasks) to "let the provider decide". That is the bug
-  issue #40 documented; the active-task scope is the v4.1 fix.
+  from prior tasks) to "let the provider decide". The provider's
+  judgment is about WHAT to canonize among the active-task slice —
+  not about filtering historical noise the facade should never have
+  fed in the first place.
 - Branching the dispatch logic on `$YOKE_PROVIDER_NAME`. The whole
   point of the facade is that providers are interchangeable.
 - Logging the provider's full stdout to `runtime/progress.md`. Only
@@ -241,8 +243,7 @@ reads the exit code as authoritative.
 
 - `docs/canonical-memory-provider-contract.md` — the working-memory
   contract every provider implements (`contract_version: 1`); the
-  "Active-task staging" section documents the diff contract added
-  for issue #40.
+  "Active-task staging" section documents the diff contract.
 - `concepts/yoke-pattern-memory-model` — the write-mediator role.
 - `lib/canonical-memory/resolve-provider.sh` — provider resolution.
 - `lib/working-memory/canonize-stage.sh` — active-task staging

--- a/skills/canonize/SKILL.md
+++ b/skills/canonize/SKILL.md
@@ -4,15 +4,17 @@ description: >
   Provider-agnostic facade for the canonical-memory write hand-off. When
   /yoke:implement terminates and the working memory under .yoke/
   carries the freshest signal the framework will ever have, this skill
-  is the single verb that hands the directory to the configured
+  is the single verb that hands the active task's diff to the configured
   canonical-memory provider. Resolves the provider via
-  lib/canonical-memory/resolve-provider.sh, dispatches to the provider's
-  pinned canonize skill (currently /yoke:teach while Bedrock is the
-  in-Yoke seed; rewires to /bedrock:canonize in Sprint 2), and appends
-  a single canonize: line to .yoke/runtime/progress.md. Never bundles,
-  summarizes, or pre-processes the working memory; never classifies
-  maturity (provider judgment); never silently swallows the provider's
-  exit code.
+  lib/canonical-memory/resolve-provider.sh, stages the active task's
+  archive files into a fresh tmp directory (per issue #40 — historical
+  PRDs / specs / sprints / acceptance documents are NOT re-fed),
+  dispatches to the provider's pinned canonize skill (e.g. /bedrock:teach
+  for the bedrock provider per providers.yaml), removes the stage on
+  exit, and appends a single canonize: line to .yoke/runtime/progress.md.
+  Never bundles, summarizes, or pre-processes inside the staged tree;
+  never classifies maturity (provider judgment); never silently swallows
+  the provider's exit code.
   Use when: "canonize", "yoke canonize", "/yoke:canonize", "save working
   memory to canonical memory", or whenever /yoke:implement terminates.
 argument-hint: ""
@@ -27,10 +29,12 @@ configured provider an absolute path and a single argument verb, then
 log a one-line `canonize:` entry and propagate the provider's exit
 code.
 
-This facade is the single write entry point that every Yoke caller
-will be rewritten toward (Sprint 2 task s02-t05). In Sprint 1 the
-legacy `/yoke:preserve` continues to work and this facade is purely
-additive.
+This facade is the single write entry point for every Yoke caller —
+the canonize-only Orchestrator subagent at full-run termination, plus
+manual re-canonize invocations. The legacy `/yoke:preserve` skill was
+retired with the v2.0.0 facade extraction; the substrate-specific
+canonize logic now lives inside the active provider plugin (e.g.
+`/bedrock:teach` for the bedrock provider per `providers.yaml`).
 
 ## Plugin paths
 
@@ -76,17 +80,42 @@ abort with:
 wm: /yoke:canonize takes no arguments at v2.0.0
 ```
 
-## Phase 1 — Resolve absolute path of `.yoke/`
+## Phase 1 — Stage the active task's diff
 
-The provider expects an **absolute** path. Resolve via `cd && pwd`:
+Per issue #40, this facade does NOT hand the provider the full
+`.yoke/` directory anymore. Historical PRDs, specs, sprints, and
+acceptance documents from prior tasks have already been canonized in
+their own runs; re-feeding them every cycle wastes provider tokens
+and re-runs entity-matching against a vault that already has those
+entries (concrete impact during the v4.0.0 cutover: 138 files in
+`.yoke/`, only 8 fresh — re-canonization risked vault pollution and
+turned a 5-minute hand-off into a 30+-minute one).
+
+Invoke the active-task staging helper. It reads
+`.yoke/runtime/.current` for the slug, copies only the slug's
+archive files plus `config.yaml`/`.gitignore`/`runtime/` into a
+fresh tmp directory shaped exactly like `.yoke/`, and echoes the
+absolute path on stdout:
 
 ```bash
-wm_path="$(cd "$PWD/.yoke" && pwd)"
+stage_dir="$(<plugin_dir>/lib/working-memory/canonize-stage.sh)"
 ```
 
-`$wm_path` is the only path passed to the provider. Never pass a
-relative path; never pass any path other than the resolved
-`.yoke/` directory.
+Helper exit codes — surface verbatim, do NOT retry:
+
+| Exit | Meaning |
+|---|---|
+| 0 | Staged; absolute path on stdout |
+| 2 | Invalid args, missing `.yoke/`, or unsupported bash |
+| 3 | No active slug (`.yoke/runtime/.current` missing) |
+
+`$stage_dir` is the only path passed to the provider. Sensors live
+in `.yoke/sensors/<id>.md` (project-scoped, not per-task) and are
+explicitly NOT staged — re-feeding them on every canonize is
+exactly what the issue rejected.
+
+Per the working-memory provider contract, the directory is read-only
+from the provider's perspective; the facade still owns the cleanup.
 
 ## Phase 2 — Resolve the provider
 
@@ -116,18 +145,19 @@ After exit 0:
 
 ## Phase 3 — Dispatch to the provider's canonize skill
 
-Invoke the provider's pinned canonize skill with the resolved
-absolute working-memory path:
+Invoke the provider's pinned canonize skill with the staged absolute
+working-memory path produced in Phase 1:
 
 ```text
-Skill(skill: "${YOKE_PROVIDER_CANONIZE_SKILL}", args: "--working-memory ${wm_path}")
+Skill(skill: "${YOKE_PROVIDER_CANONIZE_SKILL}", args: "--working-memory ${stage_dir}")
 ```
 
 In the seed configuration (`provider: bedrock`),
-`$YOKE_PROVIDER_CANONIZE_SKILL == "yoke:teach"`, so this resolves to:
+`$YOKE_PROVIDER_CANONIZE_SKILL == "bedrock:teach"` per
+`providers.yaml`, so this resolves to:
 
 ```text
-Skill(skill: "yoke:teach", args: "--working-memory <abs-path-to-.yoke>")
+Skill(skill: "bedrock:teach", args: "--working-memory <abs-path-to-stage>")
 ```
 
 Capture the provider's stdout. Capture the provider's exit code in
@@ -135,71 +165,86 @@ Capture the provider's stdout. Capture the provider's exit code in
 
 ## Phase 4 — Append a canonize: line to runtime/progress.md
 
-Append a single line beginning `canonize:` to
-`.yoke/runtime/progress.md` summarizing the dispatch. The line is a
-soft convention (per `docs/canonical-memory-provider-contract.md`'s
-"Soft exit-summary convention" section); the provider's stdout MAY
-include a structured summary line which the facade forwards verbatim.
+Append a single line beginning `canonize:` to the host's
+`.yoke/runtime/progress.md` (NOT the staged copy — the stage is
+ephemeral and is removed in Phase 5) summarizing the dispatch. The
+line is a soft convention (per
+`docs/canonical-memory-provider-contract.md`'s "Soft exit-summary
+convention" section); the provider's stdout MAY include a structured
+summary line which the facade forwards verbatim.
 
 ```bash
-progress="$wm_path/runtime/progress.md"
-mkdir -p "$wm_path/runtime"
+progress="$PWD/.yoke/runtime/progress.md"
+mkdir -p "$PWD/.yoke/runtime"
 [ -f "$progress" ] || printf '# Progress\n\n' > "$progress"
 
 # If the provider emitted an exit-summary line on stdout, prefer that
 # (it's the authoritative count). Otherwise emit a minimal record.
 summary_line="$(printf '%s\n' "${provider_stdout:-}" | grep -E '^canonize:' | tail -n 1 || true)"
 if [ -z "$summary_line" ]; then
-  summary_line="canonize: provider=${YOKE_PROVIDER_NAME} working_memory=${wm_path} exit=${provider_rc}"
+  summary_line="canonize: provider=${YOKE_PROVIDER_NAME} working_memory=${stage_dir} exit=${provider_rc}"
 fi
 printf '%s\n' "$summary_line" >> "$progress"
 ```
 
-The line is the **only** write this facade performs. The contents of
-`.yoke/` are otherwise read-only from the facade's perspective.
+The line is the **only** write this facade performs against the host
+project. The staged tree is read-only from the facade's perspective
+(per the provider contract).
 
-## Phase 5 — Propagate the provider's exit code
+## Phase 5 — Cleanup the staged directory + propagate exit
 
 ```bash
+# Stage was a fresh mktemp -d; remove it unconditionally.
+[ -n "${stage_dir:-}" ] && rm -rf "$stage_dir"
+
 exit "$provider_rc"
 ```
 
-Never zero out a non-zero provider exit. Never translate provider
-exit codes into a normalized scheme. The caller (the runtime
-Orchestrator subagent in canonize mode) reads the exit code as
-authoritative.
+Cleanup runs even on non-zero `$provider_rc` so failed canonize runs
+do not leave tmp dirs behind. Never zero out a non-zero provider
+exit. Never translate provider exit codes into a normalized scheme.
+The caller (the runtime Orchestrator subagent in canonize mode)
+reads the exit code as authoritative.
 
 ## Critical rules
 
 | # | Rule |
 |---|---|
-| 1 | NEVER bundle, summarize, classify, or pre-process the working memory. The provider owns those decisions. |
-| 2 | NEVER pass a relative path. Always resolve to absolute via `cd && pwd`. |
-| 3 | NEVER pass any path other than the resolved `.yoke/` directory. |
+| 1 | NEVER classify maturity, summarize, or otherwise pre-process inside the staged tree. The provider owns canonization decisions; the facade only narrows the input set to the active task (issue #40). |
+| 2 | NEVER pass a relative path. The staging helper outputs an absolute path via `mktemp -d`. |
+| 3 | NEVER pass the host's `.yoke/` directly. Always pass the staged copy from Phase 1. |
 | 4 | NEVER swallow the provider's exit code. Propagate it verbatim. |
-| 5 | NEVER write inside `.yoke/` except for the single `canonize:` line appended to `runtime/progress.md`. |
-| 6 | NEVER fall back to the legacy `/yoke:preserve` when the resolver fails. Surface exit codes 3/4/5 verbatim. |
-| 7 | NEVER invoke the legacy `/yoke:teach` directly. Always dispatch through `$YOKE_PROVIDER_CANONIZE_SKILL`. |
-| 8 | NEVER read or write outside the working memory: provider's responsibility. |
+| 5 | NEVER write inside the host's `.yoke/` except for the single `canonize:` line appended to `runtime/progress.md` in Phase 4. |
+| 6 | NEVER stage `.yoke/sensors/<id>.md` files. They are project-scoped, not per-task; re-feeding them is exactly the bloat issue #40 rejected. |
+| 7 | NEVER invoke the provider's canonize skill (e.g. `/bedrock:teach`) directly. Always dispatch through `$YOKE_PROVIDER_CANONIZE_SKILL`. |
+| 8 | NEVER skip the Phase 5 stage cleanup. Even on non-zero `$provider_rc`, `rm -rf "$stage_dir"` runs unconditionally. |
 
 ## Anti-patterns
 
 - Reading `.yoke/specs/`, `.yoke/sprints/`, `.yoke/contracts/`,
   `.yoke/runtime/` to "decide what's canonization-worthy" before
-  invoking the provider. The provider judges; the facade dispatches.
-- Pre-bundling `.yoke/` into a tarball or single document. The
-  provider expects a directory tree.
+  invoking the provider. The provider judges; the facade only
+  narrows by active-task scope.
+- Pre-bundling the staged tree into a tarball or single document.
+  The provider expects a directory tree shaped like `.yoke/`.
+- Staging the full `.yoke/` (every historical PRD/spec/sprint/AC
+  from prior tasks) to "let the provider decide". That is the bug
+  issue #40 documented; the active-task scope is the v4.1 fix.
 - Branching the dispatch logic on `$YOKE_PROVIDER_NAME`. The whole
   point of the facade is that providers are interchangeable.
 - Logging the provider's full stdout to `runtime/progress.md`. Only
   the soft `canonize:` summary line is recorded.
+- Leaving `$stage_dir` on disk after the dispatch returns. The
+  facade is the only owner of the stage; cleanup is unconditional.
 
 ## See also
 
 - `docs/canonical-memory-provider-contract.md` — the working-memory
-  contract every provider implements (`contract_version: 1`).
+  contract every provider implements (`contract_version: 1`); the
+  "Active-task staging" section documents the diff contract added
+  for issue #40.
 - `concepts/yoke-pattern-memory-model` — the write-mediator role.
 - `lib/canonical-memory/resolve-provider.sh` — provider resolution.
+- `lib/working-memory/canonize-stage.sh` — active-task staging
+  helper invoked in Phase 1.
 - `providers.yaml` — curated provider registry.
-- Acceptance Contract Scenario 4 / FR-1 / FR-4.
-- Sprint 1 task `2026-04-30-pluggable-canonical-memory-s01-t04`.

--- a/tests/smoke/canonize-active-task-scope.test.sh
+++ b/tests/smoke/canonize-active-task-scope.test.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+# tests/smoke/canonize-active-task-scope.test.sh
+#
+# Sensor: canonize-active-task-scope (computational, cheap).
+#
+# Pins the regression documented in
+# https://github.com/iurykrieger/claude-yoke/issues/40:
+# /yoke:canonize used to hand the provider the ENTIRE `.yoke/`
+# directory — every historical PRD, spec, sprint bundle, and
+# acceptance document from every prior task. The reference provider
+# (`bedrock:teach`) re-ran graphify and entity-matching over all 138
+# files when only 8 carried fresh signal during the v4.0.0 cutover
+# canonization. Cost: 5-minute hand-off blew up to 30+ minutes, with
+# real risk of polluting the vault if any historical file's
+# frontmatter had drifted since its original canonization.
+#
+# This sensor pins the v4.1 fix: `lib/working-memory/canonize-stage.sh`
+# stages only the active slug's archive files (plus config.yaml,
+# .gitignore, and the runtime/ subtree) into a fresh tmp directory
+# shaped exactly like `.yoke/`. Sensors and historical-task archives
+# are explicitly excluded.
+#
+# Coverage:
+#   (A) Helper exits 2 when invoked outside a `.yoke/` host.
+#   (B) Helper exits 3 when `.yoke/runtime/.current` is missing
+#       (no active slug).
+#   (C) Happy path with a synthetic `.yoke/` containing 1 active
+#       slug + 1 historical slug:
+#         - stdout is an absolute path that exists on disk
+#         - staged tree contains the active slug's prd/spec/sprints
+#           (3 sprints) / acceptance-criteria / contracts
+#         - staged tree does NOT contain any historical slug's files
+#         - staged tree does NOT contain `.yoke/sensors/` (project-
+#           scoped, not per-task)
+#         - `config.yaml` and `.gitignore` are staged
+#         - `runtime/` subtree is staged
+#   (D) Legacy `acceptance-contracts/<slug>.md` (pre-v4.0.0) is
+#       staged when present for the active slug.
+#   (E) Empty archive directories (e.g. `acceptance-contracts/` when
+#       the active slug only has the post-v4.0.0 `acceptance-criteria/`
+#       file) are pruned from the staged tree — the shape mirrors
+#       what a fresh `.yoke/` would look like, not the helper's
+#       internal scaffolding.
+#   (F) Explicit `--slug <slug>` flag overrides `.yoke/runtime/.current`
+#       and stages the named slug. Useful for catch-up canonizations
+#       and for tests.
+#   (G) The staged path is a `mktemp -d` under `${TMPDIR:-/tmp}` —
+#       safe to `rm -rf` from the caller without touching the host's
+#       `.yoke/`.
+#
+# References:
+# - Issue: #40
+# - Helper: lib/working-memory/canonize-stage.sh
+# - Skill: skills/canonize/SKILL.md (Phase 1, Phase 5)
+
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/harness.sh"
+
+set +e
+
+# Watchdog (concepts/yoke-conventions): never let a hung subshell block CI.
+(sleep 600 && kill -TERM $$ &) >/dev/null 2>&1
+
+cd "$PLUGIN_ROOT"
+
+HELPER="$PLUGIN_ROOT/lib/working-memory/canonize-stage.sh"
+[ -x "$HELPER" ] || { err "helper missing or not executable at $HELPER"; harness::summary; }
+
+ACTIVE_SLUG="2026-05-04-active-task"
+LEGACY_SLUG="2026-04-30-historical-task"
+
+scaffold_host() {
+    local host="$1"
+    rm -rf "$host"
+    mkdir -p \
+        "$host/.yoke/prds" \
+        "$host/.yoke/specs" \
+        "$host/.yoke/sprints" \
+        "$host/.yoke/acceptance-criteria" \
+        "$host/.yoke/acceptance-contracts" \
+        "$host/.yoke/contracts" \
+        "$host/.yoke/sensors" \
+        "$host/.yoke/runtime"
+
+    cat > "$host/.yoke/config.yaml" <<YAML
+yoke_version: "4.0.0"
+canonical_memory:
+  provider: bedrock
+host:
+  project_name: "smoke-test-host"
+YAML
+
+    cat > "$host/.yoke/.gitignore" <<'GITIGNORE'
+.current
+runtime/
+GITIGNORE
+
+    # Active slug — full archive set.
+    echo "# active prd"   > "$host/.yoke/prds/${ACTIVE_SLUG}.md"
+    echo "# active spec"  > "$host/.yoke/specs/${ACTIVE_SLUG}.md"
+    echo "# active s01"   > "$host/.yoke/sprints/${ACTIVE_SLUG}-s01.md"
+    echo "# active s02"   > "$host/.yoke/sprints/${ACTIVE_SLUG}-s02.md"
+    echo "# active s03"   > "$host/.yoke/sprints/${ACTIVE_SLUG}-s03.md"
+    echo "# active AC"    > "$host/.yoke/acceptance-criteria/${ACTIVE_SLUG}.md"
+    echo "# active contracts" > "$host/.yoke/contracts/${ACTIVE_SLUG}.md"
+
+    # Historical slug — should NOT appear in the stage.
+    echo "# legacy prd"      > "$host/.yoke/prds/${LEGACY_SLUG}.md"
+    echo "# legacy spec"     > "$host/.yoke/specs/${LEGACY_SLUG}.md"
+    echo "# legacy s01"      > "$host/.yoke/sprints/${LEGACY_SLUG}-s01.md"
+    echo "# legacy AC (pre-v4)" > "$host/.yoke/acceptance-contracts/${LEGACY_SLUG}.md"
+
+    # Project-scoped sensor — should NOT appear in the stage.
+    cat > "$host/.yoke/sensors/lint.md" <<'SENSOR'
+---
+id: lint
+type: computational
+token_cost: 0
+time_cost: 30
+command: true
+---
+
+# lint
+SENSOR
+
+    # Runtime subtree — should appear in the stage.
+    printf '%s' "$ACTIVE_SLUG" > "$host/.yoke/runtime/.current"
+    printf '# Progress\n' > "$host/.yoke/runtime/progress.md"
+    mkdir -p "$host/.yoke/runtime/.snapshots"
+    printf 'cycle: 1\n' > "$host/.yoke/runtime/.snapshots/cycle-1.yaml"
+}
+
+# ----------------------------------------------------------------------
+# (A) Outside a .yoke/ host — exit 2 with diagnostic.
+# ----------------------------------------------------------------------
+TMP_A="$(mktemp -d)"
+(
+    cd "$TMP_A" && bash "$HELPER" >/dev/null 2>"$TMP_A/stderr"
+)
+rc_a=$?
+stderr_a="$(cat "$TMP_A/stderr")"
+
+[ "$rc_a" -eq 2 ] \
+    && pass "(A) helper exits 2 when no .yoke/ in CWD (got $rc_a)" \
+    || err "(A) expected exit 2, got $rc_a; stderr=$stderr_a"
+
+if printf '%s' "$stderr_a" | grep -qF ".yoke/ not found"; then
+    pass "(A) stderr names the missing .yoke/ directory"
+else
+    err "(A) stderr does not name the missing .yoke/ — got: $stderr_a"
+fi
+rm -rf "$TMP_A"
+
+# ----------------------------------------------------------------------
+# (B) No .yoke/runtime/.current — exit 3.
+# ----------------------------------------------------------------------
+TMP_B="$(mktemp -d)"
+mkdir -p "$TMP_B/.yoke/runtime"
+(
+    cd "$TMP_B" && bash "$HELPER" >/dev/null 2>"$TMP_B/stderr"
+)
+rc_b=$?
+stderr_b="$(cat "$TMP_B/stderr")"
+
+[ "$rc_b" -eq 3 ] \
+    && pass "(B) helper exits 3 when .current is missing (got $rc_b)" \
+    || err "(B) expected exit 3, got $rc_b; stderr=$stderr_b"
+
+if printf '%s' "$stderr_b" | grep -qF "no active task"; then
+    pass "(B) stderr surfaces 'no active task' diagnostic"
+else
+    err "(B) stderr does not surface 'no active task' — got: $stderr_b"
+fi
+rm -rf "$TMP_B"
+
+# ----------------------------------------------------------------------
+# (C) Happy path — active slug + historical slug + project sensor.
+# ----------------------------------------------------------------------
+HOST_C="$(mktemp -d)"
+scaffold_host "$HOST_C"
+
+stage_c="$(cd "$HOST_C" && bash "$HELPER" 2>/dev/null)"
+rc_c=$?
+
+[ "$rc_c" -eq 0 ] && [ -n "$stage_c" ] && [ -d "$stage_c" ] \
+    && pass "(C) helper exits 0 with absolute path on stdout (got: $stage_c)" \
+    || err "(C) helper exit $rc_c; stage='$stage_c'"
+
+# Active-slug files present.
+for active_file in \
+    "prds/${ACTIVE_SLUG}.md" \
+    "specs/${ACTIVE_SLUG}.md" \
+    "sprints/${ACTIVE_SLUG}-s01.md" \
+    "sprints/${ACTIVE_SLUG}-s02.md" \
+    "sprints/${ACTIVE_SLUG}-s03.md" \
+    "acceptance-criteria/${ACTIVE_SLUG}.md" \
+    "contracts/${ACTIVE_SLUG}.md" \
+    "config.yaml" \
+    ".gitignore" \
+    "runtime/.current" \
+    "runtime/progress.md" \
+    "runtime/.snapshots/cycle-1.yaml" \
+    ; do
+    if [ -f "$stage_c/$active_file" ]; then
+        pass "(C) staged: $active_file"
+    else
+        err "(C) MISSING from stage: $active_file"
+    fi
+done
+
+# Historical-slug files MUST NOT be staged.
+for absent_file in \
+    "prds/${LEGACY_SLUG}.md" \
+    "specs/${LEGACY_SLUG}.md" \
+    "sprints/${LEGACY_SLUG}-s01.md" \
+    "acceptance-contracts/${LEGACY_SLUG}.md" \
+    ; do
+    if [ ! -e "$stage_c/$absent_file" ]; then
+        pass "(C) historical file NOT staged: $absent_file"
+    else
+        err "(C) historical file LEAKED into stage: $absent_file"
+    fi
+done
+
+# Project-scoped sensors MUST NOT be staged.
+if [ ! -d "$stage_c/sensors" ] && [ ! -e "$stage_c/sensors/lint.md" ]; then
+    pass "(C) sensors/ directory NOT staged (project-scoped, not per-task)"
+else
+    err "(C) sensors/ leaked into stage at $stage_c/sensors/"
+fi
+
+# Total stage file count: 12 (7 active-slug archive files: 1 PRD + 1
+# spec + 3 sprints + 1 AC + 1 contracts; 2 dotfiles: config.yaml +
+# .gitignore; 3 runtime files: .current + progress.md +
+# .snapshots/cycle-1.yaml).
+stage_file_count="$(find "$stage_c" -type f 2>/dev/null | wc -l | tr -d ' ')"
+if [ "$stage_file_count" -eq 12 ]; then
+    pass "(C) stage contains exactly 12 files (no historical bloat)"
+else
+    err "(C) expected 12 files in stage, got $stage_file_count; tree:
+$(find "$stage_c" -type f | sort)"
+fi
+
+rm -rf "$stage_c" "$HOST_C"
+
+# ----------------------------------------------------------------------
+# (D) Legacy acceptance-contracts/<slug>.md is staged when present.
+# ----------------------------------------------------------------------
+HOST_D="$(mktemp -d)"
+scaffold_host "$HOST_D"
+# Add a legacy AC file for the ACTIVE slug (covers the "task started
+# pre-v4.0.0 and is now finishing" path).
+echo "# legacy active AC" > "$HOST_D/.yoke/acceptance-contracts/${ACTIVE_SLUG}.md"
+
+stage_d="$(cd "$HOST_D" && bash "$HELPER" 2>/dev/null)"
+
+if [ -f "$stage_d/acceptance-contracts/${ACTIVE_SLUG}.md" ]; then
+    pass "(D) legacy acceptance-contracts/ staged for active slug when present"
+else
+    err "(D) legacy acceptance-contracts/${ACTIVE_SLUG}.md missing from stage"
+fi
+
+rm -rf "$stage_d" "$HOST_D"
+
+# ----------------------------------------------------------------------
+# (E) Empty archive directories pruned. With no contracts/<slug>.md,
+# the stage's `contracts/` directory should not exist.
+# ----------------------------------------------------------------------
+HOST_E="$(mktemp -d)"
+scaffold_host "$HOST_E"
+rm -f "$HOST_E/.yoke/contracts/${ACTIVE_SLUG}.md"
+
+stage_e="$(cd "$HOST_E" && bash "$HELPER" 2>/dev/null)"
+
+if [ ! -e "$stage_e/contracts" ]; then
+    pass "(E) empty contracts/ directory pruned from stage (no per-task file present)"
+else
+    err "(E) empty contracts/ directory present in stage despite no per-task file"
+fi
+
+# acceptance-contracts/ has no per-task file in scaffold_host's default;
+# the active slug only has acceptance-criteria/. The stage must NOT
+# carry an empty acceptance-contracts/ dir.
+if [ ! -e "$stage_e/acceptance-contracts" ]; then
+    pass "(E) empty acceptance-contracts/ directory pruned (active slug uses post-v4.0 path)"
+else
+    err "(E) empty acceptance-contracts/ leaked into stage"
+fi
+
+rm -rf "$stage_e" "$HOST_E"
+
+# ----------------------------------------------------------------------
+# (F) --slug <slug> overrides .yoke/runtime/.current.
+# ----------------------------------------------------------------------
+HOST_F="$(mktemp -d)"
+scaffold_host "$HOST_F"
+# Point .current at a slug that doesn't have any archive files, then
+# pass --slug to override.
+printf 'someone-else-task' > "$HOST_F/.yoke/runtime/.current.bogus"
+# We can't actually point .current at an invalid slug (wm_validate_slug
+# will reject it). Instead, point .current at the LEGACY slug and use
+# --slug to override to the ACTIVE slug.
+printf '%s' "$LEGACY_SLUG" > "$HOST_F/.yoke/runtime/.current"
+
+stage_f="$(cd "$HOST_F" && bash "$HELPER" --slug "$ACTIVE_SLUG" 2>/dev/null)"
+rc_f=$?
+
+[ "$rc_f" -eq 0 ] \
+    && pass "(F) helper exits 0 with --slug override" \
+    || err "(F) helper exit $rc_f"
+
+if [ -f "$stage_f/prds/${ACTIVE_SLUG}.md" ] && [ ! -f "$stage_f/prds/${LEGACY_SLUG}.md" ]; then
+    pass "(F) --slug override stages the named slug, not the .current pointer's slug"
+else
+    err "(F) --slug override did not redirect; staged tree:
+$(find "$stage_f" -type f | sort)"
+fi
+
+rm -rf "$stage_f" "$HOST_F"
+
+# ----------------------------------------------------------------------
+# (G) Stage path is under TMPDIR (or /tmp) — safe to rm -rf.
+# ----------------------------------------------------------------------
+HOST_G="$(mktemp -d)"
+scaffold_host "$HOST_G"
+stage_g="$(cd "$HOST_G" && bash "$HELPER" 2>/dev/null)"
+
+tmp_root="${TMPDIR:-/tmp}"
+# Resolve symlinks for both since macOS's /tmp is a symlink to /private/tmp.
+real_stage="$(cd "$stage_g" && pwd -P)"
+real_tmp="$(cd "$tmp_root" && pwd -P)"
+
+case "$real_stage" in
+    "$real_tmp"/*)
+        pass "(G) stage path lives under TMPDIR ($tmp_root → $real_tmp): $real_stage"
+        ;;
+    *)
+        err "(G) stage path '$real_stage' is NOT under TMPDIR '$real_tmp' — caller cannot safely rm -rf"
+        ;;
+esac
+
+# rm -rf the stage and confirm host's .yoke/ is intact.
+rm -rf "$stage_g"
+[ ! -e "$stage_g" ] && pass "(G) stage removed cleanly with rm -rf" \
+    || err "(G) stage path still present after rm -rf"
+
+[ -f "$HOST_G/.yoke/prds/${ACTIVE_SLUG}.md" ] \
+    && pass "(G) host .yoke/ intact after stage cleanup" \
+    || err "(G) host .yoke/ damaged by stage cleanup"
+
+rm -rf "$HOST_G"
+
+harness::summary


### PR DESCRIPTION
## Summary

- Issue #40: `/yoke:canonize` used to hand the configured provider the full host `.yoke/`. The reference provider (`bedrock:teach`) re-ran graphify and entity-matching over every historical PRD/spec/sprint/AC from prior tasks — 138 files when only 8 carried fresh signal during the v4.0.0 cutover canonization. 5-minute hand-off → 30+ minutes; real risk of vault pollution from drifted historical frontmatter.
- This PR ships option 1 from the issue's acceptance criteria: **active-task scope** via a new `lib/working-memory/canonize-stage.sh`. The facade now stages only the active slug's archive files (PRD, spec, every sprint, AC document, sprint contracts) plus `config.yaml`, `.gitignore`, and the `runtime/` subtree into a fresh `mktemp -d` shaped exactly like `.yoke/`. Sensors are explicitly excluded (project-scoped, not per-task). Per-task ledger (option 2) is deferred to a follow-up as the issue allows.
- `skills/canonize/SKILL.md`: Phase 1 invokes the staging helper, Phase 3 dispatches the staged path, **new Phase 5** does unconditional `rm -rf "$stage_dir"` so failed runs don't leak tmp dirs.
- `docs/canonical-memory-provider-contract.md`: new "Active-task staging" section + updated directory-tree diagram (filename keys now `<active-slug>`, `sensors/` explicitly absent, `--working-memory` invariants reworded to refer to the staging directory).
- `tests/smoke/canonize-active-task-scope.test.sh` (31 checks across 7 scenarios) wired into the CI matrix.

## Test plan

- [x] Local: `bash tests/smoke/canonize-active-task-scope.test.sh` → `PASS (31 check(s))`. Coverage: helper exit codes 2 and 3, happy path with active+historical slugs, legacy `acceptance-contracts/`, empty-dir pruning, `--slug` override, stage cleanup safety.
- [x] Regression: `tests/skills-surface.test.sh` (57 checks), `tests/smoke/skill-prompt-helper-references.test.sh` (6), `tests/plugin-distribution.test.sh` (19), `tests/docs-and-lineage.test.sh` (15), `tests/canonical-memory-write.test.sh` (7), `tests/working-memory.test.sh` (9) all still pass.
- [x] End-to-end smoke against synthetic 138-file shape: stage contains 12 files (no historical, no sensors), bytes-identical content, host `.yoke/` untouched.
- [ ] CI matrix runner reports green on the new smoke test.

> Note: `tests/smoke/hard-break-pre-flight.test.sh` reports one pre-existing failure on `origin/main` (`skills/acceptance-contract/SKILL.md missing`) — leftover from the v4.0.0 acceptance-contract → acceptance-criteria rename in #38. Not introduced by this PR.

## Deferred

Per the issue: per-task canonize ledger (option 2 — record `<file-path>` + SHA after each successful canonize, diff on next invocation) ships in a follow-up. Active-task scope already eliminates the bulk of the historical re-feed.

Closes #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)